### PR TITLE
fix(dispatcher): anchor account backfill to the event's own pool

### DIFF
--- a/src/core/account_dispatcher.rs
+++ b/src/core/account_dispatcher.rs
@@ -41,6 +41,46 @@ fn find_instruction_invoke<'a>(
     })
 }
 
+/// Like [`find_instruction_invoke`], but prefers the invoke whose FIRST
+/// account equals `anchor` (for pool-scoped events: pAMM buy/sell account
+/// layouts all put the pool at index 0).
+///
+/// Rationale: `max_by_key(accounts.len())` was only ever meant to skip the
+/// 1-account event-CPI shells. It silently picks the WRONG instruction when
+/// one transaction carries TWO real invokes of the same program — e.g. a
+/// Jupiter token-to-token route (sell mint A → buy mint B) contains a pAMM
+/// sell (24 accounts) and a pAMM buy (26 accounts, cashback variant): the
+/// buy wins on length, and every event in the tx — including the SELL on
+/// pool A — gets its `base_mint` backfilled from the BUY leg's accounts.
+/// Anchoring on the event's own pool makes the match exact; when no invoke
+/// matches (defensive: unknown future layout where the pool is not at
+/// index 0) we fall back to the historical length heuristic.
+fn find_instruction_invoke_anchored<'a>(
+    invokes: &'a [(i32, i32)],
+    meta: &TransactionStatusMeta,
+    transaction: &Option<Transaction>,
+    account_keys: Option<&Vec<Vec<u8>>>,
+    anchor: &Pubkey,
+) -> Option<&'a (i32, i32)> {
+    if *anchor != Pubkey::default() {
+        let anchored = invokes.iter().find(|invoke| {
+            get_instruction_account_getter(
+                meta,
+                transaction,
+                account_keys,
+                &meta.loaded_writable_addresses,
+                &meta.loaded_readonly_addresses,
+                invoke,
+            )
+            .is_some_and(|get_account| get_account(0) == *anchor)
+        });
+        if anchored.is_some() {
+            return anchored;
+        }
+    }
+    find_instruction_invoke(invokes, meta, transaction)
+}
+
 fn instruction_has_discriminator(
     transaction: &Option<Transaction>,
     outer_idx: i32,
@@ -82,6 +122,32 @@ macro_rules! fill_event_accounts {
             if let Some(invoke) = find_instruction_invoke(invokes, $meta, $tx) {
                 let account_keys =
                     $tx.as_ref().and_then(|tx| tx.message.as_ref()).map(|msg| &msg.account_keys);
+                if let Some(get_account) = get_instruction_account_getter(
+                    $meta,
+                    $tx,
+                    account_keys,
+                    &$meta.loaded_writable_addresses,
+                    &$meta.loaded_readonly_addresses,
+                    invoke,
+                ) {
+                    $filler(&get_account);
+                }
+            }
+        }
+    };
+}
+
+/// Pool-anchored variant of [`fill_event_accounts`]: resolves the invoke
+/// whose first account equals `$anchor` before backfilling, so multi-invoke
+/// transactions (token-to-token routes) enrich each event from its own leg.
+macro_rules! fill_event_accounts_anchored {
+    ($event:expr, $meta:expr, $tx:expr, $invokes:expr, $program_id:expr, $anchor:expr, $filler:expr) => {
+        if let Some(invokes) = $invokes.get($program_id) {
+            let account_keys =
+                $tx.as_ref().and_then(|tx| tx.message.as_ref()).map(|msg| &msg.account_keys);
+            if let Some(invoke) =
+                find_instruction_invoke_anchored(invokes, $meta, $tx, account_keys, $anchor)
+            {
                 if let Some(get_account) = get_instruction_account_getter(
                     $meta,
                     $tx,
@@ -190,24 +256,28 @@ pub fn fill_accounts_with_owned_keys(
 
         // PumpSwap
         DexEvent::PumpSwapBuy(e) => {
-            fill_event_accounts!(
+            let pool = e.pool;
+            fill_event_accounts_anchored!(
                 e,
                 meta,
                 transaction,
                 program_invokes,
                 &PUMPSWAP_PROGRAM,
+                &pool,
                 |get: &AccountGetter<'_>| {
                     account_fillers::pumpswap::fill_buy_accounts(e, get);
                 }
             );
         }
         DexEvent::PumpSwapSell(e) => {
-            fill_event_accounts!(
+            let pool = e.pool;
+            fill_event_accounts_anchored!(
                 e,
                 meta,
                 transaction,
                 program_invokes,
                 &PUMPSWAP_PROGRAM,
+                &pool,
                 |get: &AccountGetter<'_>| {
                     account_fillers::pumpswap::fill_sell_accounts(e, get);
                 }
@@ -639,5 +709,136 @@ pub fn fill_accounts_with_owned_keys(
         }
 
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::events::{PumpSwapBuyEvent, PumpSwapSellEvent};
+    use crate::grpc::program_ids::PUMPSWAP_PROGRAM;
+    use yellowstone_grpc_proto::prelude::{
+        CompiledInstruction, Message, MessageHeader, Transaction, TransactionStatusMeta,
+    };
+
+    struct RouteFixture {
+        meta: TransactionStatusMeta,
+        transaction: Option<Transaction>,
+        invokes: HashMap<Pubkey, Vec<(i32, i32)>>,
+        sell_pool: Pubkey,
+        buy_pool: Pubkey,
+        sell_mint: Pubkey,
+        buy_mint: Pubkey,
+    }
+
+    /// A Jupiter-style token-to-token route: one outer pAMM sell invoke
+    /// (24 accounts, pool/base_mint of leg A) followed by one outer pAMM buy
+    /// invoke (26 accounts — the cashback variant is longer — pool/base_mint
+    /// of leg B). Mirrors live tx DRCWs7iv… where the sell event's base_mint
+    /// was backfilled from the buy leg.
+    fn token_to_token_fixture() -> RouteFixture {
+        let sell_pool = Pubkey::new_unique();
+        let buy_pool = Pubkey::new_unique();
+        let sell_mint = Pubkey::new_unique();
+        let buy_mint = Pubkey::new_unique();
+        let padding = Pubkey::new_unique();
+
+        // static keys: [0]=sell_pool [1]=buy_pool [2]=sell_mint [3]=buy_mint
+        // [4]=pumpswap program [5]=padding
+        let static_keys: Vec<Vec<u8>> = [sell_pool, buy_pool, sell_mint, buy_mint, PUMPSWAP_PROGRAM, padding]
+            .iter()
+            .map(|k| k.to_bytes().to_vec())
+            .collect();
+
+        let mut sell_accounts = vec![5u8; 24];
+        sell_accounts[0] = 0; // pool
+        sell_accounts[3] = 2; // base_mint
+        let mut buy_accounts = vec![5u8; 26];
+        buy_accounts[0] = 1; // pool
+        buy_accounts[3] = 3; // base_mint
+
+        let transaction = Some(Transaction {
+            signatures: vec![vec![0u8; 64]],
+            message: Some(Message {
+                header: Some(MessageHeader::default()),
+                account_keys: static_keys,
+                recent_blockhash: vec![0u8; 32],
+                instructions: vec![
+                    CompiledInstruction { program_id_index: 4, accounts: sell_accounts, data: vec![0] },
+                    CompiledInstruction { program_id_index: 4, accounts: buy_accounts, data: vec![0] },
+                ],
+                versioned: false,
+                address_table_lookups: Vec::new(),
+            }),
+        });
+        let meta = TransactionStatusMeta::default();
+        let mut invokes = HashMap::new();
+        invokes.insert(PUMPSWAP_PROGRAM, vec![(0i32, -1i32), (1i32, -1i32)]);
+
+        RouteFixture { meta, transaction, invokes, sell_pool, buy_pool, sell_mint, buy_mint }
+    }
+
+    #[test]
+    fn token_to_token_route_backfills_each_leg_from_its_own_invoke() {
+        let f = token_to_token_fixture();
+
+        let mut sell = DexEvent::PumpSwapSell(PumpSwapSellEvent {
+            pool: f.sell_pool,
+            ..Default::default()
+        });
+        fill_accounts_with_owned_keys(&mut sell, &f.meta, &f.transaction, &f.invokes);
+        match sell {
+            DexEvent::PumpSwapSell(e) => assert_eq!(
+                e.base_mint, f.sell_mint,
+                "sell event must backfill from the SELL leg, not the longer buy invoke"
+            ),
+            _ => unreachable!(),
+        }
+
+        let mut buy = DexEvent::PumpSwapBuy(PumpSwapBuyEvent {
+            pool: f.buy_pool,
+            ..Default::default()
+        });
+        fill_accounts_with_owned_keys(&mut buy, &f.meta, &f.transaction, &f.invokes);
+        match buy {
+            DexEvent::PumpSwapBuy(e) => assert_eq!(e.base_mint, f.buy_mint),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn anchored_lookup_is_order_independent() {
+        let mut f = token_to_token_fixture();
+        // Reverse invoke order: the buy leg now comes first.
+        f.invokes.get_mut(&PUMPSWAP_PROGRAM).unwrap().reverse();
+
+        let mut sell = DexEvent::PumpSwapSell(PumpSwapSellEvent {
+            pool: f.sell_pool,
+            ..Default::default()
+        });
+        fill_accounts_with_owned_keys(&mut sell, &f.meta, &f.transaction, &f.invokes);
+        match sell {
+            DexEvent::PumpSwapSell(e) => assert_eq!(e.base_mint, f.sell_mint),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn unmatched_pool_falls_back_to_longest_invoke() {
+        let f = token_to_token_fixture();
+        // Pool that matches no invoke's first account (e.g. a future layout
+        // where the pool moved): keep the historical max-accounts behavior.
+        let mut sell = DexEvent::PumpSwapSell(PumpSwapSellEvent {
+            pool: Pubkey::new_unique(),
+            ..Default::default()
+        });
+        fill_accounts_with_owned_keys(&mut sell, &f.meta, &f.transaction, &f.invokes);
+        match sell {
+            DexEvent::PumpSwapSell(e) => assert_eq!(
+                e.base_mint, f.buy_mint,
+                "fallback must preserve the pre-fix heuristic (longest invoke wins)"
+            ),
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/core/account_dispatcher.rs
+++ b/src/core/account_dispatcher.rs
@@ -745,10 +745,11 @@ mod tests {
 
         // static keys: [0]=sell_pool [1]=buy_pool [2]=sell_mint [3]=buy_mint
         // [4]=pumpswap program [5]=padding
-        let static_keys: Vec<Vec<u8>> = [sell_pool, buy_pool, sell_mint, buy_mint, PUMPSWAP_PROGRAM, padding]
-            .iter()
-            .map(|k| k.to_bytes().to_vec())
-            .collect();
+        let static_keys: Vec<Vec<u8>> =
+            [sell_pool, buy_pool, sell_mint, buy_mint, PUMPSWAP_PROGRAM, padding]
+                .iter()
+                .map(|k| k.to_bytes().to_vec())
+                .collect();
 
         let mut sell_accounts = vec![5u8; 24];
         sell_accounts[0] = 0; // pool
@@ -764,8 +765,16 @@ mod tests {
                 account_keys: static_keys,
                 recent_blockhash: vec![0u8; 32],
                 instructions: vec![
-                    CompiledInstruction { program_id_index: 4, accounts: sell_accounts, data: vec![0] },
-                    CompiledInstruction { program_id_index: 4, accounts: buy_accounts, data: vec![0] },
+                    CompiledInstruction {
+                        program_id_index: 4,
+                        accounts: sell_accounts,
+                        data: vec![0],
+                    },
+                    CompiledInstruction {
+                        program_id_index: 4,
+                        accounts: buy_accounts,
+                        data: vec![0],
+                    },
                 ],
                 versioned: false,
                 address_table_lookups: Vec::new(),
@@ -782,10 +791,8 @@ mod tests {
     fn token_to_token_route_backfills_each_leg_from_its_own_invoke() {
         let f = token_to_token_fixture();
 
-        let mut sell = DexEvent::PumpSwapSell(PumpSwapSellEvent {
-            pool: f.sell_pool,
-            ..Default::default()
-        });
+        let mut sell =
+            DexEvent::PumpSwapSell(PumpSwapSellEvent { pool: f.sell_pool, ..Default::default() });
         fill_accounts_with_owned_keys(&mut sell, &f.meta, &f.transaction, &f.invokes);
         match sell {
             DexEvent::PumpSwapSell(e) => assert_eq!(
@@ -795,10 +802,8 @@ mod tests {
             _ => unreachable!(),
         }
 
-        let mut buy = DexEvent::PumpSwapBuy(PumpSwapBuyEvent {
-            pool: f.buy_pool,
-            ..Default::default()
-        });
+        let mut buy =
+            DexEvent::PumpSwapBuy(PumpSwapBuyEvent { pool: f.buy_pool, ..Default::default() });
         fill_accounts_with_owned_keys(&mut buy, &f.meta, &f.transaction, &f.invokes);
         match buy {
             DexEvent::PumpSwapBuy(e) => assert_eq!(e.base_mint, f.buy_mint),
@@ -812,10 +817,8 @@ mod tests {
         // Reverse invoke order: the buy leg now comes first.
         f.invokes.get_mut(&PUMPSWAP_PROGRAM).unwrap().reverse();
 
-        let mut sell = DexEvent::PumpSwapSell(PumpSwapSellEvent {
-            pool: f.sell_pool,
-            ..Default::default()
-        });
+        let mut sell =
+            DexEvent::PumpSwapSell(PumpSwapSellEvent { pool: f.sell_pool, ..Default::default() });
         fill_accounts_with_owned_keys(&mut sell, &f.meta, &f.transaction, &f.invokes);
         match sell {
             DexEvent::PumpSwapSell(e) => assert_eq!(e.base_mint, f.sell_mint),


### PR DESCRIPTION
find_instruction_invoke picks the invoke with the most accounts — a heuristic that only exists to skip 1-account event-CPI shells. When one transaction carries TWO real invokes of the same program it silently picks the wrong one: a Jupiter token-to-token route (sell mint A -> buy mint B) contains a pAMM sell (24 accounts) and a pAMM buy (26 accounts, the cashback variant is longer), so the buy leg wins on length and every PumpSwap event in the tx — including the SELL on pool A — gets base_mint and the other account fields backfilled from the BUY leg.

Observed live (mainnet tx DRCWs7ivC5E1MviLWKNtKQ5waJoMrEUAzmH6H1ibjxGSey j6SFoAMsmBbdKY2DuvFrWPjwZz5Xbn1i2w94kHcJu): the GfGA…pump sell event was emitted with base_mint=Ef4E…pump, the mint of the buy leg. Downstream consumers that validate (pool, mint) consistency drop the event entirely, so the real dump never surfaces.

Fix: PumpSwapBuy/PumpSwapSell now resolve their invoke by anchoring on the event's own pool (pAMM layouts put the pool at account index 0), falling back to the historical longest-invoke heuristic when no invoke matches (defensive for future layouts). Single-invoke transactions are unaffected.

Adds regression tests: per-leg backfill on a two-invoke route, invoke-order independence, and fallback preservation.