### PR TITLE
fix: parse current DEX event layouts

### DIFF
--- a/idl/README.md
+++ b/idl/README.md
@@ -1,19 +1,22 @@
-# IDL Source
+# IDL Sources
 
-These IDL files are synced from `bitquery/solana-idl-lib` for the pool protocols currently supported by `sol-parser-sdk`.
+Current IDLs are synced from protocol-maintained repositories or packages. JSON key order and
+formatting may differ; use a canonical JSON hash (`jq -S -c .`) when comparing copies.
 
-Source: https://github.com/bitquery/solana-idl-lib
+| Local file | Upstream source |
+| --- | --- |
+| `pumpfun.json` | `pump-fun/pump-public-docs/idl/pump.json` |
+| `pump_amm.json` | `pump-fun/pump-public-docs/idl/pump_amm.json` |
+| `pump_fees.json` | `pump-fun/pump-public-docs/idl/pump_fees.json` |
+| `raydium_clmm.json` | `raydium-io/raydium-idl/raydium_clmm/raydium_clmm.json` |
+| `raydium_cpmm.json` | `raydium-io/raydium-idl/raydium_cpmm/raydium_cp_swap.json` |
+| `raydium_launchpad.json` | `raydium-io/raydium-idl/raydium_launchpad/raydium_launchpad.json` |
+| `meteora_amm.json` | `MeteoraAg/dynamic-bonding-curve/idls/dynamic_amm.json` |
+| `meteora_damm_v2.json` | `MeteoraAg/damm-v2-sdk/src/idl/cp_amm.json` |
+| `meteora_dynamic_bonding_curve.json` | `MeteoraAg/dynamic-bonding-curve-sdk/packages/dynamic-bonding-curve/src/idl/dynamic-bonding-curve/idl.json` |
+| `meteora_dlmm.json` | `MeteoraAg/dlmm-sdk/idls/dlmm.json` |
+| `orca_whirlpool.json` | `@orca-so/whirlpools-sdk/dist/artifacts/whirlpool.json` |
 
-Mapping:
-
-- `pumpfun.json` <- `pumpfun/pump.json`
-- `pump_amm.json` <- `pumpswap/amm.json`
-- `raydium_clmm.json` <- `raydium/amm_v3_with_swapv2.json`
-- `raydium_cpmm.json` <- `raydium/raydium_cp.json`
-- `raydium_amm_v4.json` <- `raydium/raydium_amm.json`
-- `raydium_pool_v4.json` <- `raydium/pool_v4.json`
-- `raydium_launchpad.json` <- `raydium/launchpad.json`
-- `meteora_amm.json` <- `meteora/amm_052.json`
-- `meteora_damm_v2.json` <- `meteora/cp_amm_016.json`
-- `meteora_dlmm.json` <- `meteora/lb_clmm_090.json`
-- `orca_whirlpool.json` <- `orca/whirlpool_v2.json`
+Raydium AMM V4 is not an Anchor program and has no current protocol-maintained Anchor IDL. Its
+instruction and `ray_log` layouts are validated against `raydium-io/raydium-amm` source. The
+`raydium_amm_v4.json` and `raydium_pool_v4.json` files remain compatibility references.

--- a/idl/meteora_amm.json
+++ b/idl/meteora_amm.json
@@ -1,196 +1,179 @@
 {
-  "version": "0.5.2",
-  "name": "amm",
+  "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB",
+  "metadata": {
+    "name": "dynamic_amm",
+    "version": "0.5.2",
+    "spec": "0.1.0"
+  },
   "docs": [
     "Program for AMM"
   ],
   "instructions": [
     {
-      "name": "initializePermissionedPool",
+      "name": "initialize_permissioned_pool",
       "docs": [
         "Initialize a new permissioned pool."
       ],
+      "discriminator": [
+        77,
+        85,
+        178,
+        157,
+        50,
+        48,
+        212,
+        126
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Pool account (arbitrary address)"
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_a_mint",
           "docs": [
             "Token A mint of the pool. Eg: USDT"
           ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_b_mint",
           "docs": [
             "Token B mint of the pool. Eg: USDC"
           ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_a",
           "docs": [
             "Admin token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_pool_lp",
           "docs": [
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)",
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
             "Protocol fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
             "Protocol fee token account for token B. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "feeOwner",
-          "isMut": false,
-          "isSigner": false
+          "name": "fee_owner"
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Rent account."
           ]
         },
         {
-          "name": "mintMetadata",
-          "isMut": true,
-          "isSigner": false
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "metadata_program"
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
             "Associated token program."
           ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
@@ -198,211 +181,189 @@
       ],
       "args": [
         {
-          "name": "curveType",
+          "name": "curve_type",
           "type": {
-            "defined": "CurveType"
+            "defined": {
+              "name": "CurveType"
+            }
           }
         }
       ]
     },
     {
-      "name": "initializePermissionlessPool",
+      "name": "initialize_permissionless_pool",
       "docs": [
         "Initialize a new permissionless pool."
       ],
+      "discriminator": [
+        118,
+        173,
+        41,
+        157,
+        173,
+        72,
+        97,
+        103
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA address)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_a_mint",
           "docs": [
             "Token A mint of the pool. Eg: USDT"
           ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_b_mint",
           "docs": [
             "Token B mint of the pool. Eg: USDC"
           ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerPoolLp",
-          "isMut": true,
-          "isSigner": false
+          "name": "payer_pool_lp",
+          "writable": true
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
             "Protocol fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
             "Protocol fee token account for token B. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "feeOwner",
-          "isMut": false,
-          "isSigner": false
+          "name": "fee_owner"
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Rent account."
           ]
         },
         {
-          "name": "mintMetadata",
-          "isMut": true,
-          "isSigner": false
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "metadata_program"
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
             "Associated token program."
           ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
@@ -410,219 +371,197 @@
       ],
       "args": [
         {
-          "name": "curveType",
+          "name": "curve_type",
           "type": {
-            "defined": "CurveType"
+            "defined": {
+              "name": "CurveType"
+            }
           }
         },
         {
-          "name": "tokenAAmount",
+          "name": "token_a_amount",
           "type": "u64"
         },
         {
-          "name": "tokenBAmount",
+          "name": "token_b_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "initializePermissionlessPoolWithFeeTier",
+      "name": "initialize_permissionless_pool_with_fee_tier",
       "docs": [
         "Initialize a new permissionless pool with customized fee tier"
       ],
+      "discriminator": [
+        6,
+        135,
+        68,
+        147,
+        229,
+        82,
+        169,
+        113
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA address)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_a_mint",
           "docs": [
             "Token A mint of the pool. Eg: USDT"
           ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_b_mint",
           "docs": [
             "Token B mint of the pool. Eg: USDC"
           ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerPoolLp",
-          "isMut": true,
-          "isSigner": false
+          "name": "payer_pool_lp",
+          "writable": true
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
             "Protocol fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
             "Protocol fee token account for token B. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "feeOwner",
-          "isMut": false,
-          "isSigner": false
+          "name": "fee_owner"
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Rent account."
           ]
         },
         {
-          "name": "mintMetadata",
-          "isMut": true,
-          "isSigner": false
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "metadata_program"
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
             "Associated token program."
           ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
@@ -630,46 +569,56 @@
       ],
       "args": [
         {
-          "name": "curveType",
+          "name": "curve_type",
           "type": {
-            "defined": "CurveType"
+            "defined": {
+              "name": "CurveType"
+            }
           }
         },
         {
-          "name": "tradeFeeBps",
+          "name": "trade_fee_bps",
           "type": "u64"
         },
         {
-          "name": "tokenAAmount",
+          "name": "token_a_amount",
           "type": "u64"
         },
         {
-          "name": "tokenBAmount",
+          "name": "token_b_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "enableOrDisablePool",
+      "name": "enable_or_disable_pool",
       "docs": [
         "Enable or disable a pool. A disabled pool allow only remove balanced liquidity operation."
+      ],
+      "discriminator": [
+        128,
+        6,
+        228,
+        131,
+        55,
+        161,
+        52,
+        169
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "Admin account. Must be owner of the pool."
-          ]
+          ],
+          "signer": true
         }
       ],
       "args": [
@@ -684,123 +633,116 @@
       "docs": [
         "Swap token A to B, or vice versa. An amount of trading fee will be charged for liquidity provider, and the admin of the pool."
       ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userSourceToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_source_token",
           "docs": [
             "User token account. Token from this account will be transfer into the vault by the pool in exchange for another token of the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account. The exchanged token will be transfer into this account from the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "Lp token mint of vault a"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "Lp token mint of vault b"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_fee",
           "docs": [
             "Protocol fee token account. Used to receive trading fee. It's mint field must matched with user_source_token mint field."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_source_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
@@ -808,137 +750,130 @@
       ],
       "args": [
         {
-          "name": "inAmount",
+          "name": "in_amount",
           "type": "u64"
         },
         {
-          "name": "minimumOutAmount",
+          "name": "minimum_out_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "removeLiquiditySingleSide",
+      "name": "remove_liquidity_single_side",
       "docs": [
         "Withdraw only single token from the pool. Only supported by pool with stable swap curve."
+      ],
+      "discriminator": [
+        84,
+        84,
+        177,
+        66,
+        254,
+        185,
+        10,
+        251
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "User pool lp token account. LP will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account to receive token upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of the user_pool_lp account."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
@@ -946,145 +881,137 @@
       ],
       "args": [
         {
-          "name": "poolTokenAmount",
+          "name": "pool_token_amount",
           "type": "u64"
         },
         {
-          "name": "minimumOutAmount",
+          "name": "minimum_out_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "addImbalanceLiquidity",
+      "name": "add_imbalance_liquidity",
       "docs": [
         "Deposit tokens to the pool in an imbalance ratio. Only supported by pool with stable swap curve."
       ],
+      "discriminator": [
+        79,
+        35,
+        122,
+        84,
+        173,
+        15,
+        93,
+        191
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault a"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault b"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
@@ -1092,149 +1019,141 @@
       ],
       "args": [
         {
-          "name": "minimumPoolTokenAmount",
+          "name": "minimum_pool_token_amount",
           "type": "u64"
         },
         {
-          "name": "tokenAAmount",
+          "name": "token_a_amount",
           "type": "u64"
         },
         {
-          "name": "tokenBAmount",
+          "name": "token_b_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "removeBalanceLiquidity",
+      "name": "remove_balance_liquidity",
       "docs": [
         "Withdraw tokens from the pool in a balanced ratio. User will still able to withdraw from pool even the pool is disabled. This allow user to exit their liquidity when there's some unforeseen event happen."
       ],
+      "discriminator": [
+        133,
+        109,
+        44,
+        179,
+        56,
+        238,
+        114,
+        33
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault a"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault b"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
@@ -1242,149 +1161,141 @@
       ],
       "args": [
         {
-          "name": "poolTokenAmount",
+          "name": "pool_token_amount",
           "type": "u64"
         },
         {
-          "name": "minimumATokenOut",
+          "name": "minimum_a_token_out",
           "type": "u64"
         },
         {
-          "name": "minimumBTokenOut",
+          "name": "minimum_b_token_out",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "addBalanceLiquidity",
+      "name": "add_balance_liquidity",
       "docs": [
         "Deposit tokens to the pool in a balanced ratio."
       ],
+      "discriminator": [
+        168,
+        227,
+        50,
+        62,
+        189,
+        171,
+        84,
+        176
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault a"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault b"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
@@ -1392,154 +1303,168 @@
       ],
       "args": [
         {
-          "name": "poolTokenAmount",
+          "name": "pool_token_amount",
           "type": "u64"
         },
         {
-          "name": "maximumTokenAAmount",
+          "name": "maximum_token_a_amount",
           "type": "u64"
         },
         {
-          "name": "maximumTokenBAmount",
+          "name": "maximum_token_b_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "setPoolFees",
+      "name": "set_pool_fees",
       "docs": [
         "Update trading fee charged for liquidity provider, and admin."
+      ],
+      "discriminator": [
+        102,
+        44,
+        158,
+        54,
+        205,
+        37,
+        126,
+        78
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "feeOperator",
-          "isMut": false,
-          "isSigner": true,
+          "name": "fee_operator",
           "docs": [
             "Fee operator account"
-          ]
+          ],
+          "signer": true
         }
       ],
       "args": [
         {
           "name": "fees",
           "type": {
-            "defined": "PoolFees"
+            "defined": {
+              "name": "PoolFees"
+            }
           }
         },
         {
-          "name": "newPartnerFeeNumerator",
+          "name": "new_partner_fee_numerator",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "overrideCurveParam",
+      "name": "override_curve_param",
       "docs": [
         "Update swap curve parameters. This function do not allow update of curve type. For example: stable swap curve to constant product curve. Only supported by pool with stable swap curve.",
         "Only amp is allowed to be override. The other attributes of stable swap curve will be ignored."
       ],
+      "discriminator": [
+        98,
+        86,
+        204,
+        51,
+        94,
+        71,
+        69,
+        187
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "Admin account."
-          ]
+          ],
+          "signer": true
         }
       ],
       "args": [
         {
-          "name": "curveType",
+          "name": "curve_type",
           "type": {
-            "defined": "CurveType"
+            "defined": {
+              "name": "CurveType"
+            }
           }
         }
       ]
     },
     {
-      "name": "getPoolInfo",
+      "name": "get_pool_info",
       "docs": [
         "Get the general information of the pool."
+      ],
+      "discriminator": [
+        9,
+        48,
+        220,
+        101,
+        22,
+        240,
+        78,
+        200
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
           ]
         },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
           ]
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault a"
           ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault b"
           ]
@@ -1548,135 +1473,127 @@
       "args": []
     },
     {
-      "name": "bootstrapLiquidity",
+      "name": "bootstrap_liquidity",
       "docs": [
         "Bootstrap the pool when liquidity is depleted."
+      ],
+      "discriminator": [
+        4,
+        228,
+        215,
+        71,
+        225,
+        253,
+        119,
+        206
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault a"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault b"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
@@ -1684,121 +1601,121 @@
       ],
       "args": [
         {
-          "name": "tokenAAmount",
+          "name": "token_a_amount",
           "type": "u64"
         },
         {
-          "name": "tokenBAmount",
+          "name": "token_b_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "createMintMetadata",
+      "name": "create_mint_metadata",
       "docs": [
         "Create mint metadata account for old pools"
+      ],
+      "discriminator": [
+        13,
+        70,
+        168,
+        41,
+        250,
+        100,
+        148,
+        90
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Pool account"
           ]
         },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP mint account of the pool"
           ]
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "Vault A LP account of the pool"
           ]
         },
         {
-          "name": "mintMetadata",
-          "isMut": true,
-          "isSigner": false
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "metadata_program"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Payer"
-          ]
+          ],
+          "writable": true,
+          "signer": true
         }
       ],
       "args": []
     },
     {
-      "name": "createLockEscrow",
+      "name": "create_lock_escrow",
       "docs": [
         "Create lock account"
+      ],
+      "discriminator": [
+        54,
+        87,
+        165,
+        19,
+        69,
+        227,
+        218,
+        224
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Pool account"
           ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lock_escrow",
           "docs": [
             "Lock account"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner"
         },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
           ]
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Payer account"
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
@@ -1811,107 +1728,97 @@
       "docs": [
         "Lock Lp token"
       ],
+      "discriminator": [
+        21,
+        19,
+        208,
+        43,
+        237,
+        62,
+        255,
+        87
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
           ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lock_escrow",
           "docs": [
             "Lock account"
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Can be anyone"
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
+          "name": "source_tokens",
           "docs": [
             "owner lp token account"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "escrow_vault",
           "docs": [
             "Escrow vault"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault a"
           ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault b"
           ]
@@ -1919,157 +1826,148 @@
       ],
       "args": [
         {
-          "name": "maxAmount",
+          "name": "max_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "claimFee",
+      "name": "claim_fee",
       "docs": [
         "Claim fee"
+      ],
+      "discriminator": [
+        169,
+        32,
+        79,
+        137,
+        136,
+        232,
+        70,
+        137
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lock_escrow",
           "docs": [
             "Lock account"
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Owner of lock account"
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
+          "name": "source_tokens",
           "docs": [
             "owner lp token account"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "escrow_vault",
           "docs": [
             "Escrow vault"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault a"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault b"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
@@ -2077,264 +1975,258 @@
       ],
       "args": [
         {
-          "name": "maxAmount",
+          "name": "max_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "createConfig",
+      "name": "create_config",
       "docs": [
         "Create config"
+      ],
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
       ],
       "accounts": [
         {
           "name": "config",
-          "isMut": true,
-          "isSigner": false
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": true,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
         {
-          "name": "configParameters",
+          "name": "config_parameters",
           "type": {
-            "defined": "ConfigParameters"
+            "defined": {
+              "name": "ConfigParameters"
+            }
           }
         }
       ]
     },
     {
-      "name": "closeConfig",
+      "name": "close_config",
       "docs": [
         "Close config"
+      ],
+      "discriminator": [
+        145,
+        9,
+        72,
+        157,
+        95,
+        125,
+        61,
+        85
       ],
       "accounts": [
         {
           "name": "config",
-          "isMut": true,
-          "isSigner": false
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": true,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
+          "name": "rent_receiver",
+          "writable": true
         }
       ],
       "args": []
     },
     {
-      "name": "initializePermissionlessConstantProductPoolWithConfig",
+      "name": "initialize_permissionless_constant_product_pool_with_config",
       "docs": [
         "Initialize permissionless pool with config"
+      ],
+      "discriminator": [
+        7,
+        166,
+        138,
+        171,
+        206,
+        171,
+        236,
+        244
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA address)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
+          "name": "config"
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_a_mint",
           "docs": [
             "Token A mint of the pool. Eg: USDT"
           ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_b_mint",
           "docs": [
             "Token B mint of the pool. Eg: USDC"
           ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerPoolLp",
-          "isMut": true,
-          "isSigner": false
+          "name": "payer_pool_lp",
+          "writable": true
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
             "Protocol fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
             "Protocol fee token account for token B. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Rent account."
           ]
         },
         {
-          "name": "mintMetadata",
-          "isMut": true,
-          "isSigner": false
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "metadata_program"
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
             "Associated token program."
           ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
@@ -2342,213 +2234,189 @@
       ],
       "args": [
         {
-          "name": "tokenAAmount",
+          "name": "token_a_amount",
           "type": "u64"
         },
         {
-          "name": "tokenBAmount",
+          "name": "token_b_amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "initializePermissionlessConstantProductPoolWithConfig2",
+      "name": "initialize_permissionless_constant_product_pool_with_config2",
       "docs": [
         "Initialize permissionless pool with config 2"
+      ],
+      "discriminator": [
+        48,
+        149,
+        220,
+        130,
+        61,
+        11,
+        9,
+        178
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA address)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
+          "name": "config"
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_a_mint",
           "docs": [
             "Token A mint of the pool. Eg: USDT"
           ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_b_mint",
           "docs": [
             "Token B mint of the pool. Eg: USDC"
           ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerPoolLp",
-          "isMut": true,
-          "isSigner": false
+          "name": "payer_pool_lp",
+          "writable": true
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
             "Protocol fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
             "Protocol fee token account for token B. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Rent account."
           ]
         },
         {
-          "name": "mintMetadata",
-          "isMut": true,
-          "isSigner": false
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "metadata_program"
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
             "Associated token program."
           ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
@@ -2556,15 +2424,15 @@
       ],
       "args": [
         {
-          "name": "tokenAAmount",
+          "name": "token_a_amount",
           "type": "u64"
         },
         {
-          "name": "tokenBAmount",
+          "name": "token_b_amount",
           "type": "u64"
         },
         {
-          "name": "activationPoint",
+          "name": "activation_point",
           "type": {
             "option": "u64"
           }
@@ -2572,198 +2440,176 @@
       ]
     },
     {
-      "name": "initializeCustomizablePermissionlessConstantProductPool",
+      "name": "initialize_customizable_permissionless_constant_product_pool",
       "docs": [
         "Initialize permissionless pool with customizable params"
+      ],
+      "discriminator": [
+        145,
+        24,
+        172,
+        194,
+        219,
+        125,
+        3,
+        190
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA address)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
             "LP token mint of the pool"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_a_mint",
           "docs": [
             "Token A mint of the pool. Eg: USDT"
           ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_b_mint",
           "docs": [
             "Token B mint of the pool. Eg: USDC"
           ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_token_vault",
           "docs": [
             "Token vault account of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_token_vault",
           "docs": [
             "Token vault account of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp_mint",
           "docs": [
             "LP token mint of vault A"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp_mint",
           "docs": [
             "LP token mint of vault B"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerPoolLp",
-          "isMut": true,
-          "isSigner": false
+          "name": "payer_pool_lp",
+          "writable": true
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
             "Protocol fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
             "Protocol fee token account for token B. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Rent account."
           ]
         },
         {
-          "name": "mintMetadata",
-          "isMut": true,
-          "isSigner": false
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "metadata_program"
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Token program."
           ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
             "Associated token program."
           ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
             "System program."
           ]
@@ -2771,179 +2617,197 @@
       ],
       "args": [
         {
-          "name": "tokenAAmount",
+          "name": "token_a_amount",
           "type": "u64"
         },
         {
-          "name": "tokenBAmount",
+          "name": "token_b_amount",
           "type": "u64"
         },
         {
           "name": "params",
           "type": {
-            "defined": "CustomizableParams"
+            "defined": {
+              "name": "CustomizableParams"
+            }
           }
         }
       ]
     },
     {
-      "name": "updateActivationPoint",
+      "name": "update_activation_point",
       "docs": [
         "Update activation slot"
+      ],
+      "discriminator": [
+        150,
+        62,
+        125,
+        219,
+        171,
+        220,
+        26,
+        237
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "Admin account."
-          ]
+          ],
+          "signer": true
         }
       ],
       "args": [
         {
-          "name": "newActivationPoint",
+          "name": "new_activation_point",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "withdrawProtocolFees",
+      "name": "withdraw_protocol_fees",
       "docs": [
         "Withdraw protocol fee"
+      ],
+      "discriminator": [
+        11,
+        68,
+        165,
+        98,
+        18,
+        208,
+        134,
+        73
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
           ]
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false
+          "name": "a_vault_lp"
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false
+          "name": "protocol_token_a_fee",
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false
+          "name": "protocol_token_b_fee",
+          "writable": true
         },
         {
-          "name": "treasuryTokenA",
-          "isMut": true,
-          "isSigner": false
+          "name": "treasury_token_a",
+          "writable": true
         },
         {
-          "name": "treasuryTokenB",
-          "isMut": true,
-          "isSigner": false
+          "name": "treasury_token_b",
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_program"
         }
       ],
       "args": []
     },
     {
-      "name": "setWhitelistedVault",
+      "name": "set_whitelisted_vault",
       "docs": [
         "Set whitelisted vault"
+      ],
+      "discriminator": [
+        12,
+        148,
+        94,
+        42,
+        55,
+        57,
+        83,
+        247
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         }
       ],
       "args": [
         {
-          "name": "whitelistedVault",
-          "type": "publicKey"
+          "name": "whitelisted_vault",
+          "type": "pubkey"
         }
       ]
     },
     {
-      "name": "partnerClaimFee",
+      "name": "partner_claim_fee",
       "docs": [
         "Partner claim fee"
+      ],
+      "discriminator": [
+        57,
+        53,
+        176,
+        30,
+        123,
+        70,
+        52,
+        64
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
             "Pool account (PDA)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false
+          "name": "a_vault_lp"
         },
         {
-          "name": "protocolTokenAFee",
-          "isMut": true,
-          "isSigner": false
+          "name": "protocol_token_a_fee",
+          "writable": true
         },
         {
-          "name": "protocolTokenBFee",
-          "isMut": true,
-          "isSigner": false
+          "name": "protocol_token_b_fee",
+          "writable": true
         },
         {
-          "name": "partnerTokenA",
-          "isMut": true,
-          "isSigner": false
+          "name": "partner_token_a",
+          "writable": true
         },
         {
-          "name": "partnerTokenB",
-          "isMut": true,
-          "isSigner": false
+          "name": "partner_token_b",
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_program"
         },
         {
-          "name": "partnerAuthority",
-          "isMut": false,
-          "isSigner": true
+          "name": "partner_authority",
+          "signer": true
         }
       ],
       "args": [
         {
-          "name": "maxAmountA",
+          "name": "max_amount_a",
           "type": "u64"
         },
         {
-          "name": "maxAmountB",
+          "name": "max_amount_b",
           "type": "u64"
         }
       ]
@@ -2952,1245 +2816,277 @@
   "accounts": [
     {
       "name": "Config",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "poolFees",
-            "type": {
-              "defined": "PoolFees"
-            }
-          },
-          {
-            "name": "activationDuration",
-            "type": "u64"
-          },
-          {
-            "name": "vaultConfigKey",
-            "type": "publicKey"
-          },
-          {
-            "name": "poolCreatorAuthority",
-            "docs": [
-              "Only pool_creator_authority can use the current config to initialize new pool. When it's Pubkey::default, it's a public config."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "partnerFeeNumerator",
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                219
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
     },
     {
       "name": "LockEscrow",
-      "docs": [
-        "State of lock escrow account"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "pool",
-            "docs": [
-              "Pool address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "escrowVault",
-            "docs": [
-              "Vault address, store the lock user lock"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bump",
-            "docs": [
-              "bump, used to sign"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "totalLockedAmount",
-            "docs": [
-              "Total locked amount"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "lpPerToken",
-            "docs": [
-              "Lp per token, virtual price of lp token"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "unclaimedFeePending",
-            "docs": [
-              "Unclaimed fee pending"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "aFee",
-            "docs": [
-              "Total a fee claimed so far"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "bFee",
-            "docs": [
-              "Total b fee claimed so far"
-            ],
-            "type": "u64"
-          }
-        ]
-      }
+      "discriminator": [
+        190,
+        106,
+        121,
+        6,
+        200,
+        182,
+        21,
+        75
+      ]
     },
     {
       "name": "Pool",
-      "docs": [
-        "State of pool account"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lpMint",
-            "docs": [
-              "LP token mint of the pool"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenAMint",
-            "docs": [
-              "Token A mint of the pool. Eg: USDT"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBMint",
-            "docs": [
-              "Token B mint of the pool. Eg: USDC"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVault",
-            "docs": [
-              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVault",
-            "docs": [
-              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLp",
-            "docs": [
-              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVaultLp",
-            "docs": [
-              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLpBump",
-            "docs": [
-              "\"A\" vault lp bump. Used to create signer seeds."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "enabled",
-            "docs": [
-              "Flag to determine whether the pool is enabled, or disabled."
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "protocolTokenAFee",
-            "docs": [
-              "Protocol fee token account for token A. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "protocolTokenBFee",
-            "docs": [
-              "Protocol fee token account for token B. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "feeLastUpdatedAt",
-            "docs": [
-              "Fee last updated timestamp"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding0",
-            "type": {
-              "array": [
-                "u8",
-                24
-              ]
-            }
-          },
-          {
-            "name": "fees",
-            "docs": [
-              "Store the fee charges setting."
-            ],
-            "type": {
-              "defined": "PoolFees"
-            }
-          },
-          {
-            "name": "poolType",
-            "docs": [
-              "Pool type"
-            ],
-            "type": {
-              "defined": "PoolType"
-            }
-          },
-          {
-            "name": "stake",
-            "docs": [
-              "Stake pubkey of SPL stake pool"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "totalLockedLp",
-            "docs": [
-              "Total locked lp token"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "bootstrapping",
-            "docs": [
-              "bootstrapping config"
-            ],
-            "type": {
-              "defined": "Bootstrapping"
-            }
-          },
-          {
-            "name": "partnerInfo",
-            "type": {
-              "defined": "PartnerInfo"
-            }
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding for future pool field"
-            ],
-            "type": {
-              "defined": "Padding"
-            }
-          },
-          {
-            "name": "curveType",
-            "docs": [
-              "The type of the swap curve supported by the pool."
-            ],
-            "type": {
-              "defined": "CurveType"
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "TokenMultiplier",
-      "docs": [
-        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenAMultiplier",
-            "docs": [
-              "Multiplier for token A of the pool."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "tokenBMultiplier",
-            "docs": [
-              "Multiplier for token B of the pool."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "precisionFactor",
-            "docs": [
-              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PoolFees",
-      "docs": [
-        "Information regarding fee charges"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tradeFeeNumerator",
-            "docs": [
-              "Trade fees are extra token amounts that are held inside the token",
-              "accounts during a trade, making the value of liquidity tokens rise.",
-              "Trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "tradeFeeDenominator",
-            "docs": [
-              "Trade fee denominator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "protocolTradeFeeNumerator",
-            "docs": [
-              "Protocol trading fees are extra token amounts that are held inside the token",
-              "accounts during a trade, with the equivalent in pool tokens minted to",
-              "the protocol of the program.",
-              "Protocol trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "protocolTradeFeeDenominator",
-            "docs": [
-              "Protocol trade fee denominator"
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Depeg",
-      "docs": [
-        "Contains information for depeg pool"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "baseVirtualPrice",
-            "docs": [
-              "The virtual price of staking / interest bearing token"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "baseCacheUpdated",
-            "docs": [
-              "The last time base_virtual_price is updated"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "depegType",
-            "docs": [
-              "Type of the depeg pool"
-            ],
-            "type": {
-              "defined": "DepegType"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ConfigParameters",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tradeFeeNumerator",
-            "type": "u64"
-          },
-          {
-            "name": "protocolTradeFeeNumerator",
-            "type": "u64"
-          },
-          {
-            "name": "activationDuration",
-            "type": "u64"
-          },
-          {
-            "name": "vaultConfigKey",
-            "type": "publicKey"
-          },
-          {
-            "name": "poolCreatorAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "activationType",
-            "type": "u8"
-          },
-          {
-            "name": "index",
-            "type": "u64"
-          },
-          {
-            "name": "partnerFeeNumerator",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CustomizableParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tradeFeeNumerator",
-            "docs": [
-              "Trading fee."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "activationPoint",
-            "docs": [
-              "The pool start trading."
-            ],
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
-            "name": "hasAlphaVault",
-            "docs": [
-              "Whether the pool support alpha vault"
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                90
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Padding",
-      "docs": [
-        "Padding for future pool fields"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "padding0",
-            "docs": [
-              "Padding 0"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                6
-              ]
-            }
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "Padding 1"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                21
-              ]
-            }
-          },
-          {
-            "name": "padding2",
-            "docs": [
-              "Padding 2"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                21
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PartnerInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeNumerator",
-            "type": "u64"
-          },
-          {
-            "name": "partnerAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "pendingFeeA",
-            "type": "u64"
-          },
-          {
-            "name": "pendingFeeB",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Bootstrapping",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activationPoint",
-            "docs": [
-              "Activation point, can be slot or timestamp"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "whitelistedVault",
-            "docs": [
-              "Whitelisted vault to be able to buy pool before activation_point"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "poolCreator",
-            "docs": [
-              "Need to store pool creator in lauch pool, so they can modify liquidity before activation_point"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type, 0 means by slot, 1 means by timestamp"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ActivationType",
-      "docs": [
-        "Type of the activation"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Slot"
-          },
-          {
-            "name": "Timestamp"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RoundDirection",
-      "docs": [
-        "Rounding direction"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Floor"
-          },
-          {
-            "name": "Ceiling"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TradeDirection",
-      "docs": [
-        "Trade (swap) direction"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "AtoB"
-          },
-          {
-            "name": "BtoA"
-          }
-        ]
-      }
-    },
-    {
-      "name": "NewCurveType",
-      "docs": [
-        "Type of the swap curve"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "ConstantProduct"
-          },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": [
-                  "Amplification coefficient"
-                ],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": {
-                  "defined": "TokenMultiplier"
-                }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": {
-                  "defined": "Depeg"
-                }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          },
-          {
-            "name": "NewCurve",
-            "fields": [
-              {
-                "name": "field_one",
-                "type": "u64"
-              },
-              {
-                "name": "field_two",
-                "type": "u64"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "CurveType",
-      "docs": [
-        "Type of the swap curve"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "ConstantProduct"
-          },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": [
-                  "Amplification coefficient"
-                ],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": {
-                  "defined": "TokenMultiplier"
-                }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": {
-                  "defined": "Depeg"
-                }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "DepegType",
-      "docs": [
-        "Type of depeg pool"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "None"
-          },
-          {
-            "name": "Marinade"
-          },
-          {
-            "name": "Lido"
-          },
-          {
-            "name": "SplStake"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Rounding",
-      "docs": [
-        "Round up, down"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Up"
-          },
-          {
-            "name": "Down"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PoolType",
-      "docs": [
-        "Pool type"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permissioned"
-          },
-          {
-            "name": "Permissionless"
-          }
-        ]
-      }
+      "discriminator": [
+        241,
+        154,
+        109,
+        4,
+        17,
+        177,
+        109,
+        188
+      ]
     }
   ],
   "events": [
     {
       "name": "AddLiquidity",
-      "fields": [
-        {
-          "name": "lpMintAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
-        }
+      "discriminator": [
+        31,
+        94,
+        125,
+        90,
+        227,
+        52,
+        61,
+        186
       ]
     },
     {
       "name": "RemoveLiquidity",
-      "fields": [
-        {
-          "name": "lpUnmintAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenAOutAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenBOutAmount",
-          "type": "u64",
-          "index": false
-        }
+      "discriminator": [
+        116,
+        244,
+        97,
+        232,
+        103,
+        31,
+        152,
+        58
       ]
     },
     {
       "name": "BootstrapLiquidity",
-      "fields": [
-        {
-          "name": "lpMintAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        121,
+        127,
+        38,
+        136,
+        92,
+        55,
+        14,
+        247
       ]
     },
     {
       "name": "Swap",
-      "fields": [
-        {
-          "name": "inAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "outAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tradeFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "hostFee",
-          "type": "u64",
-          "index": false
-        }
+      "discriminator": [
+        81,
+        108,
+        227,
+        190,
+        205,
+        208,
+        10,
+        196
       ]
     },
     {
       "name": "SetPoolFees",
-      "fields": [
-        {
-          "name": "tradeFeeNumerator",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tradeFeeDenominator",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTradeFeeNumerator",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTradeFeeDenominator",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        245,
+        26,
+        198,
+        164,
+        88,
+        18,
+        75,
+        9
       ]
     },
     {
       "name": "PoolInfo",
-      "fields": [
-        {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "virtualPrice",
-          "type": "f64",
-          "index": false
-        },
-        {
-          "name": "currentTimestamp",
-          "type": "u64",
-          "index": false
-        }
+      "discriminator": [
+        207,
+        20,
+        87,
+        97,
+        251,
+        212,
+        234,
+        45
       ]
     },
     {
       "name": "TransferAdmin",
-      "fields": [
-        {
-          "name": "admin",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newAdmin",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        228,
+        169,
+        131,
+        244,
+        61,
+        56,
+        65,
+        254
       ]
     },
     {
       "name": "OverrideCurveParam",
-      "fields": [
-        {
-          "name": "newAmp",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "updatedTimestamp",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        247,
+        20,
+        165,
+        248,
+        75,
+        5,
+        54,
+        246
       ]
     },
     {
       "name": "PoolCreated",
-      "fields": [
-        {
-          "name": "lpMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenAMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenBMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "poolType",
-          "type": {
-            "defined": "PoolType"
-          },
-          "index": false
-        },
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        202,
+        44,
+        41,
+        88,
+        104,
+        220,
+        157,
+        82
       ]
     },
     {
       "name": "PoolEnabled",
-      "fields": [
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "enabled",
-          "type": "bool",
-          "index": false
-        }
+      "discriminator": [
+        2,
+        151,
+        18,
+        83,
+        204,
+        134,
+        92,
+        191
       ]
     },
     {
       "name": "MigrateFeeAccount",
-      "fields": [
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newAdminTokenAFee",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newAdminTokenBFee",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
-        }
+      "discriminator": [
+        223,
+        234,
+        232,
+        26,
+        252,
+        105,
+        180,
+        125
       ]
     },
     {
       "name": "CreateLockEscrow",
-      "fields": [
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        74,
+        94,
+        106,
+        141,
+        49,
+        17,
+        98,
+        109
       ]
     },
     {
       "name": "Lock",
-      "fields": [
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        }
+      "discriminator": [
+        220,
+        183,
+        67,
+        215,
+        153,
+        207,
+        56,
+        234
       ]
     },
     {
       "name": "ClaimFee",
-      "fields": [
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "aFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "bFee",
-          "type": "u64",
-          "index": false
-        }
+      "discriminator": [
+        75,
+        122,
+        154,
+        48,
+        140,
+        74,
+        123,
+        163
       ]
     },
     {
       "name": "CreateConfig",
-      "fields": [
-        {
-          "name": "tradeFeeNumerator",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTradeFeeNumerator",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "config",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        199,
+        152,
+        10,
+        19,
+        39,
+        39,
+        157,
+        104
       ]
     },
     {
       "name": "CloseConfig",
-      "fields": [
-        {
-          "name": "config",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        249,
+        181,
+        108,
+        89,
+        4,
+        150,
+        90,
+        174
       ]
     },
     {
       "name": "WithdrawProtocolFees",
-      "fields": [
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "protocolAFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolBFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolAFeeOwner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "protocolBFeeOwner",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        30,
+        240,
+        207,
+        196,
+        139,
+        239,
+        79,
+        28
       ]
     },
     {
       "name": "PartnerClaimFees",
-      "fields": [
-        {
-          "name": "pool",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "feeA",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeB",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "partner",
-          "type": "publicKey",
-          "index": false
-        }
+      "discriminator": [
+        135,
+        131,
+        10,
+        94,
+        119,
+        209,
+        202,
+        48
       ]
     }
   ],
@@ -4459,6 +3355,1262 @@
       "code": 6052,
       "name": "InvalidQuoteMint",
       "msg": "Quote token must be SOL,USDC"
+    }
+  ],
+  "types": [
+    {
+      "name": "TokenMultiplier",
+      "docs": [
+        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_multiplier",
+            "docs": [
+              "Multiplier for token A of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_multiplier",
+            "docs": [
+              "Multiplier for token B of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "precision_factor",
+            "docs": [
+              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFees",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trade fees are extra token amounts that are held inside the token",
+              "accounts during a trade, making the value of liquidity tokens rise.",
+              "Trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "docs": [
+              "Trade fee denominator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "docs": [
+              "Protocol trading fees are extra token amounts that are held inside the token",
+              "accounts during a trade, with the equivalent in pool tokens minted to",
+              "the protocol of the program.",
+              "Protocol trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "docs": [
+              "Protocol trade fee denominator"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Depeg",
+      "docs": [
+        "Contains information for depeg pool"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_virtual_price",
+            "docs": [
+              "The virtual price of staking / interest bearing token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_cache_updated",
+            "docs": [
+              "The last time base_virtual_price is updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depeg_type",
+            "docs": [
+              "Type of the depeg pool"
+            ],
+            "type": {
+              "defined": {
+                "name": "DepegType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trading fee."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "The pool start trading."
+            ],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": [
+              "Whether the pool support alpha vault"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                90
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Padding",
+      "docs": [
+        "Padding for future pool fields"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding0",
+            "docs": [
+              "Padding 0"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "docs": [
+              "Padding 1"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "docs": [
+              "Padding 2"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "partner_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "pending_fee_b",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bootstrapping",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "activation_point",
+            "docs": [
+              "Activation point, can be slot or timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "whitelisted_vault",
+            "docs": [
+              "Whitelisted vault to be able to buy pool before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator",
+            "docs": [
+              "Need to store pool creator in lauch pool, so they can modify liquidity before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type, 0 means by slot, 1 means by timestamp"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ActivationType",
+      "docs": [
+        "Type of the activation"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Slot"
+          },
+          {
+            "name": "Timestamp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RoundDirection",
+      "docs": [
+        "Rounding direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Floor"
+          },
+          {
+            "name": "Ceiling"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TradeDirection",
+      "docs": [
+        "Trade (swap) direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AtoB"
+          },
+          {
+            "name": "BtoA"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NewCurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          },
+          {
+            "name": "NewCurve",
+            "fields": [
+              {
+                "name": "field_one",
+                "type": "u64"
+              },
+              {
+                "name": "field_two",
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "CurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepegType",
+      "docs": [
+        "Type of depeg pool"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Marinade"
+          },
+          {
+            "name": "Lido"
+          },
+          {
+            "name": "SplStake"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rounding",
+      "docs": [
+        "Round up, down"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Up"
+          },
+          {
+            "name": "Down"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolType",
+      "docs": [
+        "Pool type"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Permissioned"
+          },
+          {
+            "name": "Permissionless"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "docs": [
+              "Only pool_creator_authority can use the current config to initialize new pool. When it's Pubkey::default, it's a public config."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                219
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockEscrow",
+      "docs": [
+        "State of lock escrow account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "docs": [
+              "Pool address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "escrow_vault",
+            "docs": [
+              "Vault address, store the lock user lock"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "bump, used to sign"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "total_locked_amount",
+            "docs": [
+              "Total locked amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lp_per_token",
+            "docs": [
+              "Lp per token, virtual price of lp token"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "unclaimed_fee_pending",
+            "docs": [
+              "Unclaimed fee pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "docs": [
+              "Total a fee claimed so far"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "docs": [
+              "Total b fee claimed so far"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Pool",
+      "docs": [
+        "State of pool account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "docs": [
+              "LP token mint of the pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "docs": [
+              "Token A mint of the pool. Eg: USDT"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "docs": [
+              "Token B mint of the pool. Eg: USDC"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault",
+            "docs": [
+              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault",
+            "docs": [
+              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp",
+            "docs": [
+              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault_lp",
+            "docs": [
+              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp_bump",
+            "docs": [
+              "\"A\" vault lp bump. Used to create signer seeds."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "enabled",
+            "docs": [
+              "Flag to determine whether the pool is enabled, or disabled."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "protocol_token_a_fee",
+            "docs": [
+              "Protocol fee token account for token A. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_token_b_fee",
+            "docs": [
+              "Protocol fee token account for token B. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_last_updated_at",
+            "docs": [
+              "Fee last updated timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Store the fee charges setting."
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "pool_type",
+            "docs": [
+              "Pool type"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "stake",
+            "docs": [
+              "Stake pubkey of SPL stake pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "total_locked_lp",
+            "docs": [
+              "Total locked lp token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bootstrapping",
+            "docs": [
+              "bootstrapping config"
+            ],
+            "type": {
+              "defined": {
+                "name": "Bootstrapping"
+              }
+            }
+          },
+          {
+            "name": "partner_info",
+            "type": {
+              "defined": {
+                "name": "PartnerInfo"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding for future pool field"
+            ],
+            "type": {
+              "defined": {
+                "name": "Padding"
+              }
+            }
+          },
+          {
+            "name": "curve_type",
+            "docs": [
+              "The type of the swap curve supported by the pool."
+            ],
+            "type": {
+              "defined": {
+                "name": "CurveType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_unmint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_out_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BootstrapLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "in_amount",
+            "type": "u64"
+          },
+          {
+            "name": "out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetPoolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "virtual_price",
+            "type": "f64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferAdmin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OverrideCurveParam",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_amp",
+            "type": "u64"
+          },
+          {
+            "name": "updated_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "enabled",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrateFeeAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_a_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_b_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateLockEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Lock",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawProtocolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_b_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_a_fee_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_b_fee_owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerClaimFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          }
+        ]
+      }
     }
   ]
 }

--- a/idl/meteora_damm_v2.json
+++ b/idl/meteora_damm_v2.json
@@ -1,1513 +1,4160 @@
 {
   "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",
-  "metadata": { "name": "cp_amm", "version": "0.1.6", "spec": "0.1.0", "description": "Created with Anchor" },
+  "metadata": {
+    "name": "cp_amm",
+    "version": "0.2.2",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
   "instructions": [
     {
       "name": "add_liquidity",
-      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
-        {
-          "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
-          "writable": true,
-          "relations": ["pool"]
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
-          "writable": true,
-          "relations": ["pool"]
-        },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        181,
+        157,
+        89,
+        67,
+        143,
+        182,
+        52,
+        72
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "AddLiquidityParameters" } } }]
-    },
-    {
-      "name": "claim_partner_fee",
-      "discriminator": [97, 206, 39, 105, 94, 94, 126, 148],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
-        { "name": "token_a_account", "docs": ["The treasury token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The treasury token b account"], "writable": true },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "partner", "signer": true, "relations": ["pool"] },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "max_amount_a", "type": "u64" },
-        { "name": "max_amount_b", "type": "u64" }
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "AddLiquidityParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "claim_position_fee",
-      "discriminator": [180, 38, 154, 17, 133, 33, 162, 211],
+      "discriminator": [
+        180,
+        38,
+        154,
+        17,
+        133,
+        33,
+        162,
+        211
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "claim_protocol_fee",
-      "discriminator": [165, 228, 133, 48, 99, 249, 255, 33],
+      "discriminator": [
+        165,
+        228,
+        133,
+        48,
+        99,
+        249,
+        255,
+        33
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
         {
           "name": "token_a_account",
-          "docs": ["The treasury token a account"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  48, 9, 89, 123, 106, 114, 131, 251, 50, 173, 254, 250, 10, 80, 160, 84, 143, 100,
-                  81, 249, 134, 112, 30, 213, 50, 166, 239, 78, 53, 175, 188, 85
-                ]
-              },
-              { "kind": "account", "path": "token_a_program" },
-              { "kind": "account", "path": "token_a_mint" }
-            ],
-            "program": {
-              "kind": "const",
-              "value": [
-                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153,
-                218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
-              ]
-            }
-          }
+          "writable": true
         },
         {
           "name": "token_b_account",
-          "docs": ["The treasury token b account"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  48, 9, 89, 123, 106, 114, 131, 251, 50, 173, 254, 250, 10, 80, 160, 84, 143, 100,
-                  81, 249, 134, 112, 30, 213, 50, 166, 239, 78, 53, 175, 188, 85
-                ]
-              },
-              { "kind": "account", "path": "token_b_program" },
-              { "kind": "account", "path": "token_b_mint" }
-            ],
-            "program": {
-              "kind": "const",
-              "value": [
-                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153,
-                218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
-              ]
-            }
-          }
+          "writable": true
         },
-        { "name": "operator", "docs": ["Claim fee operator"] },
-        { "name": "whitelisted_address", "docs": ["Operator"], "signer": true, "relations": ["operator"] },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "operator",
+          "docs": [
+            "Claim fee operator"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "max_amount_a", "type": "u64" },
-        { "name": "max_amount_b", "type": "u64" }
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_a_program"
+        },
+        {
+          "name": "token_b_program"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
       ]
     },
     {
       "name": "claim_reward",
-      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
+      "discriminator": [
+        149,
+        95,
+        181,
+        242,
+        94,
+        90,
+        158,
+        162
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "reward_vault", "docs": ["The vault token account for reward token"], "writable": true },
-        { "name": "reward_mint" },
-        { "name": "user_token_account", "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_program" },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
         },
-        { "name": "program" }
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "docs": [
+            "The vault token account for reward token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "skip_reward", "type": "u8" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "skip_reward",
+          "type": "u8"
+        }
       ]
     },
     {
       "name": "close_config",
-      "discriminator": [145, 9, 72, 157, 95, 125, 61, 85],
+      "discriminator": [
+        145,
+        9,
+        72,
+        157,
+        95,
+        125,
+        61,
+        85
+      ],
       "accounts": [
-        { "name": "config", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "rent_receiver", "writable": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "config",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "close_operator_account",
-      "discriminator": [171, 9, 213, 74, 120, 23, 3, 29],
+      "discriminator": [
+        171,
+        9,
+        213,
+        74,
+        120,
+        23,
+        3,
+        29
+      ],
       "accounts": [
-        { "name": "operator", "writable": true },
-        { "name": "admin", "signer": true },
-        { "name": "rent_receiver", "writable": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "operator",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "close_position",
-      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
+      "discriminator": [
+        123,
+        134,
+        81,
+        0,
+        49,
+        68,
+        98,
+        98
+      ],
       "accounts": [
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"], "writable": true },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "rent_receiver", "writable": true },
-        { "name": "owner", "docs": ["Owner of position"], "signer": true },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "docs": [
+            "Owner of position"
+          ],
+          "signer": true
+        },
         {
           "name": "token_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
           "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
-        { "name": "program" }
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "close_token_badge",
-      "discriminator": [108, 146, 86, 110, 179, 254, 10, 104],
+      "discriminator": [
+        108,
+        146,
+        86,
+        110,
+        179,
+        254,
+        10,
+        104
+      ],
       "accounts": [
-        { "name": "token_badge", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "rent_receiver", "writable": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_badge",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "create_config",
-      "docs": ["OPERATOR FUNCTIONS /////"],
-      "discriminator": [201, 207, 243, 114, 75, 111, 47, 189],
+      "docs": [
+        "OPERATOR FUNCTIONS /////"
+      ],
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
       "accounts": [
         {
           "name": "config",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [99, 111, 110, 102, 105, 103] },
-              { "kind": "arg", "path": "index" }
-            ]
-          }
-        },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "index", "type": "u64" },
-        { "name": "config_parameters", "type": { "defined": { "name": "StaticConfigParameters" } } }
+        {
+          "name": "index",
+          "type": "u64"
+        },
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "StaticConfigParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "create_dynamic_config",
-      "discriminator": [81, 251, 122, 78, 66, 57, 208, 82],
+      "discriminator": [
+        81,
+        251,
+        122,
+        78,
+        66,
+        57,
+        208,
+        82
+      ],
       "accounts": [
         {
           "name": "config",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [99, 111, 110, 102, 105, 103] },
-              { "kind": "arg", "path": "index" }
-            ]
-          }
-        },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "index", "type": "u64" },
-        { "name": "config_parameters", "type": { "defined": { "name": "DynamicConfigParameters" } } }
+        {
+          "name": "index",
+          "type": "u64"
+        },
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "DynamicConfigParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "create_operator_account",
-      "docs": ["ADMIN FUNCTIONS /////"],
-      "discriminator": [221, 64, 246, 149, 240, 153, 229, 163],
+      "docs": [
+        "ADMIN FUNCTIONS /////"
+      ],
+      "discriminator": [
+        221,
+        64,
+        246,
+        149,
+        240,
+        153,
+        229,
+        163
+      ],
       "accounts": [
         {
           "name": "operator",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [111, 112, 101, 114, 97, 116, 111, 114] },
-              { "kind": "account", "path": "whitelisted_address" }
-            ]
-          }
-        },
-        { "name": "whitelisted_address" },
-        { "name": "admin", "signer": true },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  111,
+                  114
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_address"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "whitelisted_address"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "permission", "type": "u128" }]
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
     },
     {
       "name": "create_position",
-      "discriminator": [48, 215, 197, 153, 96, 203, 180, 133],
+      "discriminator": [
+        48,
+        215,
+        197,
+        153,
+        96,
+        203,
+        180,
+        133
+      ],
       "accounts": [
-        { "name": "owner" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "pool", "writable": true },
+        {
+          "name": "pool",
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
         {
           "name": "payer",
-          "docs": ["Address paying to create the position. Can be anyone"],
+          "docs": [
+            "Address paying to create the position. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
         {
           "name": "token_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
           "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
-        { "name": "program" }
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "create_token_badge",
-      "discriminator": [88, 206, 0, 91, 60, 175, 151, 118],
+      "discriminator": [
+        88,
+        206,
+        0,
+        91,
+        60,
+        175,
+        151,
+        118
+      ],
       "accounts": [
         {
           "name": "token_badge",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 98, 97, 100, 103, 101] },
-              { "kind": "account", "path": "token_mint" }
-            ]
-          }
-        },
-        { "name": "token_mint" },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  98,
+                  97,
+                  100,
+                  103,
+                  101
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "dummy_ix",
-      "discriminator": [234, 95, 176, 185, 7, 42, 35, 159],
-      "accounts": [
-        { "name": "pod_aligned_fee_time_scheduler" },
-        { "name": "pod_aligned_fee_rate_limiter" },
-        { "name": "pod_aligned_fee_market_cap_scheduler" }
+      "discriminator": [
+        234,
+        95,
+        176,
+        185,
+        7,
+        42,
+        35,
+        159
       ],
-      "args": [{ "name": "_ixs", "type": { "defined": { "name": "DummyParams" } } }]
+      "accounts": [
+        {
+          "name": "pod_aligned_fee_time_scheduler"
+        },
+        {
+          "name": "pod_aligned_fee_rate_limiter"
+        },
+        {
+          "name": "pod_aligned_fee_market_cap_scheduler"
+        }
+      ],
+      "args": [
+        {
+          "name": "_ixs",
+          "type": {
+            "defined": {
+              "name": "DummyParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_config_fee_params",
+      "discriminator": [
+        38,
+        30,
+        216,
+        81,
+        250,
+        177,
+        243,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_fee_params",
+      "discriminator": [
+        132,
+        98,
+        81,
+        196,
+        44,
+        58,
+        120,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_layout_version",
+      "discriminator": [
+        166,
+        158,
+        69,
+        35,
+        81,
+        167,
+        200,
+        215
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
     },
     {
       "name": "fund_reward",
-      "discriminator": [188, 50, 249, 165, 93, 151, 38, 63],
+      "discriminator": [
+        188,
+        50,
+        249,
+        165,
+        93,
+        151,
+        38,
+        63
+      ],
       "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "reward_vault", "writable": true },
-        { "name": "reward_mint" },
-        { "name": "funder_token_account", "writable": true },
-        { "name": "funder", "signer": true },
-        { "name": "token_program" },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "amount", "type": "u64" },
-        { "name": "carry_forward", "type": "bool" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "carry_forward",
+          "type": "bool"
+        }
       ]
     },
     {
       "name": "initialize_customizable_pool",
-      "discriminator": [20, 161, 241, 24, 189, 221, 180, 2],
+      "discriminator": [
+        20,
+        161,
+        241,
+        24,
+        189,
+        221,
+        180,
+        2
+      ],
       "accounts": [
-        { "name": "creator" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
         {
           "name": "payer",
-          "docs": ["Address paying to create the pool. Can be anyone"],
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Initialize an account to store the pool state"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "token_a_mint", "docs": ["Token a mint"] },
-        { "name": "token_b_mint", "docs": ["Token b mint"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token a mint"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token b mint"
+          ]
+        },
         {
           "name": "token_a_vault",
-          "docs": ["Token a vault for the pool"],
+          "docs": [
+            "Token a vault for the pool"
+          ],
           "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_a_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["Token b vault for the pool"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_b_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        { "name": "payer_token_a", "docs": ["payer token a account"], "writable": true },
-        { "name": "payer_token_b", "docs": ["creator token b account"], "writable": true },
-        { "name": "token_a_program", "docs": ["Program to create mint account and mint tokens"] },
-        { "name": "token_b_program", "docs": ["Program to create mint account and mint tokens"] },
-        {
-          "name": "token_2022_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
-          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-        },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_a_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_b_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_b_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "payer token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "creator token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_2022_program",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "InitializeCustomizablePoolParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializeCustomizablePoolParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "initialize_pool",
-      "docs": ["USER FUNCTIONS ////"],
-      "discriminator": [95, 180, 10, 172, 84, 174, 232, 40],
+      "docs": [
+        "USER FUNCTIONS ////"
+      ],
+      "discriminator": [
+        95,
+        180,
+        10,
+        172,
+        84,
+        174,
+        232,
+        40
+      ],
       "accounts": [
-        { "name": "creator" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
         {
           "name": "payer",
-          "docs": ["Address paying to create the pool. Can be anyone"],
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
-        { "name": "config", "docs": ["Which config the pool belongs to."] },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Initialize an account to store the pool state"], "writable": true },
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "token_a_mint", "docs": ["Token a mint"] },
-        { "name": "token_b_mint", "docs": ["Token b mint"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token a mint"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token b mint"
+          ]
+        },
         {
           "name": "token_a_vault",
-          "docs": ["Token a vault for the pool"],
+          "docs": [
+            "Token a vault for the pool"
+          ],
           "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_a_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["Token b vault for the pool"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_b_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        { "name": "payer_token_a", "docs": ["payer token a account"], "writable": true },
-        { "name": "payer_token_b", "docs": ["creator token b account"], "writable": true },
-        { "name": "token_a_program", "docs": ["Program to create mint account and mint tokens"] },
-        { "name": "token_b_program", "docs": ["Program to create mint account and mint tokens"] },
-        {
-          "name": "token_2022_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
-          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-        },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_a_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_b_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_b_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "payer token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "creator token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_2022_program",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "InitializePoolParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "initialize_pool_with_dynamic_config",
-      "discriminator": [149, 82, 72, 197, 253, 252, 68, 15],
+      "discriminator": [
+        149,
+        82,
+        72,
+        197,
+        253,
+        252,
+        68,
+        15
+      ],
       "accounts": [
-        { "name": "creator" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
         {
           "name": "payer",
-          "docs": ["Address paying to create the pool. Can be anyone"],
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
-        { "name": "pool_creator_authority", "signer": true, "relations": ["config"] },
-        { "name": "config", "docs": ["Which config the pool belongs to."] },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Initialize an account to store the pool state"], "writable": true },
+        {
+          "name": "pool_creator_authority",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "token_a_mint", "docs": ["Token a mint"] },
-        { "name": "token_b_mint", "docs": ["Token b mint"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token a mint"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token b mint"
+          ]
+        },
         {
           "name": "token_a_vault",
-          "docs": ["Token a vault for the pool"],
+          "docs": [
+            "Token a vault for the pool"
+          ],
           "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_a_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["Token b vault for the pool"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_b_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        { "name": "payer_token_a", "docs": ["payer token a account"], "writable": true },
-        { "name": "payer_token_b", "docs": ["creator token b account"], "writable": true },
-        { "name": "token_a_program", "docs": ["Program to create mint account and mint tokens"] },
-        { "name": "token_b_program", "docs": ["Program to create mint account and mint tokens"] },
-        {
-          "name": "token_2022_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
-          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-        },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_a_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_b_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_b_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "payer token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "creator token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_2022_program",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "InitializeCustomizablePoolParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializeCustomizablePoolParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "initialize_reward",
-      "discriminator": [95, 135, 192, 196, 242, 129, 230, 68],
+      "discriminator": [
+        95,
+        135,
+        192,
+        196,
+        242,
+        129,
+        230,
+        68
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
         {
           "name": "reward_vault",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [114, 101, 119, 97, 114, 100, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "pool" },
-              { "kind": "arg", "path": "reward_index" }
-            ]
-          }
-        },
-        { "name": "reward_mint" },
-        { "name": "signer", "signer": true },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "token_program" },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  114,
+                  101,
+                  119,
+                  97,
+                  114,
+                  100,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              },
+              {
+                "kind": "arg",
+                "path": "reward_index"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "reward_duration", "type": "u64" },
-        { "name": "funder", "type": "pubkey" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "reward_duration",
+          "type": "u64"
+        },
+        {
+          "name": "funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "lock_inner_position",
+      "discriminator": [
+        72,
+        19,
+        49,
+        204,
+        18,
+        122,
+        23,
+        90
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "VestingParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "lock_position",
-      "discriminator": [227, 62, 2, 252, 247, 10, 171, 185],
-      "accounts": [
-        { "name": "pool", "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "vesting", "writable": true, "signer": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        227,
+        62,
+        2,
+        252,
+        247,
+        10,
+        171,
+        185
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "VestingParameters" } } }]
+      "accounts": [
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "vesting",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "VestingParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "permanent_lock_position",
-      "discriminator": [165, 176, 125, 6, 231, 171, 186, 213],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        165,
+        176,
+        125,
+        6,
+        231,
+        171,
+        186,
+        213
       ],
-      "args": [{ "name": "permanent_lock_liquidity", "type": "u128" }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permanent_lock_liquidity",
+          "type": "u128"
+        }
+      ]
     },
     {
       "name": "refresh_vesting",
-      "discriminator": [9, 94, 216, 14, 116, 204, 247, 0],
+      "discriminator": [
+        9,
+        94,
+        216,
+        14,
+        116,
+        204,
+        247,
+        0
+      ],
       "accounts": [
-        { "name": "pool", "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner" }
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "owner"
+        }
       ],
       "args": []
     },
     {
       "name": "remove_all_liquidity",
-      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
+      "discriminator": [
+        10,
+        51,
+        61,
+        35,
+        112,
+        105,
+        24,
+        85
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "token_a_amount_threshold", "type": "u64" },
-        { "name": "token_b_amount_threshold", "type": "u64" }
+        {
+          "name": "token_a_amount_threshold",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount_threshold",
+          "type": "u64"
+        }
       ]
     },
     {
       "name": "remove_liquidity",
-      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
+      "discriminator": [
+        80,
+        85,
+        209,
+        72,
+        24,
+        206,
+        177,
+        108
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "RemoveLiquidityParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RemoveLiquidityParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "set_pool_status",
-      "discriminator": [112, 87, 135, 223, 83, 204, 132, 53],
-      "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        112,
+        87,
+        135,
+        223,
+        83,
+        204,
+        132,
+        53
       ],
-      "args": [{ "name": "status", "type": "u8" }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
     },
     {
       "name": "split_position",
-      "discriminator": [172, 241, 221, 138, 161, 29, 253, 42],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["first_position", "second_position"] },
-        { "name": "first_position", "docs": ["The first position"], "writable": true },
-        { "name": "first_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "second_position", "docs": ["The second position"], "writable": true },
-        { "name": "second_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "first_owner", "docs": ["Owner of first position"], "signer": true },
-        { "name": "second_owner", "docs": ["Owner of second position"], "signer": true },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        172,
+        241,
+        221,
+        138,
+        161,
+        29,
+        253,
+        42
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "SplitPositionParameters" } } }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "first_position",
+            "second_position"
+          ]
+        },
+        {
+          "name": "first_position",
+          "docs": [
+            "The first position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "first_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "second_position",
+          "docs": [
+            "The second position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "second_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "first_owner",
+          "docs": [
+            "Owner of first position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "second_owner",
+          "docs": [
+            "Owner of second position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SplitPositionParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "split_position2",
-      "discriminator": [221, 147, 228, 207, 140, 212, 17, 119],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["first_position", "second_position"] },
-        { "name": "first_position", "docs": ["The first position"], "writable": true },
-        { "name": "first_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "second_position", "docs": ["The second position"], "writable": true },
-        { "name": "second_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "first_owner", "docs": ["Owner of first position"], "signer": true },
-        { "name": "second_owner", "docs": ["Owner of second position"], "signer": true },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        221,
+        147,
+        228,
+        207,
+        140,
+        212,
+        17,
+        119
       ],
-      "args": [{ "name": "numerator", "type": "u32" }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "first_position",
+            "second_position"
+          ]
+        },
+        {
+          "name": "first_position",
+          "docs": [
+            "The first position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "first_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "second_position",
+          "docs": [
+            "The second position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "second_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "first_owner",
+          "docs": [
+            "Owner of first position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "second_owner",
+          "docs": [
+            "Owner of second position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "numerator",
+          "type": "u32"
+        }
+      ]
     },
     {
       "name": "swap",
-      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Pool account"], "writable": true },
-        { "name": "input_token_account", "docs": ["The user token account for input token"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
         {
           "name": "output_token_account",
-          "docs": ["The user token account for output token"],
+          "docs": [
+            "The user token account for output token"
+          ],
           "writable": true
         },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"] },
-        { "name": "payer", "docs": ["The user performing the swap"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
         {
           "name": "referral_token_account",
-          "docs": ["referral token account"],
+          "docs": [
+            "referral token account"
+          ],
           "writable": true,
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
-        { "name": "program" }
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "_params", "type": { "defined": { "name": "SwapParameters" } } }]
+      "args": [
+        {
+          "name": "_params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "swap2",
-      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
+      "discriminator": [
+        65,
+        75,
+        63,
+        76,
+        235,
+        91,
+        91,
+        136
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Pool account"], "writable": true },
-        { "name": "input_token_account", "docs": ["The user token account for input token"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
         {
           "name": "output_token_account",
-          "docs": ["The user token account for output token"],
+          "docs": [
+            "The user token account for output token"
+          ],
           "writable": true
         },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"] },
-        { "name": "payer", "docs": ["The user performing the swap"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
         {
           "name": "referral_token_account",
-          "docs": ["referral token account"],
+          "docs": [
+            "referral token account"
+          ],
           "writable": true,
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
-        { "name": "program" }
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "_params", "type": { "defined": { "name": "SwapParameters2" } } }]
+      "args": [
+        {
+          "name": "_params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_delegate_permission",
+      "discriminator": [
+        175,
+        165,
+        56,
+        64,
+        0,
+        251,
+        89,
+        47
+      ],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u32"
+        }
+      ]
     },
     {
       "name": "update_pool_fees",
-      "discriminator": [118, 217, 203, 179, 60, 8, 70, 89],
-      "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        118,
+        217,
+        203,
+        179,
+        60,
+        8,
+        70,
+        89
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "UpdatePoolFeesParameters" } } }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "UpdatePoolFeesParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "update_reward_duration",
-      "discriminator": [138, 174, 196, 169, 213, 235, 254, 107],
+      "discriminator": [
+        138,
+        174,
+        196,
+        169,
+        213,
+        235,
+        254,
+        107
+      ],
       "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "signer", "signer": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "new_duration", "type": "u64" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "new_duration",
+          "type": "u64"
+        }
       ]
     },
     {
       "name": "update_reward_funder",
-      "discriminator": [211, 28, 48, 32, 215, 160, 35, 23],
+      "discriminator": [
+        211,
+        28,
+        48,
+        32,
+        215,
+        160,
+        35,
+        23
+      ],
       "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "signer", "signer": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "new_funder", "type": "pubkey" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "new_funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_dead_liquidity_reward",
+      "discriminator": [
+        121,
+        99,
+        224,
+        91,
+        178,
+        14,
+        22,
+        132
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        }
       ]
     },
     {
       "name": "withdraw_ineligible_reward",
-      "discriminator": [148, 206, 42, 195, 247, 49, 103, 8],
-      "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
-        { "name": "reward_vault", "writable": true },
-        { "name": "reward_mint" },
-        { "name": "funder_token_account", "writable": true },
-        { "name": "funder", "signer": true },
-        { "name": "token_program" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        148,
+        206,
+        42,
+        195,
+        247,
+        49,
+        103,
+        8
       ],
-      "args": [{ "name": "reward_index", "type": "u8" }]
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "discriminator": [
+        213,
+        155,
+        187,
+        34,
+        56,
+        182,
+        91,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_vault",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "zap claim fee operator"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ]
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
     }
   ],
   "accounts": [
-    { "name": "Config", "discriminator": [155, 12, 170, 224, 30, 250, 204, 130] },
-    { "name": "Operator", "discriminator": [219, 31, 188, 145, 69, 139, 204, 117] },
-    { "name": "PodAlignedFeeMarketCapScheduler", "discriminator": [251, 130, 208, 253, 245, 27, 145, 203] },
-    { "name": "PodAlignedFeeRateLimiter", "discriminator": [160, 219, 8, 251, 179, 7, 16, 117] },
-    { "name": "PodAlignedFeeTimeScheduler", "discriminator": [239, 132, 138, 213, 67, 154, 130, 70] },
-    { "name": "Pool", "discriminator": [241, 154, 109, 4, 17, 177, 109, 188] },
-    { "name": "Position", "discriminator": [170, 188, 143, 228, 122, 64, 247, 208] },
-    { "name": "TokenBadge", "discriminator": [116, 219, 204, 229, 249, 116, 255, 150] },
-    { "name": "Vesting", "discriminator": [100, 149, 66, 138, 95, 200, 128, 241] }
+    {
+      "name": "Config",
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [
+        219,
+        31,
+        188,
+        145,
+        69,
+        139,
+        204,
+        117
+      ]
+    },
+    {
+      "name": "PodAlignedFeeMarketCapScheduler",
+      "discriminator": [
+        251,
+        130,
+        208,
+        253,
+        245,
+        27,
+        145,
+        203
+      ]
+    },
+    {
+      "name": "PodAlignedFeeRateLimiter",
+      "discriminator": [
+        160,
+        219,
+        8,
+        251,
+        179,
+        7,
+        16,
+        117
+      ]
+    },
+    {
+      "name": "PodAlignedFeeTimeScheduler",
+      "discriminator": [
+        239,
+        132,
+        138,
+        213,
+        67,
+        154,
+        130,
+        70
+      ]
+    },
+    {
+      "name": "Pool",
+      "discriminator": [
+        241,
+        154,
+        109,
+        4,
+        17,
+        177,
+        109,
+        188
+      ]
+    },
+    {
+      "name": "Position",
+      "discriminator": [
+        170,
+        188,
+        143,
+        228,
+        122,
+        64,
+        247,
+        208
+      ]
+    },
+    {
+      "name": "TokenBadge",
+      "discriminator": [
+        116,
+        219,
+        204,
+        229,
+        249,
+        116,
+        255,
+        150
+      ]
+    },
+    {
+      "name": "Vesting",
+      "discriminator": [
+        100,
+        149,
+        66,
+        138,
+        95,
+        200,
+        128,
+        241
+      ]
+    }
   ],
   "events": [
-    { "name": "EvtClaimPartnerFee", "discriminator": [118, 99, 77, 10, 226, 1, 1, 87] },
-    { "name": "EvtClaimPositionFee", "discriminator": [198, 182, 183, 52, 97, 12, 49, 56] },
-    { "name": "EvtClaimProtocolFee", "discriminator": [186, 244, 75, 251, 188, 13, 25, 33] },
-    { "name": "EvtClaimReward", "discriminator": [218, 86, 147, 200, 235, 188, 215, 231] },
-    { "name": "EvtCloseConfig", "discriminator": [36, 30, 239, 45, 58, 132, 14, 5] },
-    { "name": "EvtClosePosition", "discriminator": [20, 145, 144, 68, 143, 142, 214, 178] },
-    { "name": "EvtCreateConfig", "discriminator": [131, 207, 180, 174, 180, 73, 165, 54] },
-    { "name": "EvtCreateDynamicConfig", "discriminator": [231, 197, 13, 164, 248, 213, 133, 152] },
-    { "name": "EvtCreatePosition", "discriminator": [156, 15, 119, 198, 29, 181, 221, 55] },
-    { "name": "EvtCreateTokenBadge", "discriminator": [141, 120, 134, 116, 34, 28, 114, 160] },
-    { "name": "EvtFundReward", "discriminator": [104, 233, 237, 122, 199, 191, 121, 85] },
-    { "name": "EvtInitializePool", "discriminator": [228, 50, 246, 85, 203, 66, 134, 37] },
-    { "name": "EvtInitializeReward", "discriminator": [129, 91, 188, 3, 246, 52, 185, 249] },
-    { "name": "EvtLiquidityChange", "discriminator": [197, 171, 78, 127, 224, 211, 87, 13] },
-    { "name": "EvtLockPosition", "discriminator": [168, 63, 108, 83, 219, 82, 2, 200] },
-    { "name": "EvtPermanentLockPosition", "discriminator": [145, 143, 162, 218, 218, 80, 67, 11] },
-    { "name": "EvtSetPoolStatus", "discriminator": [100, 213, 74, 3, 95, 91, 228, 146] },
-    { "name": "EvtSplitPosition2", "discriminator": [165, 32, 203, 174, 72, 100, 233, 103] },
-    { "name": "EvtSwap2", "discriminator": [189, 66, 51, 168, 38, 80, 117, 153] },
-    { "name": "EvtUpdatePoolFees", "discriminator": [76, 165, 246, 102, 102, 217, 156, 44] },
-    { "name": "EvtUpdateRewardDuration", "discriminator": [149, 135, 65, 231, 129, 153, 65, 57] },
-    { "name": "EvtUpdateRewardFunder", "discriminator": [76, 154, 208, 13, 40, 115, 246, 146] },
-    { "name": "EvtWithdrawIneligibleReward", "discriminator": [248, 215, 184, 78, 31, 180, 179, 168] }
+    {
+      "name": "EvtClaimPositionFee",
+      "discriminator": [
+        198,
+        182,
+        183,
+        52,
+        97,
+        12,
+        49,
+        56
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "discriminator": [
+        186,
+        244,
+        75,
+        251,
+        188,
+        13,
+        25,
+        33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
+      ]
+    },
+    {
+      "name": "EvtClaimReward",
+      "discriminator": [
+        218,
+        86,
+        147,
+        200,
+        235,
+        188,
+        215,
+        231
+      ]
+    },
+    {
+      "name": "EvtCloseConfig",
+      "discriminator": [
+        36,
+        30,
+        239,
+        45,
+        58,
+        132,
+        14,
+        5
+      ]
+    },
+    {
+      "name": "EvtClosePosition",
+      "discriminator": [
+        20,
+        145,
+        144,
+        68,
+        143,
+        142,
+        214,
+        178
+      ]
+    },
+    {
+      "name": "EvtCreateConfig",
+      "discriminator": [
+        131,
+        207,
+        180,
+        174,
+        180,
+        73,
+        165,
+        54
+      ]
+    },
+    {
+      "name": "EvtCreateDynamicConfig",
+      "discriminator": [
+        231,
+        197,
+        13,
+        164,
+        248,
+        213,
+        133,
+        152
+      ]
+    },
+    {
+      "name": "EvtCreatePosition",
+      "discriminator": [
+        156,
+        15,
+        119,
+        198,
+        29,
+        181,
+        221,
+        55
+      ]
+    },
+    {
+      "name": "EvtCreateTokenBadge",
+      "discriminator": [
+        141,
+        120,
+        134,
+        116,
+        34,
+        28,
+        114,
+        160
+      ]
+    },
+    {
+      "name": "EvtFundReward",
+      "discriminator": [
+        104,
+        233,
+        237,
+        122,
+        199,
+        191,
+        121,
+        85
+      ]
+    },
+    {
+      "name": "EvtInitializePool",
+      "discriminator": [
+        228,
+        50,
+        246,
+        85,
+        203,
+        66,
+        134,
+        37
+      ]
+    },
+    {
+      "name": "EvtInitializeReward",
+      "discriminator": [
+        129,
+        91,
+        188,
+        3,
+        246,
+        52,
+        185,
+        249
+      ]
+    },
+    {
+      "name": "EvtLiquidityChange",
+      "discriminator": [
+        197,
+        171,
+        78,
+        127,
+        224,
+        211,
+        87,
+        13
+      ]
+    },
+    {
+      "name": "EvtLockPosition",
+      "discriminator": [
+        168,
+        63,
+        108,
+        83,
+        219,
+        82,
+        2,
+        200
+      ]
+    },
+    {
+      "name": "EvtPermanentLockPosition",
+      "discriminator": [
+        145,
+        143,
+        162,
+        218,
+        218,
+        80,
+        67,
+        11
+      ]
+    },
+    {
+      "name": "EvtSetPoolStatus",
+      "discriminator": [
+        100,
+        213,
+        74,
+        3,
+        95,
+        91,
+        228,
+        146
+      ]
+    },
+    {
+      "name": "EvtSplitPosition2",
+      "discriminator": [
+        165,
+        32,
+        203,
+        174,
+        72,
+        100,
+        233,
+        103
+      ]
+    },
+    {
+      "name": "EvtSplitPosition3",
+      "discriminator": [
+        232,
+        117,
+        190,
+        218,
+        85,
+        162,
+        207,
+        78
+      ]
+    },
+    {
+      "name": "EvtSwap2",
+      "discriminator": [
+        189,
+        66,
+        51,
+        168,
+        38,
+        80,
+        117,
+        153
+      ]
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "discriminator": [
+        66,
+        188,
+        75,
+        151,
+        150,
+        232,
+        87,
+        93
+      ]
+    },
+    {
+      "name": "EvtUpdatePoolFees",
+      "discriminator": [
+        76,
+        165,
+        246,
+        102,
+        102,
+        217,
+        156,
+        44
+      ]
+    },
+    {
+      "name": "EvtUpdateRewardDuration",
+      "discriminator": [
+        149,
+        135,
+        65,
+        231,
+        129,
+        153,
+        65,
+        57
+      ]
+    },
+    {
+      "name": "EvtUpdateRewardFunder",
+      "discriminator": [
+        76,
+        154,
+        208,
+        13,
+        40,
+        115,
+        246,
+        146
+      ]
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "discriminator": [
+        228,
+        66,
+        150,
+        195,
+        42,
+        62,
+        163,
+        13
+      ]
+    },
+    {
+      "name": "EvtWithdrawIneligibleReward",
+      "discriminator": [
+        248,
+        215,
+        184,
+        78,
+        31,
+        180,
+        179,
+        168
+      ]
+    }
   ],
   "errors": [
-    { "code": 6000, "name": "MathOverflow", "msg": "Math operation overflow" },
-    { "code": 6001, "name": "InvalidFee", "msg": "Invalid fee setup" },
-    { "code": 6002, "name": "ExceededSlippage", "msg": "Exceeded slippage tolerance" },
-    { "code": 6003, "name": "PoolDisabled", "msg": "Pool disabled" },
-    { "code": 6004, "name": "ExceedMaxFeeBps", "msg": "Exceeded max fee bps" },
-    { "code": 6005, "name": "InvalidAdmin", "msg": "Invalid admin" },
-    { "code": 6006, "name": "AmountIsZero", "msg": "Amount is zero" },
-    { "code": 6007, "name": "TypeCastFailed", "msg": "Type cast error" },
-    { "code": 6008, "name": "UnableToModifyActivationPoint", "msg": "Unable to modify activation point" },
-    { "code": 6009, "name": "InvalidAuthorityToCreateThePool", "msg": "Invalid authority to create the pool" },
-    { "code": 6010, "name": "InvalidActivationType", "msg": "Invalid activation type" },
-    { "code": 6011, "name": "InvalidActivationPoint", "msg": "Invalid activation point" },
-    { "code": 6012, "name": "InvalidQuoteMint", "msg": "Quote token must be SOL,USDC" },
-    { "code": 6013, "name": "InvalidFeeCurve", "msg": "Invalid fee curve" },
-    { "code": 6014, "name": "InvalidPriceRange", "msg": "Invalid Price Range" },
-    { "code": 6015, "name": "PriceRangeViolation", "msg": "Trade is over price range" },
-    { "code": 6016, "name": "InvalidParameters", "msg": "Invalid parameters" },
-    { "code": 6017, "name": "InvalidCollectFeeMode", "msg": "Invalid collect fee mode" },
-    { "code": 6018, "name": "InvalidInput", "msg": "Invalid input" },
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "ExceededSlippage",
+      "msg": "Exceeded slippage tolerance"
+    },
+    {
+      "code": 6003,
+      "name": "PoolDisabled",
+      "msg": "Pool disabled"
+    },
+    {
+      "code": 6004,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
+    },
+    {
+      "code": 6006,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6007,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6008,
+      "name": "UnableToModifyActivationPoint",
+      "msg": "Unable to modify activation point"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidAuthorityToCreateThePool",
+      "msg": "Invalid authority to create the pool"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidActivationPoint",
+      "msg": "Invalid activation point"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidQuoteMint",
+      "msg": "Quote token must be SOL,USDC"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidFeeCurve",
+      "msg": "Invalid fee curve"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidPriceRange",
+      "msg": "Invalid Price Range"
+    },
+    {
+      "code": 6015,
+      "name": "PriceRangeViolation",
+      "msg": "Trade is over price range"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidParameters",
+      "msg": "Invalid parameters"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidInput",
+      "msg": "Invalid input"
+    },
     {
       "code": 6019,
       "name": "CannotCreateTokenBadgeOnSupportedMint",
       "msg": "Cannot create token badge on supported mint"
     },
-    { "code": 6020, "name": "InvalidTokenBadge", "msg": "Invalid token badge" },
-    { "code": 6021, "name": "InvalidMinimumLiquidity", "msg": "Invalid minimum liquidity" },
-    { "code": 6022, "name": "InvalidVestingInfo", "msg": "Invalid vesting information" },
-    { "code": 6023, "name": "InsufficientLiquidity", "msg": "Insufficient liquidity" },
-    { "code": 6024, "name": "InvalidVestingAccount", "msg": "Invalid vesting account" },
-    { "code": 6025, "name": "InvalidPoolStatus", "msg": "Invalid pool status" },
-    { "code": 6026, "name": "UnsupportNativeMintToken2022", "msg": "Unsupported native mint token2022" },
-    { "code": 6027, "name": "InvalidRewardIndex", "msg": "Invalid reward index" },
-    { "code": 6028, "name": "InvalidRewardDuration", "msg": "Invalid reward duration" },
-    { "code": 6029, "name": "RewardInitialized", "msg": "Reward already initialized" },
-    { "code": 6030, "name": "RewardUninitialized", "msg": "Reward not initialized" },
-    { "code": 6031, "name": "InvalidRewardVault", "msg": "Invalid reward vault" },
-    { "code": 6032, "name": "MustWithdrawnIneligibleReward", "msg": "Must withdraw ineligible reward" },
-    { "code": 6033, "name": "IdenticalRewardDuration", "msg": "Reward duration is the same" },
-    { "code": 6034, "name": "RewardCampaignInProgress", "msg": "Reward campaign in progress" },
-    { "code": 6035, "name": "IdenticalFunder", "msg": "Identical funder" },
-    { "code": 6036, "name": "InvalidFunder", "msg": "Invalid funder" },
-    { "code": 6037, "name": "RewardNotEnded", "msg": "Reward not ended" },
-    { "code": 6038, "name": "FeeInverseIsIncorrect", "msg": "Fee inverse is incorrect" },
-    { "code": 6039, "name": "PositionIsNotEmpty", "msg": "Position is not empty" },
-    { "code": 6040, "name": "InvalidPoolCreatorAuthority", "msg": "Invalid pool creator authority" },
-    { "code": 6041, "name": "InvalidConfigType", "msg": "Invalid config type" },
-    { "code": 6042, "name": "InvalidPoolCreator", "msg": "Invalid pool creator" },
+    {
+      "code": 6020,
+      "name": "InvalidTokenBadge",
+      "msg": "Invalid token badge"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidMinimumLiquidity",
+      "msg": "Invalid minimum liquidity"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidVestingInfo",
+      "msg": "Invalid vesting information"
+    },
+    {
+      "code": 6023,
+      "name": "InsufficientLiquidity",
+      "msg": "Insufficient liquidity"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidVestingAccount",
+      "msg": "Invalid vesting account"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidPoolStatus",
+      "msg": "Invalid pool status"
+    },
+    {
+      "code": 6026,
+      "name": "UnsupportNativeMintToken2022",
+      "msg": "Unsupported native mint token2022"
+    },
+    {
+      "code": 6027,
+      "name": "InvalidRewardIndex",
+      "msg": "Invalid reward index"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidRewardDuration",
+      "msg": "Invalid reward duration"
+    },
+    {
+      "code": 6029,
+      "name": "RewardInitialized",
+      "msg": "Reward already initialized"
+    },
+    {
+      "code": 6030,
+      "name": "RewardUninitialized",
+      "msg": "Reward not initialized"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidRewardVault",
+      "msg": "Invalid reward vault"
+    },
+    {
+      "code": 6032,
+      "name": "MustWithdrawnIneligibleReward",
+      "msg": "Must withdraw ineligible reward"
+    },
+    {
+      "code": 6033,
+      "name": "IdenticalRewardDuration",
+      "msg": "Reward duration is the same"
+    },
+    {
+      "code": 6034,
+      "name": "RewardCampaignInProgress",
+      "msg": "Reward campaign in progress"
+    },
+    {
+      "code": 6035,
+      "name": "IdenticalFunder",
+      "msg": "Identical funder"
+    },
+    {
+      "code": 6036,
+      "name": "InvalidFunder",
+      "msg": "Invalid funder"
+    },
+    {
+      "code": 6037,
+      "name": "RewardNotEnded",
+      "msg": "Reward not ended"
+    },
+    {
+      "code": 6038,
+      "name": "FeeInverseIsIncorrect",
+      "msg": "Fee inverse is incorrect"
+    },
+    {
+      "code": 6039,
+      "name": "PositionIsNotEmpty",
+      "msg": "Position is not empty"
+    },
+    {
+      "code": 6040,
+      "name": "InvalidPoolCreatorAuthority",
+      "msg": "Invalid pool creator authority"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidConfigType",
+      "msg": "Invalid config type"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidPoolCreator",
+      "msg": "Invalid pool creator"
+    },
     {
       "code": 6043,
       "name": "RewardVaultFrozenSkipRequired",
       "msg": "Reward vault is frozen, must skip reward to proceed"
     },
-    { "code": 6044, "name": "InvalidSplitPositionParameters", "msg": "Invalid parameters for split position" },
+    {
+      "code": 6044,
+      "name": "InvalidSplitPositionParameters",
+      "msg": "Invalid parameters for split position"
+    },
     {
       "code": 6045,
       "name": "UnsupportPositionHasVestingLock",
       "msg": "Unsupported split position has vesting lock"
     },
-    { "code": 6046, "name": "SamePosition", "msg": "Same position" },
-    { "code": 6047, "name": "InvalidBaseFeeMode", "msg": "Invalid base fee mode" },
-    { "code": 6048, "name": "InvalidFeeRateLimiter", "msg": "Invalid fee rate limiter" },
+    {
+      "code": 6046,
+      "name": "SamePosition",
+      "msg": "Same position"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidBaseFeeMode",
+      "msg": "Invalid base fee mode"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidFeeRateLimiter",
+      "msg": "Invalid fee rate limiter"
+    },
     {
       "code": 6049,
       "name": "FailToValidateSingleSwapInstruction",
       "msg": "Fail to validate single swap instruction in rate limiter"
     },
-    { "code": 6050, "name": "InvalidFeeTimeScheduler", "msg": "Invalid fee scheduler" },
-    { "code": 6051, "name": "UndeterminedError", "msg": "Undetermined error" },
-    { "code": 6052, "name": "InvalidPoolVersion", "msg": "Invalid pool version" },
-    { "code": 6053, "name": "InvalidAuthority", "msg": "Invalid authority to do that action" },
-    { "code": 6054, "name": "InvalidPermission", "msg": "Invalid permission" },
-    { "code": 6055, "name": "InvalidFeeMarketCapScheduler", "msg": "Invalid fee market cap scheduler" },
-    { "code": 6056, "name": "CannotUpdateBaseFee", "msg": "Cannot update base fee" },
-    { "code": 6057, "name": "InvalidDynamicFeeParameters", "msg": "Invalid dynamic fee parameters" },
-    { "code": 6058, "name": "InvalidUpdatePoolFeesParameters", "msg": "Invalid update pool fees parameters" },
-    { "code": 6059, "name": "MissingOperatorAccount", "msg": "Missing operator account" }
+    {
+      "code": 6050,
+      "name": "InvalidFeeTimeScheduler",
+      "msg": "Invalid fee scheduler"
+    },
+    {
+      "code": 6051,
+      "name": "UndeterminedError",
+      "msg": "Undetermined error"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidPoolVersion",
+      "msg": "Invalid pool version"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority to do that action"
+    },
+    {
+      "code": 6054,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidFeeMarketCapScheduler",
+      "msg": "Invalid fee market cap scheduler"
+    },
+    {
+      "code": 6056,
+      "name": "CannotUpdateBaseFee",
+      "msg": "Cannot update base fee"
+    },
+    {
+      "code": 6057,
+      "name": "InvalidDynamicFeeParameters",
+      "msg": "Invalid dynamic fee parameters"
+    },
+    {
+      "code": 6058,
+      "name": "InvalidUpdatePoolFeesParameters",
+      "msg": "Invalid update pool fees parameters"
+    },
+    {
+      "code": 6059,
+      "name": "MissingOperatorAccount",
+      "msg": "Missing operator account"
+    },
+    {
+      "code": 6060,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6062,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6063,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6064,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6065,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6066,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingFeeBps",
+      "msg": "Invalid compounding fee bps"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "TransferFeeExcludedAmountIsZero",
+      "msg": "Transfer fee excluded amount is zero"
+    },
+    {
+      "code": 6070,
+      "name": "DelegatedAmountNonZero",
+      "msg": "Delegated amount is not zero"
+    }
   ],
   "types": [
     {
@@ -1515,31 +4162,89 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity_delta", "docs": ["delta liquidity"], "type": "u128" },
-          { "name": "token_a_amount_threshold", "docs": ["maximum token a amount"], "type": "u64" },
-          { "name": "token_b_amount_threshold", "docs": ["maximum token b amount"], "type": "u64" }
+          {
+            "name": "liquidity_delta",
+            "docs": [
+              "delta liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "token_a_amount_threshold",
+            "docs": [
+              "maximum token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount_threshold",
+            "docs": [
+              "maximum token b amount"
+            ],
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "BaseFeeInfo",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
-      "type": { "kind": "struct", "fields": [{ "name": "data", "type": { "array": ["u8", 32] } }] }
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
     },
     {
       "name": "BaseFeeParameters",
-      "type": { "kind": "struct", "fields": [{ "name": "data", "type": { "array": ["u8", 30] } }] }
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "array": [
+                "u8",
+                27
+              ]
+            }
+          }
+        ]
+      }
     },
     {
       "name": "BaseFeeStruct",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "base_fee_info", "type": { "defined": { "name": "BaseFeeInfo" } } },
-          { "name": "padding_1", "type": "u64" }
+          {
+            "name": "base_fee_info",
+            "type": {
+              "defined": {
+                "name": "BaseFeeInfo"
+              }
+            }
+          },
+          {
+            "name": "padding_1",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1548,13 +4253,30 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "sqrt_price_step_bps", "type": "u32" },
-          { "name": "scheduler_expiration_duration", "type": "u32" },
-          { "name": "reduction_factor", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 3] } }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u32"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1576,13 +4298,30 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "fee_increment_bps", "type": "u16" },
-          { "name": "max_limiter_duration", "type": "u32" },
-          { "name": "max_fee_bps", "type": "u32" },
-          { "name": "reference_amount", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 3] } }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "fee_increment_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_limiter_duration",
+            "type": "u32"
+          },
+          {
+            "name": "max_fee_bps",
+            "type": "u32"
+          },
+          {
+            "name": "reference_amount",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1591,23 +4330,45 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "reduction_factor", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 3] } }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
     {
       "name": "Config",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "vault_config_key", "docs": ["Vault config key"], "type": "pubkey" },
+          {
+            "name": "vault_config_key",
+            "docs": [
+              "Vault config key"
+            ],
+            "type": "pubkey"
+          },
           {
             "name": "pool_creator_authority",
             "docs": [
@@ -1615,18 +4376,83 @@
             ],
             "type": "pubkey"
           },
-          { "name": "pool_fees", "docs": ["Pool fee"], "type": { "defined": { "name": "PoolFeesConfig" } } },
-          { "name": "activation_type", "docs": ["Activation type"], "type": "u8" },
-          { "name": "collect_fee_mode", "docs": ["Collect fee mode"], "type": "u8" },
-          { "name": "config_type", "docs": ["Config type mode, 0 for static, 1 for dynamic"], "type": "u8" },
-          { "name": "_padding_0", "docs": ["padding 0"], "type": { "array": ["u8", 5] } },
-          { "name": "index", "docs": ["config index"], "type": "u64" },
-          { "name": "sqrt_min_price", "docs": ["sqrt min price"], "type": "u128" },
-          { "name": "sqrt_max_price", "docs": ["sqrt max price"], "type": "u128" },
+          {
+            "name": "pool_fees",
+            "docs": [
+              "Pool fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeesConfig"
+              }
+            }
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "Collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "config_type",
+            "docs": [
+              "Config type mode, 0 for static, 1 for dynamic"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "padding 0"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "index",
+            "docs": [
+              "config index"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_min_price",
+            "docs": [
+              "sqrt min price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "docs": [
+              "sqrt max price"
+            ],
+            "type": "u128"
+          },
           {
             "name": "_padding_1",
-            "docs": ["Fee curve point", "Padding for further use"],
-            "type": { "array": ["u64", 10] }
+            "docs": [
+              "Fee curve point",
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
           }
         ]
       }
@@ -1638,40 +4464,102 @@
         "fields": [
           {
             "name": "borsh_fee_time_scheduler_params",
-            "type": { "defined": { "name": "BorshFeeTimeScheduler" } }
+            "type": {
+              "defined": {
+                "name": "BorshFeeTimeScheduler"
+              }
+            }
           },
           {
             "name": "borsh_fee_rate_limiter_params",
-            "type": { "defined": { "name": "BorshFeeRateLimiter" } }
+            "type": {
+              "defined": {
+                "name": "BorshFeeRateLimiter"
+              }
+            }
           },
           {
             "name": "borsh_fee_market_cap_scheduler_params",
-            "type": { "defined": { "name": "BorshFeeMarketCapScheduler" } }
+            "type": {
+              "defined": {
+                "name": "BorshFeeMarketCapScheduler"
+              }
+            }
           }
         ]
       }
     },
     {
       "name": "DynamicConfigParameters",
-      "type": { "kind": "struct", "fields": [{ "name": "pool_creator_authority", "type": "pubkey" }] }
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
     },
     {
       "name": "DynamicFeeConfig",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "initialized", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 7] } },
-          { "name": "max_volatility_accumulator", "type": "u32" },
-          { "name": "variable_fee_control", "type": "u32" },
-          { "name": "bin_step", "type": "u16" },
-          { "name": "filter_period", "type": "u16" },
-          { "name": "decay_period", "type": "u16" },
-          { "name": "reduction_factor", "type": "u16" },
-          { "name": "padding_1", "type": { "array": ["u8", 8] } },
-          { "name": "bin_step_u128", "type": "u128" }
+          {
+            "name": "initialized",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "padding_1",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1680,47 +4568,103 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "bin_step", "type": "u16" },
-          { "name": "bin_step_u128", "type": "u128" },
-          { "name": "filter_period", "type": "u16" },
-          { "name": "decay_period", "type": "u16" },
-          { "name": "reduction_factor", "type": "u16" },
-          { "name": "max_volatility_accumulator", "type": "u32" },
-          { "name": "variable_fee_control", "type": "u32" }
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          }
         ]
       }
     },
     {
       "name": "DynamicFeeStruct",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "initialized", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 7] } },
-          { "name": "max_volatility_accumulator", "type": "u32" },
-          { "name": "variable_fee_control", "type": "u32" },
-          { "name": "bin_step", "type": "u16" },
-          { "name": "filter_period", "type": "u16" },
-          { "name": "decay_period", "type": "u16" },
-          { "name": "reduction_factor", "type": "u16" },
-          { "name": "last_update_timestamp", "type": "u64" },
-          { "name": "bin_step_u128", "type": "u128" },
-          { "name": "sqrt_price_reference", "type": "u128" },
-          { "name": "volatility_accumulator", "type": "u128" },
-          { "name": "volatility_reference", "type": "u128" }
-        ]
-      }
-    },
-    {
-      "name": "EvtClaimPartnerFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" }
+          {
+            "name": "initialized",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "last_update_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price_reference",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_accumulator",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_reference",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1729,11 +4673,26 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "fee_a_claimed", "type": "u64" },
-          { "name": "fee_b_claimed", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_a_claimed",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b_claimed",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1742,9 +4701,42 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1753,23 +4745,55 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "mint_reward", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "total_reward", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_reward",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "EvtCloseConfig",
-      "docs": ["Close config"],
+      "docs": [
+        "Close config"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "config", "docs": ["Config pubkey"], "type": "pubkey" },
-          { "name": "admin", "docs": ["admin pk"], "type": "pubkey" }
+          {
+            "name": "config",
+            "docs": [
+              "Config pubkey"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "admin",
+            "docs": [
+              "admin pk"
+            ],
+            "type": "pubkey"
+          }
         ]
       }
     },
@@ -1778,40 +4802,96 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "position_nft_mint", "type": "pubkey" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "position_nft_mint",
+            "type": "pubkey"
+          }
         ]
       }
     },
     {
       "name": "EvtCreateConfig",
-      "docs": ["Create static config"],
+      "docs": [
+        "Create static config"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool_fees", "type": { "defined": { "name": "PoolFeeParameters" } } },
-          { "name": "vault_config_key", "type": "pubkey" },
-          { "name": "pool_creator_authority", "type": "pubkey" },
-          { "name": "activation_type", "type": "u8" },
-          { "name": "sqrt_min_price", "type": "u128" },
-          { "name": "sqrt_max_price", "type": "u128" },
-          { "name": "collect_fee_mode", "type": "u8" },
-          { "name": "index", "type": "u64" },
-          { "name": "config", "type": "pubkey" }
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "sqrt_min_price",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "type": "u128"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
         ]
       }
     },
     {
       "name": "EvtCreateDynamicConfig",
-      "docs": ["Create dynamic config"],
+      "docs": [
+        "Create dynamic config"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "config", "type": "pubkey" },
-          { "name": "pool_creator_authority", "type": "pubkey" },
-          { "name": "index", "type": "u64" }
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1820,32 +4900,81 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "position_nft_mint", "type": "pubkey" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "position_nft_mint",
+            "type": "pubkey"
+          }
         ]
       }
     },
     {
       "name": "EvtCreateTokenBadge",
-      "docs": ["Create token badge"],
-      "type": { "kind": "struct", "fields": [{ "name": "token_mint", "type": "pubkey" }] }
+      "docs": [
+        "Create token badge"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          }
+        ]
+      }
     },
     {
       "name": "EvtFundReward",
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "funder", "type": "pubkey" },
-          { "name": "mint_reward", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "amount", "type": "u64" },
-          { "name": "transfer_fee_excluded_amount_in", "type": "u64" },
-          { "name": "reward_duration_end", "type": "u64" },
-          { "name": "pre_reward_rate", "type": "u128" },
-          { "name": "post_reward_rate", "type": "u128" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_reward",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_excluded_amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration_end",
+            "type": "u64"
+          },
+          {
+            "name": "pre_reward_rate",
+            "type": "u128"
+          },
+          {
+            "name": "post_reward_rate",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1854,27 +4983,94 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "token_a_mint", "type": "pubkey" },
-          { "name": "token_b_mint", "type": "pubkey" },
-          { "name": "creator", "type": "pubkey" },
-          { "name": "payer", "type": "pubkey" },
-          { "name": "alpha_vault", "type": "pubkey" },
-          { "name": "pool_fees", "type": { "defined": { "name": "PoolFeeParameters" } } },
-          { "name": "sqrt_min_price", "type": "u128" },
-          { "name": "sqrt_max_price", "type": "u128" },
-          { "name": "activation_type", "type": "u8" },
-          { "name": "collect_fee_mode", "type": "u8" },
-          { "name": "liquidity", "type": "u128" },
-          { "name": "sqrt_price", "type": "u128" },
-          { "name": "activation_point", "type": "u64" },
-          { "name": "token_a_flag", "type": "u8" },
-          { "name": "token_b_flag", "type": "u8" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" },
-          { "name": "total_amount_a", "type": "u64" },
-          { "name": "total_amount_b", "type": "u64" },
-          { "name": "pool_type", "type": "u8" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "payer",
+            "type": "pubkey"
+          },
+          {
+            "name": "alpha_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "sqrt_min_price",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "type": "u128"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_flag",
+            "type": "u8"
+          },
+          {
+            "name": "token_b_flag",
+            "type": "u8"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "total_amount_a",
+            "type": "u64"
+          },
+          {
+            "name": "total_amount_b",
+            "type": "u64"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1883,12 +5079,30 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_mint", "type": "pubkey" },
-          { "name": "funder", "type": "pubkey" },
-          { "name": "creator", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "reward_duration", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "reward_duration",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1897,19 +5111,58 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" },
-          { "name": "transfer_fee_included_token_a_amount", "type": "u64" },
-          { "name": "transfer_fee_included_token_b_amount", "type": "u64" },
-          { "name": "reserve_a_amount", "type": "u64" },
-          { "name": "reserve_b_amount", "type": "u64" },
-          { "name": "liquidity_delta", "type": "u128" },
-          { "name": "token_a_amount_threshold", "type": "u64" },
-          { "name": "token_b_amount_threshold", "type": "u64" },
-          { "name": "change_type", "type": "u8" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_included_token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_included_token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "liquidity_delta",
+            "type": "u128"
+          },
+          {
+            "name": "token_a_amount_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "change_type",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1918,15 +5171,42 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "vesting", "type": "pubkey" },
-          { "name": "cliff_point", "type": "u64" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "cliff_unlock_liquidity", "type": "u128" },
-          { "name": "liquidity_per_period", "type": "u128" },
-          { "name": "number_of_period", "type": "u16" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "vesting",
+            "type": "pubkey"
+          },
+          {
+            "name": "cliff_point",
+            "type": "u64"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          }
         ]
       }
     },
@@ -1935,10 +5215,22 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "lock_liquidity_amount", "type": "u128" },
-          { "name": "total_permanent_locked_liquidity", "type": "u128" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_liquidity_amount",
+            "type": "u128"
+          },
+          {
+            "name": "total_permanent_locked_liquidity",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1947,8 +5239,14 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "status", "type": "u8" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1957,18 +5255,125 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "first_owner", "type": "pubkey" },
-          { "name": "second_owner", "type": "pubkey" },
-          { "name": "first_position", "type": "pubkey" },
-          { "name": "second_position", "type": "pubkey" },
-          { "name": "current_sqrt_price", "type": "u128" },
-          { "name": "amount_splits", "type": { "defined": { "name": "SplitAmountInfo" } } },
-          { "name": "first_position_info", "type": { "defined": { "name": "SplitPositionInfo" } } },
-          { "name": "second_position_info", "type": { "defined": { "name": "SplitPositionInfo" } } },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "amount_splits",
+            "type": {
+              "defined": {
+                "name": "SplitAmountInfo"
+              }
+            }
+          },
+          {
+            "name": "first_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo"
+              }
+            }
+          },
+          {
+            "name": "second_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo"
+              }
+            }
+          },
           {
             "name": "split_position_parameters",
-            "type": { "defined": { "name": "SplitPositionParameters2" } }
+            "type": {
+              "defined": {
+                "name": "SplitPositionParameters2"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSplitPosition3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "amount_splits",
+            "type": {
+              "defined": {
+                "name": "SplitAmountInfo2"
+              }
+            }
+          },
+          {
+            "name": "first_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "second_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "split_position_parameters",
+            "type": {
+              "defined": {
+                "name": "SplitPositionParameters3"
+              }
+            }
           }
         ]
       }
@@ -1978,18 +5383,88 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "trade_direction", "type": "u8" },
-          { "name": "collect_fee_mode", "type": "u8" },
-          { "name": "has_referral", "type": "bool" },
-          { "name": "params", "type": { "defined": { "name": "SwapParameters2" } } },
-          { "name": "swap_result", "type": { "defined": { "name": "SwapResult2" } } },
-          { "name": "included_transfer_fee_amount_in", "type": "u64" },
-          { "name": "included_transfer_fee_amount_out", "type": "u64" },
-          { "name": "excluded_transfer_fee_amount_out", "type": "u64" },
-          { "name": "current_timestamp", "type": "u64" },
-          { "name": "reserve_a_amount", "type": "u64" },
-          { "name": "reserve_b_amount", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "included_transfer_fee_amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "included_transfer_fee_amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_transfer_fee_amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u32"
+          },
+          {
+            "name": "delegate",
+            "type": {
+              "option": "pubkey"
+            }
+          }
         ]
       }
     },
@@ -1998,9 +5473,22 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "operator", "type": "pubkey" },
-          { "name": "params", "type": { "defined": { "name": "UpdatePoolFeesParameters" } } }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "UpdatePoolFeesParameters"
+              }
+            }
+          }
         ]
       }
     },
@@ -2009,10 +5497,22 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "old_reward_duration", "type": "u64" },
-          { "name": "new_reward_duration", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "old_reward_duration",
+            "type": "u64"
+          },
+          {
+            "name": "new_reward_duration",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2021,10 +5521,42 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "old_funder", "type": "pubkey" },
-          { "name": "new_funder", "type": "pubkey" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "old_funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_funder",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2033,9 +5565,18 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_mint", "type": "pubkey" },
-          { "name": "amount", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2046,13 +5587,43 @@
         "fields": [
           {
             "name": "pool_fees",
-            "docs": ["pool fees"],
-            "type": { "defined": { "name": "PoolFeeParameters" } }
+            "docs": [
+              "pool fees"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
           },
-          { "name": "sqrt_min_price", "docs": ["sqrt min price"], "type": "u128" },
-          { "name": "sqrt_max_price", "docs": ["sqrt max price"], "type": "u128" },
-          { "name": "has_alpha_vault", "docs": ["has alpha vault"], "type": "bool" },
-          { "name": "liquidity", "docs": ["initialize liquidity"], "type": "u128" },
+          {
+            "name": "sqrt_min_price",
+            "docs": [
+              "sqrt min price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "docs": [
+              "sqrt max price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": [
+              "has alpha vault"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "initialize liquidity"
+            ],
+            "type": "u128"
+          },
           {
             "name": "sqrt_price",
             "docs": [
@@ -2060,9 +5631,29 @@
             ],
             "type": "u128"
           },
-          { "name": "activation_type", "docs": ["activation type"], "type": "u8" },
-          { "name": "collect_fee_mode", "docs": ["collect fee mode"], "type": "u8" },
-          { "name": "activation_point", "docs": ["activation point"], "type": { "option": "u64" } }
+          {
+            "name": "activation_type",
+            "docs": [
+              "activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "activation point"
+            ],
+            "type": {
+              "option": "u64"
+            }
+          }
         ]
       }
     },
@@ -2071,164 +5662,575 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity", "docs": ["initialize liquidity"], "type": "u128" },
           {
-            "name": "sqrt_price",
-            "docs": ["The init price of the pool as a sqrt(token_b/token_a) Q64.64 value"],
+            "name": "liquidity",
+            "docs": [
+              "initialize liquidity"
+            ],
             "type": "u128"
           },
-          { "name": "activation_point", "docs": ["activation point"], "type": { "option": "u64" } }
+          {
+            "name": "sqrt_price",
+            "docs": [
+              "The init price of the pool as a sqrt(token_b/token_a) Q64.64 value"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "activation point"
+            ],
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InnerVesting",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_point",
+            "type": "u64"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "total_released_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          }
         ]
       }
     },
     {
       "name": "Operator",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "whitelisted_address", "type": "pubkey" },
-          { "name": "permission", "type": "u128" },
-          { "name": "padding", "type": { "array": ["u64", 2] } }
+          {
+            "name": "whitelisted_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
         ]
       }
     },
     {
       "name": "PodAlignedFeeMarketCapScheduler",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 5] } },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "sqrt_price_step_bps", "type": "u32" },
-          { "name": "scheduler_expiration_duration", "type": "u32" },
-          { "name": "reduction_factor", "type": "u64" }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u32"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "PodAlignedFeeRateLimiter",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 5] } },
-          { "name": "fee_increment_bps", "type": "u16" },
-          { "name": "max_limiter_duration", "type": "u32" },
-          { "name": "max_fee_bps", "type": "u32" },
-          { "name": "reference_amount", "type": "u64" }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "fee_increment_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_limiter_duration",
+            "type": "u32"
+          },
+          {
+            "name": "max_fee_bps",
+            "type": "u32"
+          },
+          {
+            "name": "reference_amount",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "PodAlignedFeeTimeScheduler",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 5] } },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "reduction_factor", "type": "u64" }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "Pool",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool_fees", "docs": ["Pool fee"], "type": { "defined": { "name": "PoolFeesStruct" } } },
-          { "name": "token_a_mint", "docs": ["token a mint"], "type": "pubkey" },
-          { "name": "token_b_mint", "docs": ["token b mint"], "type": "pubkey" },
-          { "name": "token_a_vault", "docs": ["token a vault"], "type": "pubkey" },
-          { "name": "token_b_vault", "docs": ["token b vault"], "type": "pubkey" },
           {
-            "name": "whitelisted_vault",
-            "docs": ["Whitelisted vault to be able to buy pool before activation_point"],
+            "name": "pool_fees",
+            "docs": [
+              "Pool fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeesStruct"
+              }
+            }
+          },
+          {
+            "name": "token_a_mint",
+            "docs": [
+              "token a mint"
+            ],
             "type": "pubkey"
           },
-          { "name": "partner", "docs": ["partner"], "type": "pubkey" },
-          { "name": "liquidity", "docs": ["liquidity share"], "type": "u128" },
           {
-            "name": "_padding",
-            "docs": ["padding, previous reserve amount, be careful to use that field"],
+            "name": "token_b_mint",
+            "docs": [
+              "token b mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_vault",
+            "docs": [
+              "token a vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_vault",
+            "docs": [
+              "token b vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "whitelisted_vault",
+            "docs": [
+              "Whitelisted vault to be able to buy pool before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "padding, previously partner pubkey, be careful when using this field"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "liquidity share"
+            ],
             "type": "u128"
           },
-          { "name": "protocol_a_fee", "docs": ["protocol a fee"], "type": "u64" },
-          { "name": "protocol_b_fee", "docs": ["protocol b fee"], "type": "u64" },
-          { "name": "partner_a_fee", "docs": ["partner a fee"], "type": "u64" },
-          { "name": "partner_b_fee", "docs": ["partner b fee"], "type": "u64" },
-          { "name": "sqrt_min_price", "docs": ["min price"], "type": "u128" },
-          { "name": "sqrt_max_price", "docs": ["max price"], "type": "u128" },
-          { "name": "sqrt_price", "docs": ["current price"], "type": "u128" },
+          {
+            "name": "padding_1",
+            "docs": [
+              "padding, previous reserve amount, be careful to use that field"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "protocol_a_fee",
+            "docs": [
+              "protocol a fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_b_fee",
+            "docs": [
+              "protocol b fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding_2",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_min_price",
+            "docs": [
+              "min price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "docs": [
+              "max price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price",
+            "docs": [
+              "current price"
+            ],
+            "type": "u128"
+          },
           {
             "name": "activation_point",
-            "docs": ["Activation point, can be slot or timestamp"],
+            "docs": [
+              "Activation point, can be slot or timestamp"
+            ],
             "type": "u64"
           },
           {
             "name": "activation_type",
-            "docs": ["Activation type, 0 means by slot, 1 means by timestamp"],
+            "docs": [
+              "Activation type, 0 means by slot, 1 means by timestamp"
+            ],
             "type": "u8"
           },
-          { "name": "pool_status", "docs": ["pool status, 0: enable, 1 disable"], "type": "u8" },
-          { "name": "token_a_flag", "docs": ["token a flag"], "type": "u8" },
-          { "name": "token_b_flag", "docs": ["token b flag"], "type": "u8" },
+          {
+            "name": "pool_status",
+            "docs": [
+              "pool status, 0: enable, 1 disable"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_a_flag",
+            "docs": [
+              "token a flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_b_flag",
+            "docs": [
+              "token b flag"
+            ],
+            "type": "u8"
+          },
           {
             "name": "collect_fee_mode",
-            "docs": ["0 is collect fee in both token, 1 only collect fee only in token b"],
+            "docs": [
+              "0 is collect fee in both token, 1 only collect fee only in token b"
+            ],
             "type": "u8"
           },
-          { "name": "pool_type", "docs": ["pool type"], "type": "u8" },
           {
-            "name": "version",
-            "docs": ["pool version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"],
+            "name": "pool_type",
+            "docs": [
+              "pool type"
+            ],
             "type": "u8"
           },
-          { "name": "_padding_0", "docs": ["padding"], "type": "u8" },
-          { "name": "fee_a_per_liquidity", "docs": ["cumulative"], "type": { "array": ["u8", 32] } },
-          { "name": "fee_b_per_liquidity", "docs": ["cumulative"], "type": { "array": ["u8", 32] } },
-          { "name": "permanent_lock_liquidity", "type": "u128" },
-          { "name": "metrics", "docs": ["metrics"], "type": { "defined": { "name": "PoolMetrics" } } },
-          { "name": "creator", "docs": ["pool creator"], "type": "pubkey" },
-          { "name": "_padding_1", "docs": ["Padding for further use"], "type": { "array": ["u64", 6] } },
+          {
+            "name": "fee_version",
+            "docs": [
+              "pool fee version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_3",
+            "docs": [
+              "padding"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fee_a_per_liquidity",
+            "docs": [
+              "cumulative"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "fee_b_per_liquidity",
+            "docs": [
+              "cumulative"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "permanent_lock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "metrics",
+            "docs": [
+              "metrics"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolMetrics"
+              }
+            }
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "pool creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "docs": [
+              "token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "docs": [
+              "token b amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "layout_version",
+            "docs": [
+              "layout version: version 0: haven't track token_a_amount and token_b_amount, version 1: track token_a_amount and token_b_amount"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_4",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "padding_5",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          },
           {
             "name": "reward_infos",
-            "docs": ["Farming reward information"],
-            "type": { "array": [{ "defined": { "name": "RewardInfo" } }, 2] }
+            "docs": [
+              "Farming reward information"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RewardInfo"
+                  }
+                },
+                2
+              ]
+            }
           }
         ]
       }
     },
     {
       "name": "PoolFeeParameters",
-      "docs": ["Information regarding fee charges"],
+      "docs": [
+        "Information regarding fee charges"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "base_fee",
-            "docs": ["Base fee"],
-            "type": { "defined": { "name": "BaseFeeParameters" } }
+            "docs": [
+              "Base fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "BaseFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only have value if CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": "u8"
           },
           {
             "name": "dynamic_fee",
-            "docs": ["dynamic fee"],
-            "type": { "option": { "defined": { "name": "DynamicFeeParameters" } } }
+            "docs": [
+              "dynamic fee"
+            ],
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "DynamicFeeParameters"
+                }
+              }
+            }
           }
         ]
       }
@@ -2236,17 +6238,65 @@
     {
       "name": "PoolFeesConfig",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "base_fee", "type": { "defined": { "name": "BaseFeeInfo" } } },
-          { "name": "dynamic_fee", "type": { "defined": { "name": "DynamicFeeConfig" } } },
-          { "name": "protocol_fee_percent", "type": "u8" },
-          { "name": "partner_fee_percent", "type": "u8" },
-          { "name": "referral_fee_percent", "type": "u8" },
-          { "name": "padding_0", "type": { "array": ["u8", 5] } },
-          { "name": "padding_1", "type": { "array": ["u64", 5] } }
+          {
+            "name": "base_fee",
+            "type": {
+              "defined": {
+                "name": "BaseFeeInfo"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "type": {
+              "defined": {
+                "name": "DynamicFeeConfig"
+              }
+            }
+          },
+          {
+            "name": "protocol_fee_percent",
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": "u8"
+          },
+          {
+            "name": "referral_fee_percent",
+            "type": "u8"
+          },
+          {
+            "name": "padding_1",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee bps, only non-zero if collect_fee_mode is compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding_2",
+            "type": {
+              "array": [
+                "u64",
+                5
+              ]
+            }
+          }
         ]
       }
     },
@@ -2256,11 +6306,12 @@
         "Information regarding fee charges",
         "trading_fee = amount * trade_fee_numerator / denominator",
         "protocol_fee = trading_fee * protocol_fee_percentage / 100",
-        "referral_fee = protocol_fee * referral_percentage / 100",
-        "partner_fee = (protocol_fee - referral_fee) * partner_fee_percentage / denominator"
+        "referral_fee = protocol_fee * referral_percentage / 100"
       ],
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
@@ -2271,7 +6322,11 @@
               "accounts during a trade, making the value of liquidity tokens rise.",
               "Trade fee numerator"
             ],
-            "type": { "defined": { "name": "BaseFeeStruct" } }
+            "type": {
+              "defined": {
+                "name": "BaseFeeStruct"
+              }
+            }
           },
           {
             "name": "protocol_fee_percent",
@@ -2283,79 +6338,258 @@
             ],
             "type": "u8"
           },
-          { "name": "partner_fee_percent", "docs": ["partner fee"], "type": "u8" },
-          { "name": "referral_fee_percent", "docs": ["referral fee"], "type": "u8" },
-          { "name": "padding_0", "docs": ["padding"], "type": { "array": ["u8", 5] } },
+          {
+            "name": "padding_0",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "referral_fee_percent",
+            "docs": [
+              "referral fee"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_1",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only non-zero in CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
+          },
           {
             "name": "dynamic_fee",
-            "docs": ["dynamic fee"],
-            "type": { "defined": { "name": "DynamicFeeStruct" } }
+            "docs": [
+              "dynamic fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "DynamicFeeStruct"
+              }
+            }
           },
-          { "name": "init_sqrt_price", "type": "u128" }
+          {
+            "name": "init_sqrt_price",
+            "type": "u128"
+          }
         ]
       }
     },
     {
       "name": "PoolMetrics",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "total_lp_a_fee", "type": "u128" },
-          { "name": "total_lp_b_fee", "type": "u128" },
-          { "name": "total_protocol_a_fee", "type": "u64" },
-          { "name": "total_protocol_b_fee", "type": "u64" },
-          { "name": "total_partner_a_fee", "type": "u64" },
-          { "name": "total_partner_b_fee", "type": "u64" },
-          { "name": "total_position", "type": "u64" },
-          { "name": "padding", "type": "u64" }
+          {
+            "name": "total_lp_a_fee",
+            "type": "u128"
+          },
+          {
+            "name": "total_lp_b_fee",
+            "type": "u128"
+          },
+          {
+            "name": "total_protocol_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_protocol_b_fee",
+            "type": "u64"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          },
+          {
+            "name": "total_position",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "Position",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "nft_mint", "docs": ["nft mint"], "type": "pubkey" },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "nft_mint",
+            "docs": [
+              "nft mint"
+            ],
+            "type": "pubkey"
+          },
           {
             "name": "fee_a_per_token_checkpoint",
-            "docs": ["fee a checkpoint"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "fee a checkpoint"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "fee_b_per_token_checkpoint",
-            "docs": ["fee b checkpoint"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "fee b checkpoint"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
-          { "name": "fee_a_pending", "docs": ["fee a pending"], "type": "u64" },
-          { "name": "fee_b_pending", "docs": ["fee b pending"], "type": "u64" },
-          { "name": "unlocked_liquidity", "docs": ["unlock liquidity"], "type": "u128" },
-          { "name": "vested_liquidity", "docs": ["vesting liquidity"], "type": "u128" },
-          { "name": "permanent_locked_liquidity", "docs": ["permanent locked liquidity"], "type": "u128" },
-          { "name": "metrics", "docs": ["metrics"], "type": { "defined": { "name": "PositionMetrics" } } },
+          {
+            "name": "fee_a_pending",
+            "docs": [
+              "fee a pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_b_pending",
+            "docs": [
+              "fee b pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "docs": [
+              "unlock liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "docs": [
+              "vesting liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "permanent_locked_liquidity",
+            "docs": [
+              "permanent locked liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "metrics",
+            "docs": [
+              "metrics"
+            ],
+            "type": {
+              "defined": {
+                "name": "PositionMetrics"
+              }
+            }
+          },
           {
             "name": "reward_infos",
-            "docs": ["Farming reward information"],
-            "type": { "array": [{ "defined": { "name": "UserRewardInfo" } }, 2] }
+            "docs": [
+              "Farming reward information"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "UserRewardInfo"
+                  }
+                },
+                2
+              ]
+            }
           },
-          { "name": "padding", "docs": ["padding for future usage"], "type": { "array": ["u128", 6] } }
+          {
+            "name": "inner_vesting",
+            "docs": [
+              "inner vesting info"
+            ],
+            "type": {
+              "defined": {
+                "name": "InnerVesting"
+              }
+            }
+          },
+          {
+            "name": "delegate_permission",
+            "docs": [
+              "delegate permission bitmask (paired with SPL token Approve)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future usage"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                12
+              ]
+            }
+          }
         ]
       }
     },
     {
       "name": "PositionMetrics",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "total_claimed_a_fee", "type": "u64" },
-          { "name": "total_claimed_b_fee", "type": "u64" }
+          {
+            "name": "total_claimed_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_b_fee",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2364,42 +6598,134 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity_delta", "docs": ["delta liquidity"], "type": "u128" },
-          { "name": "token_a_amount_threshold", "docs": ["minimum token a amount"], "type": "u64" },
-          { "name": "token_b_amount_threshold", "docs": ["minimum token b amount"], "type": "u64" }
+          {
+            "name": "liquidity_delta",
+            "docs": [
+              "delta liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "token_a_amount_threshold",
+            "docs": [
+              "minimum token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount_threshold",
+            "docs": [
+              "minimum token b amount"
+            ],
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "RewardInfo",
-      "docs": ["Stores the state relevant for tracking liquidity mining rewards"],
+      "docs": [
+        "Stores the state relevant for tracking liquidity mining rewards"
+      ],
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "initialized", "docs": ["Indicates if the reward has been initialized"], "type": "u8" },
-          { "name": "reward_token_flag", "docs": ["reward token flag"], "type": "u8" },
-          { "name": "_padding_0", "docs": ["padding"], "type": { "array": ["u8", 6] } },
           {
-            "name": "_padding_1",
-            "docs": ["Padding to ensure `reward_rate: u128` is 16-byte aligned"],
-            "type": { "array": ["u8", 8] }
+            "name": "initialized",
+            "docs": [
+              "Indicates if the reward has been initialized"
+            ],
+            "type": "u8"
           },
-          { "name": "mint", "docs": ["Reward token mint."], "type": "pubkey" },
-          { "name": "vault", "docs": ["Reward vault token account."], "type": "pubkey" },
-          { "name": "funder", "docs": ["Authority account that allows to fund rewards"], "type": "pubkey" },
-          { "name": "reward_duration", "docs": ["reward duration"], "type": "u64" },
-          { "name": "reward_duration_end", "docs": ["reward duration end"], "type": "u64" },
-          { "name": "reward_rate", "docs": ["reward rate"], "type": "u128" },
+          {
+            "name": "reward_token_flag",
+            "docs": [
+              "reward token flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "dead_liquidity_reward_checkpoint",
+            "docs": [
+              "Cumulative dead-liquidity reward (Compounding Pool only)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Reward token mint."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "Reward vault token account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "docs": [
+              "Authority account that allows to fund rewards"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_duration",
+            "docs": [
+              "reward duration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration_end",
+            "docs": [
+              "reward duration end"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_rate",
+            "docs": [
+              "reward rate"
+            ],
+            "type": "u128"
+          },
           {
             "name": "reward_per_token_stored",
-            "docs": ["Reward per token stored"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "Reward per token stored"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "last_update_time",
-            "docs": ["The last time reward states were updated."],
+            "docs": [
+              "The last time reward states were updated."
+            ],
             "type": "u64"
           },
           {
@@ -2418,12 +6744,66 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "permanent_locked_liquidity", "type": "u128" },
-          { "name": "unlocked_liquidity", "type": "u128" },
-          { "name": "fee_a", "type": "u64" },
-          { "name": "fee_b", "type": "u64" },
-          { "name": "reward_0", "type": "u64" },
-          { "name": "reward_1", "type": "u64" }
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitAmountInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2432,11 +6812,62 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity", "type": "u128" },
-          { "name": "fee_a", "type": "u64" },
-          { "name": "fee_b", "type": "u64" },
-          { "name": "reward_0", "type": "u64" },
-          { "name": "reward_1", "type": "u64" }
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2447,35 +6878,65 @@
         "fields": [
           {
             "name": "unlocked_liquidity_percentage",
-            "docs": ["Percentage of unlocked liquidity to split to the second position"],
+            "docs": [
+              "Percentage of unlocked liquidity to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "permanent_locked_liquidity_percentage",
-            "docs": ["Percentage of permanent locked liquidity to split to the second position"],
+            "docs": [
+              "Percentage of permanent locked liquidity to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "fee_a_percentage",
-            "docs": ["Percentage of fee A pending to split to the second position"],
+            "docs": [
+              "Percentage of fee A pending to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "fee_b_percentage",
-            "docs": ["Percentage of fee B pending to split to the second position"],
+            "docs": [
+              "Percentage of fee B pending to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "reward_0_percentage",
-            "docs": ["Percentage of reward 0 pending to split to the second position"],
+            "docs": [
+              "Percentage of reward 0 pending to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "reward_1_percentage",
-            "docs": ["Percentage of reward 1 pending to split to the second position"],
+            "docs": [
+              "Percentage of reward 1 pending to split to the second position"
+            ],
             "type": "u8"
           },
-          { "name": "padding", "docs": ["padding for future"], "type": { "array": ["u8", 16] } }
+          {
+            "name": "inner_vesting_liquidity_percentage",
+            "docs": [
+              "Percentage of inner vesting liquidity"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                15
+              ]
+            }
+          }
         ]
       }
     },
@@ -2484,12 +6945,66 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "unlocked_liquidity_numerator", "type": "u32" },
-          { "name": "permanent_locked_liquidity_numerator", "type": "u32" },
-          { "name": "fee_a_numerator", "type": "u32" },
-          { "name": "fee_b_numerator", "type": "u32" },
-          { "name": "reward_0_numerator", "type": "u32" },
-          { "name": "reward_1_numerator", "type": "u32" }
+          {
+            "name": "unlocked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "permanent_locked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_a_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_b_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_0_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_1_numerator",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionParameters3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "permanent_locked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_a_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_b_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_0_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_1_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "inner_vesting_liquidity_numerator",
+            "type": "u32"
+          }
         ]
       }
     },
@@ -2498,13 +7013,38 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool_fees", "type": { "defined": { "name": "PoolFeeParameters" } } },
-          { "name": "sqrt_min_price", "type": "u128" },
-          { "name": "sqrt_max_price", "type": "u128" },
-          { "name": "vault_config_key", "type": "pubkey" },
-          { "name": "pool_creator_authority", "type": "pubkey" },
-          { "name": "activation_type", "type": "u8" },
-          { "name": "collect_fee_mode", "type": "u8" }
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "sqrt_min_price",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "type": "u128"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -2513,8 +7053,14 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "amount_in", "type": "u64" },
-          { "name": "minimum_amount_out", "type": "u64" }
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "minimum_amount_out",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2537,7 +7083,13 @@
             ],
             "type": "u64"
           },
-          { "name": "swap_mode", "docs": ["Swap mode, refer [SwapMode]"], "type": "u8" }
+          {
+            "name": "swap_mode",
+            "docs": [
+              "Swap mode, refer [SwapMode]"
+            ],
+            "type": "u8"
+          }
         ]
       }
     },
@@ -2546,28 +7098,76 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "included_fee_input_amount", "type": "u64" },
-          { "name": "excluded_fee_input_amount", "type": "u64" },
-          { "name": "amount_left", "type": "u64" },
-          { "name": "output_amount", "type": "u64" },
-          { "name": "next_sqrt_price", "type": "u128" },
-          { "name": "trading_fee", "type": "u64" },
-          { "name": "protocol_fee", "type": "u64" },
-          { "name": "partner_fee", "type": "u64" },
-          { "name": "referral_fee", "type": "u64" }
+          {
+            "name": "included_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "claiming_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "compounding_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "TokenBadge",
-      "docs": ["Parameter that set by the protocol"],
+      "docs": [
+        "Parameter that set by the protocol"
+      ],
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "token_mint", "docs": ["token mint"], "type": "pubkey" },
-          { "name": "_padding", "docs": ["Reserve"], "type": { "array": ["u8", 128] } }
+          {
+            "name": "token_mint",
+            "docs": [
+              "token mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          }
         ]
       }
     },
@@ -2583,7 +7183,9 @@
               "- None: skip base fee update",
               "- Some: update new cliff_fee_numerator if base fee is static"
             ],
-            "type": { "option": "u64" }
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "dynamic_fee",
@@ -2593,7 +7195,24 @@
               "- Some(with default value): disable dynamic fee",
               "- Some(with non default value): enable dynamic fee if disabled or update dynamic fee if enabled"
             ],
-            "type": { "option": { "defined": { "name": "DynamicFeeParameters" } } }
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "DynamicFeeParameters"
+                }
+              }
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee update mode:",
+              "- None: skip compounding fee update",
+              "- Some: update compounding_fee_bps; pool must use CollectFeeMode::Compounding"
+            ],
+            "type": {
+              "option": "u16"
+            }
           }
         ]
       }
@@ -2601,36 +7220,71 @@
     {
       "name": "UserRewardInfo",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "reward_per_token_checkpoint",
-            "docs": ["The latest update reward checkpoint"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "The latest update reward checkpoint"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
-          { "name": "reward_pendings", "docs": ["Current pending rewards"], "type": "u64" },
-          { "name": "total_claimed_rewards", "docs": ["Total claimed rewards"], "type": "u64" }
+          {
+            "name": "reward_pendings",
+            "docs": [
+              "Current pending rewards"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_rewards",
+            "docs": [
+              "Total claimed rewards"
+            ],
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "Vesting",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "position", "type": "pubkey" },
-          { "name": "cliff_point", "type": "u64" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "cliff_unlock_liquidity", "type": "u128" },
-          { "name": "liquidity_per_period", "type": "u128" },
-          { "name": "total_released_liquidity", "type": "u128" },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "padding", "type": { "array": ["u8", 14] } },
-          { "name": "padding2", "type": { "array": ["u128", 4] } }
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "inner_vesting",
+            "type": {
+              "defined": {
+                "name": "InnerVesting"
+              }
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u128",
+                4
+              ]
+            }
+          }
         ]
       }
     },
@@ -2639,23 +7293,58 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_point", "type": { "option": "u64" } },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "cliff_unlock_liquidity", "type": "u128" },
-          { "name": "liquidity_per_period", "type": "u128" },
-          { "name": "number_of_period", "type": "u16" }
+          {
+            "name": "cliff_point",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          }
         ]
       }
     }
   ],
   "constants": [
-    { "name": "BIN_STEP_BPS_DEFAULT", "type": "u16", "value": "1" },
+    {
+      "name": "BIN_STEP_BPS_DEFAULT",
+      "type": "u16",
+      "value": "1"
+    },
     {
       "name": "BIN_STEP_U128_DEFAULT_LE_BYTES",
-      "type": { "array": ["u8", 16] },
+      "type": {
+        "array": [
+          "u8",
+          16
+        ]
+      },
       "value": "[203, 16, 199, 186, 184, 141, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
     },
-    { "name": "CUSTOMIZABLE_POOL_PREFIX", "type": "bytes", "value": "[99, 112, 111, 111, 108]" },
+    {
+      "name": "CURRENT_POOL_VERSION",
+      "type": "u8",
+      "value": "1"
+    },
+    {
+      "name": "CUSTOMIZABLE_POOL_PREFIX",
+      "type": "bytes",
+      "value": "[99, 112, 111, 111, 108]"
+    },
     {
       "name": "FEE_DENOMINATOR",
       "docs": [
@@ -2664,15 +7353,47 @@
       "type": "u64",
       "value": "1000000000"
     },
-    { "name": "MAX_BASIS_POINT", "docs": ["Max basis point. 100% in pct"], "type": "u64", "value": "10000" },
+    {
+      "name": "MAX_BASIS_POINT",
+      "docs": [
+        "Max basis point. 100% in pct"
+      ],
+      "type": "u16",
+      "value": "10000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V0",
+      "type": "u64",
+      "value": "500000000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V1",
+      "type": "u64",
+      "value": "990000000"
+    },
     {
       "name": "MAX_SQRT_PRICE_LE_BYTES",
-      "type": { "array": ["u8", 16] },
+      "type": {
+        "array": [
+          "u8",
+          16
+        ]
+      },
       "value": "[155, 87, 105, 78, 169, 26, 92, 132, 177, 196, 254, 255, 0, 0, 0, 0]"
     },
     {
+      "name": "MIN_FEE_NUMERATOR",
+      "type": "u64",
+      "value": "100000"
+    },
+    {
       "name": "MIN_SQRT_PRICE_LE_BYTES",
-      "type": { "array": ["u8", 16] },
+      "type": {
+        "array": [
+          "u8",
+          16
+        ]
+      },
       "value": "[80, 59, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
     },
     {
@@ -2680,14 +7401,26 @@
       "type": "bytes",
       "value": "[112, 111, 111, 108, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121]"
     },
-    { "name": "POOL_PREFIX", "type": "bytes", "value": "[112, 111, 111, 108]" },
+    {
+      "name": "POOL_PREFIX",
+      "type": "bytes",
+      "value": "[112, 111, 111, 108]"
+    },
     {
       "name": "POSITION_NFT_ACCOUNT_PREFIX",
       "type": "bytes",
       "value": "[112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117, 110, 116]"
     },
-    { "name": "POSITION_PREFIX", "type": "bytes", "value": "[112, 111, 115, 105, 116, 105, 111, 110]" },
-    { "name": "SPLIT_POSITION_DENOMINATOR", "type": "u32", "value": "1000000000" },
+    {
+      "name": "POSITION_PREFIX",
+      "type": "bytes",
+      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
+    },
+    {
+      "name": "SPLIT_POSITION_DENOMINATOR",
+      "type": "u32",
+      "value": "1000000000"
+    },
     {
       "name": "TOKEN_VAULT_PREFIX",
       "type": "bytes",

--- a/idl/meteora_dlmm.json
+++ b/idl/meteora_dlmm.json
@@ -1,500 +1,1993 @@
 {
-  "version": "0.9.0",
-  "name": "lb_clmm",
-  "constants": [
-    {
-      "name": "BASIS_POINT_MAX",
-      "type": "i32",
-      "value": "10000"
-    },
-    {
-      "name": "MAX_BIN_PER_ARRAY",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "MAX_BIN_PER_POSITION",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "MAX_RESIZE_LENGTH",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "POSITION_MAX_LENGTH",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "1400"
-    },
-    {
-      "name": "MIN_BIN_ID",
-      "type": "i32",
-      "value": "- 443636"
-    },
-    {
-      "name": "MAX_BIN_ID",
-      "type": "i32",
-      "value": "443636"
-    },
-    {
-      "name": "MAX_FEE_RATE",
-      "type": "u64",
-      "value": "100_000_000"
-    },
-    {
-      "name": "FEE_PRECISION",
-      "type": "u64",
-      "value": "1_000_000_000"
-    },
-    {
-      "name": "MAX_PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "2_500"
-    },
-    {
-      "name": "HOST_FEE_BPS",
-      "type": "u16",
-      "value": "2_000"
-    },
-    {
-      "name": "NUM_REWARDS",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "2"
-    },
-    {
-      "name": "MIN_REWARD_DURATION",
-      "type": "u64",
-      "value": "1"
-    },
-    {
-      "name": "MAX_REWARD_DURATION",
-      "type": "u64",
-      "value": "31536000"
-    },
-    {
-      "name": "EXTENSION_BINARRAY_BITMAP_SIZE",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "12"
-    },
-    {
-      "name": "BIN_ARRAY_BITMAP_SIZE",
-      "type": "i32",
-      "value": "512"
-    },
-    {
-      "name": "MAX_REWARD_BIN_SPLIT",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "15"
-    },
-    {
-      "name": "ILM_PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "2000"
-    },
-    {
-      "name": "PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "500"
-    },
-    {
-      "name": "MAX_BIN_STEP",
-      "type": "u16",
-      "value": "400"
-    },
-    {
-      "name": "MAX_BASE_FEE",
-      "type": "u128",
-      "value": "100_000_000"
-    },
-    {
-      "name": "MIN_BASE_FEE",
-      "type": "u128",
-      "value": "100_000"
-    },
-    {
-      "name": "MINIMUM_LIQUIDITY",
-      "type": "u128",
-      "value": "1_000_000"
-    },
-    {
-      "name": "BIN_ARRAY",
-      "type": "bytes",
-      "value": "[98, 105, 110, 95, 97, 114, 114, 97, 121]"
-    },
-    {
-      "name": "ORACLE",
-      "type": "bytes",
-      "value": "[111, 114, 97, 99, 108, 101]"
-    },
-    {
-      "name": "BIN_ARRAY_BITMAP_SEED",
-      "type": "bytes",
-      "value": "[98, 105, 116, 109, 97, 112]"
-    },
-    {
-      "name": "PRESET_PARAMETER",
-      "type": "bytes",
-      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114]"
-    },
-    {
-      "name": "PRESET_PARAMETER2",
-      "type": "bytes",
-      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 50]"
-    },
-    {
-      "name": "POSITION",
-      "type": "bytes",
-      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
-    },
-    {
-      "name": "CLAIM_PROTOCOL_FEE_OPERATOR",
-      "type": "bytes",
-      "value": "[99, 102, 95, 111, 112, 101, 114, 97, 116, 111, 114]"
-    }
-  ],
+  "address": "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",
+  "metadata": {
+    "name": "lb_clmm",
+    "version": "0.12.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
   "instructions": [
     {
-      "name": "initializeLbPair",
+      "name": "add_liquidity",
+      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "position",
+          "writable": true
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "presetParameter",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "activeId",
-          "type": "i32"
-        },
-        {
-          "name": "binStep",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializePermissionLbPair",
-      "accounts": [
-        {
-          "name": "base",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ixData",
-          "type": {
-            "defined": "InitPermissionPairIx"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeCustomizablePermissionlessLbPair",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CustomizableParams"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeBinArrayBitmapExtension",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize an account to store if a bin array is initialized."
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
           ]
         },
         {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_x",
+          "writable": true
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity2",
+      "discriminator": [228, 162, 78, 28, 70, 219, 116, 115],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameter"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy",
+      "discriminator": [7, 3, 150, 127, 148, 40, 61, 200],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategy"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy2",
+      "discriminator": [3, 221, 149, 218, 111, 141, 118, 213],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategy"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy_one_side",
+      "discriminator": [41, 5, 238, 175, 100, 225, 6, 205],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategyOneSide"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_weight",
+      "discriminator": [28, 140, 238, 99, 231, 162, 21, 149],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByWeight"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_weight2",
+      "discriminator": [209, 59, 63, 91, 111, 200, 153, 228],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByWeight"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side",
+      "discriminator": [94, 155, 103, 151, 70, 95, 220, 165],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityOneSideParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side_precise",
+      "discriminator": [161, 194, 103, 84, 171, 71, 250, 154],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "parameter",
+          "type": {
+            "defined": {
+              "name": "AddLiquiditySingleSidePreciseParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side_precise2",
+      "discriminator": [33, 51, 163, 201, 117, 98, 125, 231],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "AddLiquiditySingleSidePreciseParameter2"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancel_limit_order",
+      "discriminator": [132, 156, 132, 31, 67, 40, 232, 97],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension", "limit_order"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner_token_x",
+          "docs": [
+            "When dont set it tokenAccount to prevent unnecessary create token account (rent fee) when user only withdraw token y"
+          ],
+          "writable": true
+        },
+        {
+          "name": "owner_token_y",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bins",
+          "type": {
+            "vec": "i32"
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_fee",
+      "discriminator": [169, 32, 79, 137, 136, 232, 70, 137],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
     },
     {
-      "name": "initializeBinArray",
+      "name": "claim_fee2",
+      "discriminator": [112, 191, 101, 171, 28, 144, 127, 187],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
         },
         {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "min_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "max_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_reward",
+      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_reward2",
+      "discriminator": [190, 3, 127, 119, 178, 87, 157, 183],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "min_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "max_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_bin_array",
+      "discriminator": [68, 174, 88, 80, 181, 204, 19, 224],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_claim_fee_operator_account",
+      "discriminator": [184, 213, 88, 31, 179, 101, 130, 36],
+      "accounts": [
+        {
+          "name": "claim_fee_operator",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_limit_order_if_empty",
+      "discriminator": [57, 124, 36, 155, 126, 249, 93, 171],
+      "accounts": [
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_operator_account",
+      "discriminator": [171, 9, 213, 74, 120, 23, 3, 29],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position",
+      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position2",
+      "discriminator": [174, 90, 35, 115, 186, 40, 147, 226],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position_if_empty",
+      "discriminator": [59, 124, 212, 118, 91, 152, 110, 157],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_preset_parameter",
+      "discriminator": [4, 148, 145, 100, 134, 26, 181, 61],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_preset_parameter2",
+      "discriminator": [39, 25, 95, 107, 116, 17, 115, 28],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_token_badge",
+      "discriminator": [108, 146, 86, 110, 179, 254, 10, 104],
+      "accounts": [
+        {
+          "name": "token_badge",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_operator_account",
+      "discriminator": [221, 64, 246, 149, 240, 153, 229, 163],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 112, 101, 114, 97, 116, 111, 114]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "whitelisted_signer"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "decrease_position_length",
+      "discriminator": [194, 219, 136, 32, 25, 96, 105, 37],
+      "accounts": [
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_remove",
+          "type": "u16"
+        },
+        {
+          "name": "side",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "for_idl_type_generation_do_not_call",
+      "discriminator": [180, 105, 69, 80, 95, 50, 73, 108],
+      "accounts": [
+        {
+          "name": "dummy_zc_account"
+        }
+      ],
+      "args": [
+        {
+          "name": "_ix",
+          "type": {
+            "defined": {
+              "name": "DummyIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fund_reward",
+      "discriminator": [188, 50, 249, 165, 93, 151, 38, 63],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
         },
         {
           "name": "funder",
-          "isMut": true,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "carry_forward",
+          "type": "bool"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "go_to_a_bin",
+      "discriminator": [146, 72, 174, 224, 40, 253, 84, 174],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "bin_array_bitmap_extension",
+            "from_bin_array",
+            "to_bin_array"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "optional": true
+        },
+        {
+          "name": "from_bin_array",
+          "optional": true
+        },
+        {
+          "name": "to_bin_array",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_id",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "increase_oracle_length",
+      "discriminator": [190, 61, 125, 87, 103, 79, 158, 173],
+      "accounts": [
+        {
+          "name": "oracle",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_add",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_position_length",
+      "discriminator": [80, 83, 117, 211, 66, 13, 33, 149],
+      "accounts": [
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_add",
+          "type": "u16"
+        },
+        {
+          "name": "side",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "increase_position_length2",
+      "discriminator": [255, 210, 204, 71, 115, 137, 225, 113],
+      "accounts": [
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "minimum_upper_bin_id",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "initialize_bin_array",
+      "discriminator": [35, 86, 19, 185, 78, 212, 75, 211],
+      "accounts": [
+        {
+          "name": "lb_pair"
+        },
+        {
+          "name": "bin_array",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 110, 95, 97, 114, 114, 97, 121]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -505,578 +1998,762 @@
       ]
     },
     {
-      "name": "addLiquidity",
+      "name": "initialize_bin_array_bitmap_extension",
+      "discriminator": [47, 157, 226, 180, 12, 240, 33, 71],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "bin_array_bitmap_extension",
+          "docs": [
+            "Initialize an account to store if a bin array is initialized."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "funder",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "rent"
         }
       ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameter"
-          }
-        }
-      ]
+      "args": []
     },
     {
-      "name": "addLiquidityByWeight",
+      "name": "initialize_customizable_permissionless_lb_pair",
+      "discriminator": [46, 39, 41, 135, 111, 183, 200, 64],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByWeight"
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategy",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_mint_x"
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "token_mint_y"
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategy"
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategyOneSide",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategyOneSide"
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSide",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityOneSideParameter"
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidity",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_x"
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "funder",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_y"
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "binLiquidityRemoval",
+          "name": "params",
           "type": {
-            "vec": {
-              "defined": "BinLiquidityReduction"
+            "defined": {
+              "name": "CustomizableParams"
             }
           }
         }
       ]
     },
     {
-      "name": "initializePosition",
+      "name": "initialize_customizable_permissionless_lb_pair2",
+      "discriminator": [243, 73, 129, 126, 51, 19, 241, 107],
       "accounts": [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          "name": "lb_pair",
+          "writable": true
         },
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_mint_x"
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "name": "token_mint_y"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_x"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "user_token_y"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CustomizableParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_lb_pair",
+      "discriminator": [45, 154, 237, 210, 221, 15, 166, 92],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "preset_parameter"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "active_id",
+          "type": "i32"
+        },
+        {
+          "name": "bin_step",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initialize_lb_pair2",
+      "discriminator": [73, 59, 36, 120, 237, 83, 108, 198],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "preset_parameter"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializeLbPair2Params"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_permission_lb_pair",
+      "discriminator": [108, 102, 213, 85, 251, 3, 53, 21],
+      "accounts": [
+        {
+          "name": "base",
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "ix_data",
+          "type": {
+            "defined": {
+              "name": "InitPermissionPairIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_position",
+      "discriminator": [219, 192, 234, 71, 190, 191, 102, 80],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair"
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1086,60 +2763,51 @@
       ]
     },
     {
-      "name": "initializePositionPda",
+      "name": "initialize_position2",
+      "discriminator": [143, 19, 242, 145, 213, 15, 104, 115],
       "accounts": [
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "base",
-          "isMut": false,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "owner"
-          ]
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1149,70 +2817,88 @@
       ]
     },
     {
-      "name": "initializePositionByOperator",
+      "name": "initialize_position_by_operator",
+      "discriminator": [251, 189, 190, 244, 117, 254, 35, 148],
       "accounts": [
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "base",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "base"
+              },
+              {
+                "kind": "arg",
+                "path": "lower_bin_id"
+              },
+              {
+                "kind": "arg",
+                "path": "width"
+              }
+            ]
+          }
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner"
         },
         {
           "name": "operator",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "operator"
-          ]
+          "docs": ["operator"],
+          "signer": true
         },
         {
-          "name": "operatorTokenX",
-          "isMut": false,
-          "isSigner": false
+          "name": "operator_token_x"
         },
         {
-          "name": "ownerTokenX",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner_token_x"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1220,5733 +2906,2316 @@
           "type": "i32"
         },
         {
-          "name": "feeOwner",
-          "type": "publicKey"
+          "name": "fee_owner",
+          "type": "pubkey"
         },
         {
-          "name": "lockReleasePoint",
+          "name": "lock_release_point",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "updatePositionOperator",
+      "name": "initialize_position_pda",
+      "discriminator": [46, 82, 125, 146, 85, 141, 228, 153],
       "accounts": [
         {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "base",
+          "signer": true
+        },
+        {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "base"
+              },
+              {
+                "kind": "arg",
+                "path": "lower_bin_id"
+              },
+              {
+                "kind": "arg",
+                "path": "width"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lb_pair"
         },
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "docs": ["owner"],
+          "signer": true
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "operator",
-          "type": "publicKey"
+          "name": "lower_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "width",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "initialize_preset_parameter",
+      "discriminator": [66, 188, 71, 211, 98, 109, 14, 186],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101,
+                  116, 101, 114, 50
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "ix.index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "ix",
+          "type": {
+            "defined": {
+              "name": "InitPresetParametersIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_reward",
+      "discriminator": [95, 135, 192, 196, 242, 129, 230, 68],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "arg",
+                "path": "reward_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "token_badge",
+          "optional": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "reward_duration",
+          "type": "u64"
+        },
+        {
+          "name": "funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "initialize_token_badge",
+      "discriminator": [253, 77, 205, 95, 27, 224, 89, 223],
+      "accounts": [
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "token_badge",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [116, 111, 107, 101, 110, 95, 98, 97, 100, 103, 101]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "place_limit_order",
+      "discriminator": [108, 176, 33, 186, 146, 229, 1, 197],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "limit_order",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "PlaceLimitOrderParams"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "rebalance_liquidity",
+      "discriminator": [92, 4, 176, 193, 119, 185, 83, 9],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "rent_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RebalanceLiquidityParams"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_all_liquidity",
+      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_liquidity",
+      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_liquidity_removal",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "BinLiquidityReduction"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity2",
+      "discriminator": [230, 215, 82, 127, 241, 101, 227, 146],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_liquidity_removal",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "BinLiquidityReduction"
+              }
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range",
+      "discriminator": [26, 82, 102, 152, 240, 74, 105, 26],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "from_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "to_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "bps_to_remove",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range2",
+      "discriminator": [204, 2, 195, 145, 53, 145, 145, 205],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "from_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "to_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "bps_to_remove",
+          "type": "u16"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_activation_point",
+      "discriminator": [91, 249, 15, 165, 26, 129, 254, 125],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "activation_point",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_pair_status",
+      "discriminator": [67, 248, 231, 137, 154, 149, 217, 174],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_pair_status_permissionless",
+      "discriminator": [78, 59, 152, 211, 70, 183, 46, 208],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_permissionless_operation_bits",
+      "discriminator": [84, 58, 203, 139, 163, 81, 190, 186],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bits",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_pre_activation_duration",
+      "discriminator": [165, 61, 201, 244, 130, 159, 22, 100],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pre_activation_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_pre_activation_swap_address",
+      "discriminator": [57, 139, 47, 123, 216, 80, 223, 10],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pre_activation_swap_address",
+          "type": "pubkey"
         }
       ]
     },
     {
       "name": "swap",
+      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "minAmountOut",
+          "name": "min_amount_out",
           "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "swapExactOut",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "user",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "maxInAmount",
-          "type": "u64"
-        },
-        {
-          "name": "outAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "swapWithPriceImpact",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "user",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amountIn",
-          "type": "u64"
-        },
-        {
-          "name": "activeId",
-          "type": {
-            "option": "i32"
-          }
-        },
-        {
-          "name": "maxPriceImpactBps",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "withdrawProtocolFee",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "receiverTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "receiverTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "claimFeeOperator",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "operator",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "operator"
-          ]
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amountX",
-          "type": "u64"
-        },
-        {
-          "name": "amountY",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "rewardDuration",
-          "type": "u64"
-        },
-        {
-          "name": "funder",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "fundReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "carryForward",
-          "type": "bool"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateRewardFunder",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "newFunder",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "updateRewardDuration",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "newDuration",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "claimReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "claimFee",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closePosition",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateBaseFeeParameters",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeParameter",
-          "type": {
-            "defined": "BaseFeeParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateDynamicFeeParameters",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeParameter",
-          "type": {
-            "defined": "DynamicFeeParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "increaseOracleLength",
-      "accounts": [
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "lengthToAdd",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "initializePresetParameter",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ix",
-          "type": {
-            "defined": "InitPresetParametersIx"
-          }
-        }
-      ]
-    },
-    {
-      "name": "closePresetParameter",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closePresetParameter2",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "removeAllLiquidity",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setPairStatus",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "status",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "migratePosition",
-      "accounts": [
-        {
-          "name": "positionV2",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionV1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "migrateBinArray",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateFeesAndRewards",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "withdrawIneligibleReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "setActivationPoint",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "activationPoint",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidityByRange",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "fromBinId",
-          "type": "i32"
-        },
-        {
-          "name": "toBinId",
-          "type": "i32"
-        },
-        {
-          "name": "bpsToRemove",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSidePrecise",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "parameter",
-          "type": {
-            "defined": "AddLiquiditySingleSidePreciseParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "goToABin",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "fromBinArray",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "toBinArray",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "binId",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "setPreActivationDuration",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "preActivationDuration",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "setPreActivationSwapAddress",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "preActivationSwapAddress",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "setPairStatusPermissionless",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "status",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "initializeTokenBadge",
-      "accounts": [
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "createClaimProtocolFeeOperator",
-      "accounts": [
-        {
-          "name": "claimFeeOperator",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "operator",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closeClaimProtocolFeeOperator",
-      "accounts": [
-        {
-          "name": "claimFeeOperator",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializePresetParameter2",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ix",
-          "type": {
-            "defined": "InitPresetParameters2Ix"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeLbPair2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "presetParameter",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "InitializeLbPair2Params"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeCustomizablePermissionlessLbPair2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CustomizableParams"
-          }
-        }
-      ]
-    },
-    {
-      "name": "claimFee2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "minBinId",
-          "type": "i32"
-        },
-        {
-          "name": "maxBinId",
-          "type": "i32"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "claimReward2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "minBinId",
-          "type": "i32"
-        },
-        {
-          "name": "maxBinId",
-          "type": "i32"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidity2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameter"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategy2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategy"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSidePrecise2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "AddLiquiditySingleSidePreciseParameter2"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidity2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "binLiquidityRemoval",
-          "type": {
-            "vec": {
-              "defined": "BinLiquidityReduction"
-            }
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidityByRange2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "fromBinId",
-          "type": "i32"
-        },
-        {
-          "name": "toBinId",
-          "type": "i32"
-        },
-        {
-          "name": "bpsToRemove",
-          "type": "u16"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
         }
       ]
     },
     {
       "name": "swap2",
+      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "minAmountOut",
+          "name": "min_amount_out",
           "type": "u64"
         },
         {
-          "name": "remainingAccountsInfo",
+          "name": "remaining_accounts_info",
           "type": {
-            "defined": "RemainingAccountsInfo"
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
           }
         }
       ]
     },
     {
-      "name": "swapExactOut2",
+      "name": "swap_exact_out",
+      "discriminator": [250, 73, 101, 33, 38, 207, 75, 184],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "maxInAmount",
+          "name": "max_in_amount",
           "type": "u64"
         },
         {
-          "name": "outAmount",
+          "name": "out_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "swap_exact_out2",
+      "discriminator": [43, 215, 247, 132, 137, 60, 243, 81],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_in",
+          "writable": true
+        },
+        {
+          "name": "user_token_out",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_in_amount",
           "type": "u64"
         },
         {
-          "name": "remainingAccountsInfo",
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
           "type": {
-            "defined": "RemainingAccountsInfo"
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
           }
         }
       ]
     },
     {
-      "name": "swapWithPriceImpact2",
+      "name": "swap_with_price_impact",
+      "discriminator": [56, 173, 230, 208, 173, 228, 156, 205],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "activeId",
+          "name": "active_id",
           "type": {
             "option": "i32"
           }
         },
         {
-          "name": "maxPriceImpactBps",
+          "name": "max_price_impact_bps",
           "type": "u16"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
         }
       ]
     },
     {
-      "name": "closePosition2",
+      "name": "swap_with_price_impact2",
+      "discriminator": [74, 98, 192, 214, 177, 51, 75, 51],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateFeesAndReward2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "minBinId",
+          "name": "amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "active_id",
+          "type": {
+            "option": "i32"
+          }
+        },
+        {
+          "name": "max_price_impact_bps",
+          "type": "u16"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_base_fee_parameters",
+      "discriminator": [75, 168, 223, 161, 16, 195, 3, 47],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_parameter",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_dynamic_fee_parameters",
+      "discriminator": [92, 161, 46, 246, 255, 189, 22, 22],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_parameter",
+          "type": {
+            "defined": {
+              "name": "DynamicFeeParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_fees_and_reward2",
+      "discriminator": [32, 142, 184, 154, 103, 65, 184, 88],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "owner",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "min_bin_id",
           "type": "i32"
         },
         {
-          "name": "maxBinId",
+          "name": "max_bin_id",
           "type": "i32"
         }
       ]
     },
     {
-      "name": "closePositionIfEmpty",
+      "name": "update_fees_and_rewards",
+      "discriminator": [154, 230, 250, 13, 236, 209, 75, 223],
       "accounts": [
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true
         },
         {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
         },
         {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
+          "name": "bin_array_lower",
+          "writable": true
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "bin_array_upper",
+          "writable": true
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner",
+          "signer": true
         }
       ],
       "args": []
+    },
+    {
+      "name": "update_position_operator",
+      "discriminator": [202, 184, 103, 143, 180, 191, 116, 217],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "operator",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_duration",
+      "discriminator": [138, 174, 196, 169, 213, 235, 254, 107],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "new_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_funder",
+      "discriminator": [211, 28, 48, 32, 215, 160, 35, 23],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "new_funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_ineligible_reward",
+      "discriminator": [148, 206, 42, 195, 247, 49, 103, 8],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fee",
+      "discriminator": [158, 201, 158, 189, 33, 93, 162, 103],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "receiver_token_x",
+          "writable": true
+        },
+        {
+          "name": "receiver_token_y",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": ["operator"],
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_x",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_y",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "discriminator": [213, 155, 187, 34, 56, 182, 91, 240],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": ["operator"],
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
     }
   ],
   "accounts": [
     {
-      "name": "BinArrayBitmapExtension",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "type": "publicKey"
-          },
-          {
-            "name": "positiveBinArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state for start_bin_index is positive"
-            ],
-            "type": {
-              "array": [
-                {
-                  "array": [
-                    "u64",
-                    8
-                  ]
-                },
-                12
-              ]
-            }
-          },
-          {
-            "name": "negativeBinArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state for start_bin_index is negative"
-            ],
-            "type": {
-              "array": [
-                {
-                  "array": [
-                    "u64",
-                    8
-                  ]
-                },
-                12
-              ]
-            }
-          }
-        ]
-      }
+      "name": "BinArray",
+      "discriminator": [92, 142, 92, 220, 5, 148, 70, 181]
     },
     {
-      "name": "BinArray",
-      "docs": [
-        "An account to contain a range of bin. For example: Bin 100 <-> 200.",
-        "For example:",
-        "BinArray index: 0 contains bin 0 <-> 599",
-        "index: 2 contains bin 600 <-> 1199, ..."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "index",
-            "type": "i64"
-          },
-          {
-            "name": "version",
-            "docs": [
-              "Version of binArray"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
-          },
-          {
-            "name": "lbPair",
-            "type": "publicKey"
-          },
-          {
-            "name": "bins",
-            "type": {
-              "array": [
-                {
-                  "defined": "Bin"
-                },
-                70
-              ]
-            }
-          }
-        ]
-      }
+      "name": "BinArrayBitmapExtension",
+      "discriminator": [80, 111, 124, 113, 55, 237, 18, 5]
     },
     {
       "name": "ClaimFeeOperator",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "operator",
-            "docs": [
-              "operator"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Reserve"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [166, 48, 134, 86, 34, 200, 188, 150]
+    },
+    {
+      "name": "DummyZcAccount",
+      "discriminator": [94, 107, 238, 80, 208, 48, 180, 8]
     },
     {
       "name": "LbPair",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "parameters",
-            "type": {
-              "defined": "StaticParameters"
-            }
-          },
-          {
-            "name": "vParameters",
-            "type": {
-              "defined": "VariableParameters"
-            }
-          },
-          {
-            "name": "bumpSeed",
-            "type": {
-              "array": [
-                "u8",
-                1
-              ]
-            }
-          },
-          {
-            "name": "binStepSeed",
-            "docs": [
-              "Bin step signer seed"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "pairType",
-            "docs": [
-              "Type of the pair"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "status",
-            "docs": [
-              "Status of the pair. Check PairStatus enum."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "requireBaseFactorSeed",
-            "docs": [
-              "Require base factor seed"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "baseFactorSeed",
-            "docs": [
-              "Base factor seed"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "creatorPoolOnOffControl",
-            "docs": [
-              "Allow pool creator to enable/disable pool with restricted validation. Only applicable for customizable permissionless pair type."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "tokenXMint",
-            "docs": [
-              "Token X mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenYMint",
-            "docs": [
-              "Token Y mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserveX",
-            "docs": [
-              "LB token X vault"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserveY",
-            "docs": [
-              "LB token Y vault"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "protocolFee",
-            "docs": [
-              "Uncollected protocol fee"
-            ],
-            "type": {
-              "defined": "ProtocolFee"
-            }
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "_padding_1, previous Fee owner, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "RewardInfo"
-                },
-                2
-              ]
-            }
-          },
-          {
-            "name": "oracle",
-            "docs": [
-              "Oracle pubkey"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "binArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                16
-              ]
-            }
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last time the pool fee parameter was updated"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "padding2",
-            "docs": [
-              "_padding_2, previous whitelisted_wallet, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "preActivationSwapAddress",
-            "docs": [
-              "Address allowed to swap when the current point is greater than or equal to the pre-activation point. The pre-activation point is calculated as `activation_point - pre_activation_duration`."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "baseKey",
-            "docs": [
-              "Base keypair. Only required for permission pair"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "activationPoint",
-            "docs": [
-              "Time point to enable the pair. Only applicable for permission pair."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "preActivationDuration",
-            "docs": [
-              "Duration before activation activation_point. Used to calculate pre-activation time point for pre_activation_swap_address"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding3",
-            "docs": [
-              "_padding 3 is reclaimed free space from swap_cap_deactivate_point and swap_cap_amount before, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          },
-          {
-            "name": "padding4",
-            "docs": [
-              "_padding_4, previous lock_duration, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "creator",
-            "docs": [
-              "Pool creator"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenMintXProgramFlag",
-            "docs": [
-              "token_mint_x_program_flag"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "tokenMintYProgramFlag",
-            "docs": [
-              "token_mint_y_program_flag"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                22
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [33, 11, 49, 98, 181, 101, 177, 13]
+    },
+    {
+      "name": "LimitOrder",
+      "discriminator": [137, 183, 212, 91, 115, 29, 141, 227]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [219, 31, 188, 145, 69, 139, 204, 117]
     },
     {
       "name": "Oracle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "idx",
-            "docs": [
-              "Index of latest observation"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeSize",
-            "docs": [
-              "Size of active sample. Active sample is initialized observation."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "length",
-            "docs": [
-              "Number of observations"
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "docs": [
-              "The LB pair of this position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner of the position. Client rely on this to to fetch their positions."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidityShares",
-            "docs": [
-              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
-            ],
-            "type": {
-              "array": [
-                "u64",
-                70
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "UserRewardInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "feeInfos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "FeeInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "lowerBinId",
-            "docs": [
-              "Lower bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "upperBinId",
-            "docs": [
-              "Upper bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last updated timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "totalClaimedFeeXAmount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedFeeYAmount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedRewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                160
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [139, 194, 131, 179, 140, 179, 229, 244]
     },
     {
       "name": "PositionV2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "docs": [
-              "The LB pair of this position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner of the position. Client rely on this to to fetch their positions."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidityShares",
-            "docs": [
-              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
-            ],
-            "type": {
-              "array": [
-                "u128",
-                70
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "UserRewardInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "feeInfos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "FeeInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "lowerBinId",
-            "docs": [
-              "Lower bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "upperBinId",
-            "docs": [
-              "Upper bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last updated timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "totalClaimedFeeXAmount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedFeeYAmount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedRewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          },
-          {
-            "name": "operator",
-            "docs": [
-              "Operator of position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "lockReleasePoint",
-            "docs": [
-              "Time point which the locked liquidity can be withdraw"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding0",
-            "docs": [
-              "_padding_0, previous subjected_to_bootstrap_liquidity_locking, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "feeOwner",
-            "docs": [
-              "Address is able to claim fee in this position, only valid for bootstrap_liquidity_position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                87
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PresetParameter2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "index",
-            "docs": [
-              "index"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding0",
-            "docs": [
-              "Padding 0 for future use"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "Padding 1 for future use"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                20
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [117, 176, 212, 199, 245, 180, 133, 182]
     },
     {
       "name": "PresetParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "minBinId",
-            "docs": [
-              "Min bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "Max bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
+      "discriminator": [242, 62, 244, 34, 181, 112, 58, 170]
+    },
+    {
+      "name": "PresetParameter2",
+      "discriminator": [171, 236, 148, 115, 162, 113, 222, 174]
     },
     {
       "name": "TokenBadge",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenMint",
-            "docs": [
-              "token mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Reserve"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "InitPresetParameters2Ix",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "index",
-            "type": "u16"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitPresetParametersIx",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BaseFeeParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Base factor for base fee rate"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "DynamicFeeParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByStrategyOneSide",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyParameters",
-            "docs": [
-              "strategy parameters"
-            ],
-            "type": {
-              "defined": "StrategyParameters"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByStrategy",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyParameters",
-            "docs": [
-              "strategy parameters"
-            ],
-            "type": {
-              "defined": "StrategyParameters"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "StrategyParameters",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "minBinId",
-            "docs": [
-              "min bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "max bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyType",
-            "docs": [
-              "strategy type"
-            ],
-            "type": {
-              "defined": "StrategyType"
-            }
-          },
-          {
-            "name": "parameteres",
-            "docs": [
-              "parameters"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityOneSideParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistributionByWeight"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityDistributionByWeight",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "weight",
-            "docs": [
-              "weight of liquidity distributed for this bin id"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByWeight",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistributionByWeight"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AddLiquiditySingleSidePreciseParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "bins",
-            "type": {
-              "vec": {
-                "defined": "CompressedBinDepositAmount"
-              }
-            }
-          },
-          {
-            "name": "decompressMultiplier",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CompressedBinDepositAmount",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "amount",
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityDistribution",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "distributionX",
-            "docs": [
-              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "distributionY",
-            "docs": [
-              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistribution"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "CustomizableParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "docs": [
-              "Pool price"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Base factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type. 0 = Slot, 1 = Time. Check ActivationType enum"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "hasAlphaVault",
-            "docs": [
-              "Whether the pool has an alpha vault"
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "activationPoint",
-            "docs": [
-              "Decide when does the pool start trade. None = Now"
-            ],
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
-            "name": "creatorPoolOnOffControl",
-            "docs": [
-              "Pool creator have permission to enable/disable pool with restricted program validation. Only applicable for customizable permissionless pool."
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                62
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitPermissionPairIx",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "type": "u8"
-          },
-          {
-            "name": "activationType",
-            "type": "u8"
-          },
-          {
-            "name": "protocolShare",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AddLiquiditySingleSidePreciseParameter2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "bins",
-            "type": {
-              "vec": {
-                "defined": "CompressedBinDepositAmount"
-              }
-            }
-          },
-          {
-            "name": "decompressMultiplier",
-            "type": "u64"
-          },
-          {
-            "name": "maxAmount",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CompressedBinDepositAmount2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "amount",
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitializeLbPair2Params",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "docs": [
-              "Pool price"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                96
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityReduction",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "bpsToRemove",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Bin",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of token X in the bin. This already excluded protocol fees."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of token Y in the bin. This already excluded protocol fees."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "price",
-            "docs": [
-              "Bin price"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "liquiditySupply",
-            "docs": [
-              "Liquidities of the bin. This is the same as LP mint supply. q-number"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "rewardPerTokenStored",
-            "docs": [
-              "reward_a_per_token_stored"
-            ],
-            "type": {
-              "array": [
-                "u128",
-                2
-              ]
-            }
-          },
-          {
-            "name": "feeAmountXPerTokenStored",
-            "docs": [
-              "Swap fee amount of token X per liquidity deposited."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "feeAmountYPerTokenStored",
-            "docs": [
-              "Swap fee amount of token Y per liquidity deposited."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "amountXIn",
-            "docs": [
-              "Total token X swap into the bin. Only used for tracking purpose."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "amountYIn",
-            "docs": [
-              "Total token Y swap into he bin. Only used for tracking purpose."
-            ],
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ProtocolFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RewardInfo",
-      "docs": [
-        "Stores the state relevant for tracking liquidity mining rewards"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mint",
-            "docs": [
-              "Reward token mint."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "vault",
-            "docs": [
-              "Reward vault token account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "funder",
-            "docs": [
-              "Authority account that allows to fund rewards"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardDuration",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "rewardDurationEnd",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "rewardRate",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "lastUpdateTime",
-            "docs": [
-              "The last time reward states were updated."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "cumulativeSecondsWithEmptyLiquidityReward",
-            "docs": [
-              "Accumulated seconds where when farm distribute rewards, but the bin is empty. The reward will be accumulated for next reward time window."
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Observation",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "cumulativeActiveBinId",
-            "docs": [
-              "Cumulative active bin ID"
-            ],
-            "type": "i128"
-          },
-          {
-            "name": "createdAt",
-            "docs": [
-              "Observation sample created timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Observation sample last updated timestamp"
-            ],
-            "type": "i64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "StaticParameters",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "minBinId",
-            "docs": [
-              "Min bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "Max bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                5
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "VariableParameters",
-      "docs": [
-        "Parameters that changes based on dynamic of the market"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "volatilityAccumulator",
-            "docs": [
-              "Volatility accumulator measure the number of bin crossed since reference bin ID. Normally (without filter period taken into consideration), reference bin ID is the active bin of last swap.",
-              "It affects the variable fee rate"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "volatilityReference",
-            "docs": [
-              "Volatility reference is decayed volatility accumulator. It is always <= volatility_accumulator"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "indexReference",
-            "docs": [
-              "Active bin id of last swap."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                4
-              ]
-            }
-          },
-          {
-            "name": "lastUpdateTimestamp",
-            "docs": [
-              "Last timestamp the variable parameters was updated"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeXPerTokenComplete",
-            "type": "u128"
-          },
-          {
-            "name": "feeYPerTokenComplete",
-            "type": "u128"
-          },
-          {
-            "name": "feeXPending",
-            "type": "u64"
-          },
-          {
-            "name": "feeYPending",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UserRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "rewardPerTokenCompletes",
-            "type": {
-              "array": [
-                "u128",
-                2
-              ]
-            }
-          },
-          {
-            "name": "rewardPendings",
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsSlice",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "accountsType",
-            "type": {
-              "defined": "AccountsType"
-            }
-          },
-          {
-            "name": "length",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slices",
-            "type": {
-              "vec": {
-                "defined": "RemainingAccountsSlice"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "StrategyType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "SpotOneSide"
-          },
-          {
-            "name": "CurveOneSide"
-          },
-          {
-            "name": "BidAskOneSide"
-          },
-          {
-            "name": "SpotBalanced"
-          },
-          {
-            "name": "CurveBalanced"
-          },
-          {
-            "name": "BidAskBalanced"
-          },
-          {
-            "name": "SpotImBalanced"
-          },
-          {
-            "name": "CurveImBalanced"
-          },
-          {
-            "name": "BidAskImBalanced"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Rounding",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Up"
-          },
-          {
-            "name": "Down"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ActivationType",
-      "docs": [
-        "Type of the activation"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Slot"
-          },
-          {
-            "name": "Timestamp"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LayoutVersion",
-      "docs": [
-        "Layout version"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V0"
-          },
-          {
-            "name": "V1"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PairType",
-      "docs": [
-        "Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permissionless"
-          },
-          {
-            "name": "Permission"
-          },
-          {
-            "name": "CustomizablePermissionless"
-          },
-          {
-            "name": "PermissionlessV2"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PairStatus",
-      "docs": [
-        "Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Enabled"
-          },
-          {
-            "name": "Disabled"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenProgramFlags",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TokenProgram"
-          },
-          {
-            "name": "TokenProgram2022"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AccountsType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TransferHookX"
-          },
-          {
-            "name": "TransferHookY"
-          },
-          {
-            "name": "TransferHookReward"
-          }
-        ]
-      }
+      "discriminator": [116, 219, 204, 229, 249, 116, 255, 150]
     }
   ],
   "events": [
     {
-      "name": "CompositionFee",
-      "fields": [
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "binId",
-          "type": "i16",
-          "index": false
-        },
-        {
-          "name": "tokenXFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenYFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTokenXFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTokenYFeeAmount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
       "name": "AddLiquidity",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amounts",
-          "type": {
-            "array": [
-              "u64",
-              2
-            ]
-          },
-          "index": false
-        },
-        {
-          "name": "activeBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
+      "discriminator": [31, 94, 125, 90, 227, 52, 61, 186]
     },
     {
-      "name": "RemoveLiquidity",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amounts",
-          "type": {
-            "array": [
-              "u64",
-              2
-            ]
-          },
-          "index": false
-        },
-        {
-          "name": "activeBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "Swap",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "startBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "endBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "amountIn",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amountOut",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "swapForY",
-          "type": "bool",
-          "index": false
-        },
-        {
-          "name": "fee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeBps",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "hostFee",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "ClaimReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "totalReward",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "FundReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "funder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "InitializeReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "funder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "rewardDuration",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdateRewardDuration",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldRewardDuration",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "newRewardDuration",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdateRewardFunder",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldFunder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newFunder",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "PositionClose",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "CancelLimitOrderEvt",
+      "discriminator": [131, 234, 194, 133, 9, 14, 189, 209]
     },
     {
       "name": "ClaimFee",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "feeX",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeY",
-          "type": "u64",
-          "index": false
-        }
-      ]
+      "discriminator": [75, 122, 154, 48, 140, 74, 123, 163]
     },
     {
-      "name": "LbPairCreate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "binStep",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "tokenX",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenY",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "ClaimFee2",
+      "discriminator": [232, 171, 242, 97, 58, 77, 35, 45]
     },
     {
-      "name": "PositionCreate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "ClaimReward",
+      "discriminator": [148, 116, 134, 204, 22, 171, 85, 95]
     },
     {
-      "name": "IncreasePositionLength",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "lengthToAdd",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "side",
-          "type": "u8",
-          "index": false
-        }
-      ]
+      "name": "ClaimReward2",
+      "discriminator": [27, 143, 244, 33, 80, 43, 110, 146]
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "discriminator": [142, 135, 8, 76, 92, 63, 118, 83]
+    },
+    {
+      "name": "CompositionFee",
+      "discriminator": [128, 151, 123, 106, 17, 102, 113, 142]
     },
     {
       "name": "DecreasePositionLength",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "lengthToRemove",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "side",
-          "type": "u8",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "FeeParameterUpdate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "protocolShare",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "baseFactor",
-          "type": "u16",
-          "index": false
-        }
-      ]
+      "discriminator": [52, 118, 235, 85, 172, 169, 15, 128]
     },
     {
       "name": "DynamicFeeParameterUpdate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "filterPeriod",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "variableFeeControl",
-          "type": "u32",
-          "index": false
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32",
-          "index": false
-        }
-      ]
+      "discriminator": [88, 88, 178, 135, 194, 146, 91, 243]
     },
     {
-      "name": "IncreaseObservation",
-      "fields": [
-        {
-          "name": "oracle",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newObservationLength",
-          "type": "u64",
-          "index": false
-        }
-      ]
+      "name": "FeeParameterUpdate",
+      "discriminator": [48, 76, 241, 117, 144, 215, 242, 44]
     },
     {
-      "name": "WithdrawIneligibleReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdatePositionOperator",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "oldOperator",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newOperator",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdatePositionLockReleasePoint",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "currentPoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "newLockReleasePoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldLockReleasePoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "sender",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "FundReward",
+      "discriminator": [246, 228, 58, 130, 145, 170, 79, 204]
     },
     {
       "name": "GoToABin",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "fromBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "toBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
+      "discriminator": [59, 138, 76, 68, 138, 131, 176, 67]
+    },
+    {
+      "name": "IncreaseObservation",
+      "discriminator": [99, 249, 17, 121, 166, 156, 207, 215]
+    },
+    {
+      "name": "IncreasePositionLength",
+      "discriminator": [157, 239, 42, 204, 30, 56, 223, 46]
+    },
+    {
+      "name": "InitializeReward",
+      "discriminator": [211, 153, 88, 62, 149, 60, 177, 70]
+    },
+    {
+      "name": "LbPairCreate",
+      "discriminator": [185, 74, 252, 125, 27, 215, 188, 111]
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "discriminator": [43, 79, 27, 169, 244, 28, 225, 63]
+    },
+    {
+      "name": "PositionClose",
+      "discriminator": [255, 196, 16, 107, 28, 202, 53, 128]
+    },
+    {
+      "name": "PositionCreate",
+      "discriminator": [144, 142, 252, 84, 157, 53, 37, 121]
+    },
+    {
+      "name": "Rebalancing",
+      "discriminator": [0, 109, 117, 179, 61, 91, 199, 200]
+    },
+    {
+      "name": "RemoveLiquidity",
+      "discriminator": [116, 244, 97, 232, 103, 31, 152, 58]
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "discriminator": [195, 229, 147, 245, 29, 125, 48, 168]
+    },
+    {
+      "name": "Swap",
+      "discriminator": [81, 108, 227, 190, 205, 208, 10, 196]
+    },
+    {
+      "name": "Swap2Evt",
+      "discriminator": [46, 116, 82, 215, 148, 27, 84, 77]
+    },
+    {
+      "name": "UpdatePositionLockReleasePoint",
+      "discriminator": [133, 214, 66, 224, 64, 12, 7, 191]
+    },
+    {
+      "name": "UpdatePositionOperator",
+      "discriminator": [39, 115, 48, 204, 246, 47, 66, 57]
+    },
+    {
+      "name": "UpdateRewardDuration",
+      "discriminator": [223, 245, 224, 153, 49, 29, 163, 172]
+    },
+    {
+      "name": "UpdateRewardFunder",
+      "discriminator": [224, 178, 174, 74, 252, 165, 85, 180]
+    },
+    {
+      "name": "WithdrawIneligibleReward",
+      "discriminator": [231, 189, 65, 149, 102, 215, 154, 244]
     }
   ],
   "errors": [
@@ -7364,6 +5633,3599 @@
       "code": 6082,
       "name": "NotSupportAtTheMoment",
       "msg": "Not support at the moment"
+    },
+    {
+      "code": 6083,
+      "name": "InvalidRebalanceParameters",
+      "msg": "Invalid rebalance parameters"
+    },
+    {
+      "code": 6084,
+      "name": "InvalidRewardAccounts",
+      "msg": "Invalid reward accounts"
+    },
+    {
+      "code": 6085,
+      "name": "UndeterminedError",
+      "msg": "Undetermined error"
+    },
+    {
+      "code": 6086,
+      "name": "ReallocExceedMaxLengthPerInstruction",
+      "msg": "Realloc exceed max length per instruction"
+    },
+    {
+      "code": 6087,
+      "name": "InvalidBaseFeeMantissa",
+      "msg": "Mantissa cannot more than two significant digits"
+    },
+    {
+      "code": 6088,
+      "name": "InvalidPositionOwner",
+      "msg": "Invalid position owner"
+    },
+    {
+      "code": 6089,
+      "name": "InvalidPoolAddress",
+      "msg": "Invalid pool address"
+    },
+    {
+      "code": 6090,
+      "name": "InvalidTokenBadgeType",
+      "msg": "Invalid token badge type"
+    },
+    {
+      "code": 6091,
+      "name": "InvalidTransferHookAuthority",
+      "msg": "Invalid transfer hook authority"
+    },
+    {
+      "code": 6092,
+      "name": "AmountXIsNegative",
+      "msg": "Amount x is negative"
+    },
+    {
+      "code": 6093,
+      "name": "AmountYIsNegative",
+      "msg": "Amount y is negative"
+    },
+    {
+      "code": 6094,
+      "name": "InvalidPoolCreator",
+      "msg": "Invalid pool creator"
+    },
+    {
+      "code": 6095,
+      "name": "InvalidFunctionType",
+      "msg": "Invalid function type"
+    },
+    {
+      "code": 6096,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6097,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6098,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6099,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6100,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6101,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6102,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6103,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6104,
+      "name": "InsufficientInAmount",
+      "msg": "Insufficient in amount"
+    },
+    {
+      "code": 6105,
+      "name": "InvalidPlaceLimitOrderParameters",
+      "msg": "Invalid place limit order parameters"
+    },
+    {
+      "code": 6106,
+      "name": "InvalidLimitOrderOwner",
+      "msg": "Invalid limit order owner"
+    },
+    {
+      "code": 6107,
+      "name": "InvalidCancelLimitOrderParameters",
+      "msg": "Invalid cancel limit order parameters"
+    },
+    {
+      "code": 6108,
+      "name": "CannotFindLimitOrderByBinId",
+      "msg": "Cannot find limit order by bin id"
+    },
+    {
+      "code": 6109,
+      "name": "CancelNonEmptyLimitOrder",
+      "msg": "Cannot cancel non-empty limit order"
+    },
+    {
+      "code": 6110,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccountsType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookX"
+          },
+          {
+            "name": "TransferHookY"
+          },
+          {
+            "name": "TransferHookReward"
+          },
+          {
+            "name": "TransferHookMultiReward",
+            "fields": ["u8"]
+          },
+          {
+            "name": "TransferHookReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ActivationType",
+      "docs": ["Type of the activation"],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Slot"
+          },
+          {
+            "name": "Timestamp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_delta_id",
+            "type": "i32"
+          },
+          {
+            "name": "max_delta_id",
+            "type": "i32"
+          },
+          {
+            "name": "x0",
+            "type": "u64"
+          },
+          {
+            "name": "y0",
+            "type": "u64"
+          },
+          {
+            "name": "delta_x",
+            "type": "u64"
+          },
+          {
+            "name": "delta_y",
+            "type": "u64"
+          },
+          {
+            "name": "bit_flag",
+            "type": "u8"
+          },
+          {
+            "name": "favor_x_in_active_id",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CompressedBinDepositAmount"
+                }
+              }
+            }
+          },
+          {
+            "name": "decompress_multiplier",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CompressedBinDepositAmount"
+                }
+              }
+            }
+          },
+          {
+            "name": "decompress_multiplier",
+            "type": "u64"
+          },
+          {
+            "name": "max_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": ["Base factor for base fee rate"],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bin",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": [
+              "Amount of token X in the bin for market making. This already excluded protocol fees."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": [
+              "Amount of token Y in the bin for market making. This already excluded protocol fees."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price",
+            "docs": ["Bin price"],
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_supply",
+            "docs": ["Bin MM liquidity supply."],
+            "type": "u128"
+          },
+          {
+            "name": "fulfilled_order_amount_x",
+            "docs": ["Total fulfilled order amount x"],
+            "type": "u64"
+          },
+          {
+            "name": "fulfilled_order_amount_y",
+            "docs": ["Total fulfilled order amount y"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_ask_side",
+            "docs": ["Limit order fee collected by ask side orders"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_bid_side",
+            "docs": ["Limit order fee collected by bid side orders"],
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount_x_per_token_stored",
+            "docs": ["Swap fee amount of token X per liquidity deposited."],
+            "type": "u128"
+          },
+          {
+            "name": "fee_amount_y_per_token_stored",
+            "docs": ["Swap fee amount of token Y per liquidity deposited."],
+            "type": "u128"
+          },
+          {
+            "name": "open_order_amount",
+            "docs": ["Pending open limit orders amount in the bin."],
+            "type": "u64"
+          },
+          {
+            "name": "total_processing_order_amount",
+            "docs": ["Total processing order amount"],
+            "type": "u64"
+          },
+          {
+            "name": "processed_order_remaining_amount",
+            "docs": [
+              "Remaining in processing open limit orders amount in the bin."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "order_age",
+            "docs": ["Age"],
+            "type": "u32"
+          },
+          {
+            "name": "limit_order_ask_side",
+            "docs": ["limit order flag"],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["padding"],
+            "type": {
+              "array": ["u8", 3]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinArray",
+      "docs": [
+        "An account to contain a range of bin. For example: Bin 100 <-> 200.",
+        "For example:",
+        "BinArray index: 0 contains bin 0 <-> 599",
+        "index: 2 contains bin 600 <-> 1199, ..."
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "i64"
+          },
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "bins",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Bin"
+                  }
+                },
+                70
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinArrayBitmapExtension",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "positive_bin_array_bitmap",
+            "docs": [
+              "Packed initialized bin array state for start_bin_index is positive"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 8]
+                },
+                12
+              ]
+            }
+          },
+          {
+            "name": "negative_bin_array_bitmap",
+            "docs": [
+              "Packed initialized bin array state for start_bin_index is negative"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 8]
+                },
+                12
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLimitOrderAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "i32"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityDistribution",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "docs": ["Define the bin ID wish to deposit to."],
+            "type": "i32"
+          },
+          {
+            "name": "distribution_x",
+            "docs": [
+              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "distribution_y",
+            "docs": [
+              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityDistributionByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "docs": ["Define the bin ID wish to deposit to."],
+            "type": "i32"
+          },
+          {
+            "name": "weight",
+            "docs": ["weight of liquidity distributed for this bin id"],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityReduction",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "bps_to_remove",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CancelLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": "i32"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_x",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_x",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y",
+            "type": "u64"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFeeOperator",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "docs": ["operator"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Reserve"],
+            "type": {
+              "array": ["u8", 128]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimReward2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CompositionFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_id",
+            "type": "i16"
+          },
+          {
+            "name": "token_x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_y_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_token_x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_token_y_fee_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CompressedBinDepositAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "amount",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Pool price"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step"],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": ["Base factor"],
+            "type": "u16"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type. 0 = Slot, 1 = Time. Check ActivationType enum"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": ["Whether the pool has an alpha vault"],
+            "type": "bool"
+          },
+          {
+            "name": "activation_point",
+            "docs": ["Decide when does the pool start trade. None = Now"],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "creator_pool_on_off_control",
+            "docs": [
+              "Pool creator have permission to enable/disable pool with restricted program validation. Only applicable for customizable permissionless pool."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": ["Concrete function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["Collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": ["Padding, for future use"],
+            "type": {
+              "array": ["u8", 60]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DecreasePositionLength",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "length_to_remove",
+            "type": "u16"
+          },
+          {
+            "name": "side",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DummyIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "_pair_status",
+            "type": {
+              "defined": {
+                "name": "PairStatus"
+              }
+            }
+          },
+          {
+            "name": "_pair_type",
+            "type": {
+              "defined": {
+                "name": "PairType"
+              }
+            }
+          },
+          {
+            "name": "_activation_type",
+            "type": {
+              "defined": {
+                "name": "ActivationType"
+              }
+            }
+          },
+          {
+            "name": "_token_program_flag",
+            "type": {
+              "defined": {
+                "name": "TokenProgramFlags"
+              }
+            }
+          },
+          {
+            "name": "_resize_side",
+            "type": {
+              "defined": {
+                "name": "ResizeSide"
+              }
+            }
+          },
+          {
+            "name": "_rounding",
+            "type": {
+              "defined": {
+                "name": "Rounding"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DummyZcAccount",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_bin_data",
+            "type": {
+              "defined": {
+                "name": "PositionBinData"
+              }
+            }
+          },
+          {
+            "name": "limit_order_bin_data",
+            "type": {
+              "defined": {
+                "name": "LimitOrderBinData"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameterUpdate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_x_per_token_complete",
+            "type": "u128"
+          },
+          {
+            "name": "fee_y_per_token_complete",
+            "type": "u128"
+          },
+          {
+            "name": "fee_x_pending",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y_pending",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeParameterUpdate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_share",
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FundReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GoToABin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "to_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreaseObservation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_observation_length",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreasePositionLength",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "length_to_add",
+            "type": "u16"
+          },
+          {
+            "name": "side",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPermissionPairIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": "u16"
+          },
+          {
+            "name": "concrete_function_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPresetParametersIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": ["function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["collect fee mode"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeLbPair2Params",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Pool price"],
+            "type": "i32"
+          },
+          {
+            "name": "padding",
+            "docs": ["Padding, for future use"],
+            "type": {
+              "array": ["u8", 96]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LbPair",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "parameters",
+            "type": {
+              "defined": {
+                "name": "StaticParameters"
+              }
+            }
+          },
+          {
+            "name": "v_parameters",
+            "type": {
+              "defined": {
+                "name": "VariableParameters"
+              }
+            }
+          },
+          {
+            "name": "bump_seed",
+            "type": {
+              "array": ["u8", 1]
+            }
+          },
+          {
+            "name": "bin_step_seed",
+            "docs": ["Bin step signer seed"],
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "pair_type",
+            "docs": ["Type of the pair"],
+            "type": "u8"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": ["Status of the pair. Check PairStatus enum."],
+            "type": "u8"
+          },
+          {
+            "name": "require_base_factor_seed",
+            "docs": ["Require base factor seed"],
+            "type": "u8"
+          },
+          {
+            "name": "base_factor_seed",
+            "docs": ["Base factor seed"],
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "activation_type",
+            "docs": ["Activation type"],
+            "type": "u8"
+          },
+          {
+            "name": "creator_pool_on_off_control",
+            "docs": [
+              "Allow pool creator to enable/disable pool with restricted validation. Only applicable for customizable permissionless pair type."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_x_mint",
+            "docs": ["Token X mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_y_mint",
+            "docs": ["Token Y mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserve_x",
+            "docs": ["LB token X vault"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserve_y",
+            "docs": ["LB token Y vault"],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee",
+            "docs": ["Uncollected protocol fee"],
+            "type": {
+              "defined": {
+                "name": "ProtocolFee"
+              }
+            }
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["padding 1"],
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "reward_infos",
+            "docs": ["Farming reward information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RewardInfo"
+                  }
+                },
+                2
+              ]
+            }
+          },
+          {
+            "name": "oracle",
+            "docs": ["Oracle pubkey"],
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_array_bitmap",
+            "docs": ["Packed initialized bin array state"],
+            "type": {
+              "array": ["u64", 16]
+            }
+          },
+          {
+            "name": "last_updated_at",
+            "docs": ["Last time the pool fee parameter was updated"],
+            "type": "i64"
+          },
+          {
+            "name": "_padding_2",
+            "docs": ["_padding_2"],
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "pre_activation_swap_address",
+            "docs": [
+              "Address allowed to swap when the current point is greater than or equal to the pre-activation point. The pre-activation point is calculated as `activation_point - pre_activation_duration`."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_key",
+            "docs": ["Base keypair. Only required for permission pair"],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "Time point to enable the pair. Only applicable for permission pair."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pre_activation_duration",
+            "docs": [
+              "Duration before activation activation_point. Used to calculate pre-activation time point for pre_activation_swap_address"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_3",
+            "docs": ["_padding 3"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "_padding_4",
+            "docs": ["_padding_4"],
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "docs": ["Pool creator"],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint_x_program_flag",
+            "docs": ["token_mint_x_program_flag"],
+            "type": "u8"
+          },
+          {
+            "name": "token_mint_y_program_flag",
+            "docs": ["token_mint_y_program_flag"],
+            "type": "u8"
+          },
+          {
+            "name": "version",
+            "docs": ["version to know whether we have reset tombstone fields"],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u8", 21]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LbPairCreate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "token_x",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_y",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrder",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "docs": ["The LB pair of this LO"],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the LO. Client rely on this to to fetch their LOs."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_count",
+            "docs": ["Bin count"],
+            "type": "u16"
+          },
+          {
+            "name": "_padding_0",
+            "docs": ["Padding"],
+            "type": {
+              "array": ["u8", 14]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u64", 4]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrderBinData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "age",
+            "type": "u32"
+          },
+          {
+            "name": "_padding_0",
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "is_ask",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": ["u8", 11]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityOneSideParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": ["Amount of X token or Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistributionByWeight"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistribution"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategy",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_parameters",
+            "docs": ["strategy parameters"],
+            "type": {
+              "defined": {
+                "name": "StrategyParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategyOneSide",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": ["Amount of X token or Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_parameters",
+            "docs": ["strategy parameters"],
+            "type": {
+              "defined": {
+                "name": "StrategyParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistributionByWeight"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signer",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Oracle",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "idx",
+            "docs": ["Index of latest observation"],
+            "type": "u64"
+          },
+          {
+            "name": "active_size",
+            "docs": [
+              "Size of active sample. Active sample is initialized observation."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "length",
+            "docs": ["Number of observations"],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairStatus",
+      "docs": [
+        "Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility."
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Enabled"
+          },
+          {
+            "name": "Disabled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairType",
+      "docs": [
+        "Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility."
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Permissionless"
+          },
+          {
+            "name": "Permission"
+          },
+          {
+            "name": "CustomizablePermissionless"
+          },
+          {
+            "name": "PermissionlessV2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "sender",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "PlaceLimitOrderParams"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceLimitOrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_ask_side",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "relative_bin",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RelativeBin"
+                }
+              }
+            }
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLimitOrderAmount"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionBinData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidity_share",
+            "type": "u128"
+          },
+          {
+            "name": "reward_info",
+            "type": {
+              "defined": {
+                "name": "UserRewardInfo"
+              }
+            }
+          },
+          {
+            "name": "fee_info",
+            "type": {
+              "defined": {
+                "name": "FeeInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionClose",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionCreate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionV2",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "docs": ["The LB pair of this position"],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the position. Client rely on this to to fetch their positions."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_shares",
+            "docs": [
+              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
+            ],
+            "type": {
+              "array": ["u128", 70]
+            }
+          },
+          {
+            "name": "reward_infos",
+            "docs": ["Farming reward information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "UserRewardInfo"
+                  }
+                },
+                70
+              ]
+            }
+          },
+          {
+            "name": "fee_infos",
+            "docs": ["Swap fee to claim information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "FeeInfo"
+                  }
+                },
+                70
+              ]
+            }
+          },
+          {
+            "name": "lower_bin_id",
+            "docs": ["Lower bin ID"],
+            "type": "i32"
+          },
+          {
+            "name": "upper_bin_id",
+            "docs": ["Upper bin ID"],
+            "type": "i32"
+          },
+          {
+            "name": "last_updated_at",
+            "docs": ["Last updated timestamp"],
+            "type": "i64"
+          },
+          {
+            "name": "total_claimed_fee_x_amount",
+            "docs": ["Total claimed token fee X"],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_fee_y_amount",
+            "docs": ["Total claimed token fee Y"],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_rewards",
+            "docs": ["Total claimed rewards"],
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "operator",
+            "docs": ["Operator of position"],
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_release_point",
+            "docs": ["Time point which the locked liquidity can be withdraw"],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "_padding_0, previous subjected_to_bootstrap_liquidity_locking, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fee_owner",
+            "docs": [
+              "Address is able to claim fee in this position, only valid for bootstrap_liquidity_position"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "version",
+            "docs": ["version to know whether we have reset tombstone fields"],
+            "type": "u8"
+          },
+          {
+            "name": "permissionless_operation_bits",
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u8", 85]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PresetParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "min_bin_id",
+            "docs": [
+              "Min bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": [
+              "Max bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PresetParameter2",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "index",
+            "docs": ["index"],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": [
+              "function type, to check whether the pool should have LM farming or other functions in the future, refer ConcreteFunctionType"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": ["Padding 1 for future use"],
+            "type": {
+              "array": ["u64", 19]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolFee",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RebalanceLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["active id"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "u16"
+          },
+          {
+            "name": "should_claim_fee",
+            "docs": ["a flag to indicate that whether fee should be harvested"],
+            "type": "bool"
+          },
+          {
+            "name": "should_claim_reward",
+            "docs": [
+              "a flag to indicate that whether rewards should be harvested"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "min_withdraw_x_amount",
+            "docs": ["threshold for withdraw token x"],
+            "type": "u64"
+          },
+          {
+            "name": "max_deposit_x_amount",
+            "docs": ["threshold for deposit token x"],
+            "type": "u64"
+          },
+          {
+            "name": "min_withdraw_y_amount",
+            "docs": ["threshold for withdraw token y"],
+            "type": "u64"
+          },
+          {
+            "name": "max_deposit_y_amount",
+            "docs": ["threshold for deposit token y"],
+            "type": "u64"
+          },
+          {
+            "name": "shrink_mode",
+            "docs": ["shrink mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": ["padding 32 bytes for future usage"],
+            "type": {
+              "array": ["u8", 31]
+            }
+          },
+          {
+            "name": "removes",
+            "docs": ["removes"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemoveLiquidityParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "adds",
+            "docs": ["adds"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "AddLiquidityParams"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rebalancing",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "x_withdrawn_amount",
+            "type": "u64"
+          },
+          {
+            "name": "x_added_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_withdrawn_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_added_amount",
+            "type": "u64"
+          },
+          {
+            "name": "x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "old_min_id",
+            "type": "i32"
+          },
+          {
+            "name": "old_max_id",
+            "type": "i32"
+          },
+          {
+            "name": "new_min_id",
+            "type": "i32"
+          },
+          {
+            "name": "new_max_id",
+            "type": "i32"
+          },
+          {
+            "name": "rewards",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RelativeBin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": {
+              "defined": {
+                "name": "AccountsType"
+              }
+            }
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_bin_id",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "max_bin_id",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "bps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ResizeSide",
+      "docs": ["Side of resize, 0 for lower and 1 for upper"],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Lower"
+          },
+          {
+            "name": "Upper"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardInfo",
+      "docs": [
+        "Stores the state relevant for tracking liquidity mining rewards"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": ["Reward token mint."],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": ["Reward vault token account."],
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "docs": ["Authority account that allows to fund rewards"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_duration",
+            "docs": ["LM reward duration in seconds."],
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration_end",
+            "docs": ["LM reward duration end time."],
+            "type": "u64"
+          },
+          {
+            "name": "reward_rate",
+            "docs": ["LM reward rate"],
+            "type": "u128"
+          },
+          {
+            "name": "last_update_time",
+            "docs": ["The last time reward states were updated."],
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_seconds_with_empty_liquidity_reward",
+            "docs": [
+              "Accumulated seconds where when farm distribute rewards, but the bin is empty. The reward will be accumulated for next reward time window."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rounding",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Up"
+          },
+          {
+            "name": "Down"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_bits",
+            "type": "u8"
+          },
+          {
+            "name": "new_bits",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StaticParameters",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "min_bin_id",
+            "docs": [
+              "Min bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": [
+              "Max bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "function_type",
+            "docs": ["function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["Collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 3]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_bin_id",
+            "docs": ["min bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": ["max bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_type",
+            "docs": ["strategy type"],
+            "type": {
+              "defined": {
+                "name": "StrategyType"
+              }
+            }
+          },
+          {
+            "name": "parameteres",
+            "docs": ["parameters"],
+            "type": {
+              "array": ["u8", 64]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SpotOneSide"
+          },
+          {
+            "name": "CurveOneSide"
+          },
+          {
+            "name": "BidAskOneSide"
+          },
+          {
+            "name": "SpotBalanced"
+          },
+          {
+            "name": "CurveBalanced"
+          },
+          {
+            "name": "BidAskBalanced"
+          },
+          {
+            "name": "SpotImBalanced"
+          },
+          {
+            "name": "CurveImBalanced"
+          },
+          {
+            "name": "BidAskImBalanced"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "end_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "swap_for_y",
+            "type": "bool"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "fee_bps",
+            "type": "u128"
+          },
+          {
+            "name": "host_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap2Evt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "end_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "swap_for_y",
+            "type": "bool"
+          },
+          {
+            "name": "fee_bps",
+            "type": "u128"
+          },
+          {
+            "name": "amount_in",
+            "docs": ["Total amount, user transfer out"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "docs": ["Leftover amount"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "docs": ["Total amount transfer to user, including transfer fee"],
+            "type": "u64"
+          },
+          {
+            "name": "mm_fee",
+            "docs": ["Market maker fee"],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "docs": ["Total protocol fee"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee",
+            "docs": ["Total limit order fee"],
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "docs": ["Total host fee"],
+            "type": "u64"
+          },
+          {
+            "name": "fees_on_input",
+            "docs": ["check if fees on input"],
+            "type": "bool"
+          },
+          {
+            "name": "fees_on_token_x",
+            "docs": ["check if fees is on token x"],
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenBadge",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint",
+            "docs": ["token mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Reserve"],
+            "type": {
+              "array": ["u8", 128]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenProgramFlags",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenProgram"
+          },
+          {
+            "name": "TokenProgram2022"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdatePositionLockReleasePoint",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_point",
+            "type": "u64"
+          },
+          {
+            "name": "new_lock_release_point",
+            "type": "u64"
+          },
+          {
+            "name": "old_lock_release_point",
+            "type": "u64"
+          },
+          {
+            "name": "sender",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdatePositionOperator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateRewardDuration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "old_reward_duration",
+            "type": "u64"
+          },
+          {
+            "name": "new_reward_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateRewardFunder",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "old_funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_funder",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserRewardInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reward_per_token_completes",
+            "type": {
+              "array": ["u128", 2]
+            }
+          },
+          {
+            "name": "reward_pendings",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VariableParameters",
+      "docs": ["Parameters that changes based on dynamic of the market"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "volatility_accumulator",
+            "docs": [
+              "Volatility accumulator measure the number of bin crossed since reference bin ID. Normally (without filter period taken into consideration), reference bin ID is the active bin of last swap.",
+              "It affects the variable fee rate"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "volatility_reference",
+            "docs": [
+              "Volatility reference is decayed volatility accumulator. It is always <= volatility_accumulator"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "index_reference",
+            "docs": ["Active bin id of last swap."],
+            "type": "i32"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "last_update_timestamp",
+            "docs": ["Last timestamp the variable parameters was updated"],
+            "type": "i64"
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawIneligibleReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "BASIS_POINT_MAX",
+      "type": "u16",
+      "value": "10000"
+    },
+    {
+      "name": "BIN_ARRAY",
+      "type": "bytes",
+      "value": "[98, 105, 110, 95, 97, 114, 114, 97, 121]"
+    },
+    {
+      "name": "BIN_ARRAY_BITMAP_SEED",
+      "type": "bytes",
+      "value": "[98, 105, 116, 109, 97, 112]"
+    },
+    {
+      "name": "BIN_ARRAY_BITMAP_SIZE",
+      "type": "i32",
+      "value": "512"
+    },
+    {
+      "name": "CLAIM_PROTOCOL_FEE_OPERATOR",
+      "type": "bytes",
+      "value": "[99, 102, 95, 111, 112, 101, 114, 97, 116, 111, 114]"
+    },
+    {
+      "name": "DEFAULT_BIN_PER_POSITION",
+      "type": "u64",
+      "value": "70"
+    },
+    {
+      "name": "EXTENSION_BINARRAY_BITMAP_SIZE",
+      "type": "u64",
+      "value": "12"
+    },
+    {
+      "name": "FEE_DENOMINATOR",
+      "type": "u64",
+      "value": "1000000000"
+    },
+    {
+      "name": "HOST_FEE_BPS",
+      "docs": ["Host fee. 20%"],
+      "type": "u16",
+      "value": "2000"
+    },
+    {
+      "name": "ILM_PROTOCOL_SHARE",
+      "type": "u16",
+      "value": "2000"
+    },
+    {
+      "name": "LIMIT_ORDER_FEE_SHARE",
+      "type": "u16",
+      "value": "5000"
+    },
+    {
+      "name": "MAX_BASE_FEE",
+      "docs": ["Maximum base fee, base_fee / 10^9 = fee_in_percentage"],
+      "type": "u128",
+      "value": "100000000"
+    },
+    {
+      "name": "MAX_BIN_ID_PER_BIN_STEP",
+      "docs": [
+        "Maximum bin ID per bin step. Computed based on 1 bps. Used for bin id bound estimation."
+      ],
+      "type": "i32",
+      "value": "351639"
+    },
+    {
+      "name": "MAX_BIN_PER_ARRAY",
+      "type": "u64",
+      "value": "70"
+    },
+    {
+      "name": "MAX_BIN_PER_LIMIT_ORDER",
+      "type": "u64",
+      "value": "50"
+    },
+    {
+      "name": "MAX_BIN_STEP",
+      "docs": ["Maximum bin step"],
+      "type": "u16",
+      "value": "400"
+    },
+    {
+      "name": "MAX_FEE_RATE",
+      "docs": ["Maximum fee rate. 10%"],
+      "type": "u64",
+      "value": "100000000"
+    },
+    {
+      "name": "MAX_PROTOCOL_SHARE",
+      "docs": ["Maximum protocol share of the fee. 25%"],
+      "type": "u16",
+      "value": "2500"
+    },
+    {
+      "name": "MAX_RESIZE_LENGTH",
+      "type": "u64",
+      "value": "91"
+    },
+    {
+      "name": "MAX_REWARD_BIN_SPLIT",
+      "type": "u64",
+      "value": "15"
+    },
+    {
+      "name": "MAX_REWARD_DURATION",
+      "type": "u64",
+      "value": "31536000"
+    },
+    {
+      "name": "MINIMUM_LIQUIDITY",
+      "type": "u128",
+      "value": "1000000"
+    },
+    {
+      "name": "MIN_BASE_FEE",
+      "docs": ["Minimum base fee"],
+      "type": "u128",
+      "value": "100000"
+    },
+    {
+      "name": "MIN_REWARD_DURATION",
+      "type": "u64",
+      "value": "1"
+    },
+    {
+      "name": "NUM_REWARDS",
+      "type": "u64",
+      "value": "2"
+    },
+    {
+      "name": "OPERATOR_PREFIX",
+      "type": "bytes",
+      "value": "[111, 112, 101, 114, 97, 116, 111, 114]"
+    },
+    {
+      "name": "ORACLE",
+      "type": "bytes",
+      "value": "[111, 114, 97, 99, 108, 101]"
+    },
+    {
+      "name": "POSITION",
+      "type": "bytes",
+      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
+    },
+    {
+      "name": "POSITION_MAX_LENGTH",
+      "type": "u64",
+      "value": "1400"
+    },
+    {
+      "name": "PRESET_PARAMETER",
+      "type": "bytes",
+      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114]"
+    },
+    {
+      "name": "PRESET_PARAMETER2",
+      "type": "bytes",
+      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 50]"
+    },
+    {
+      "name": "PROTOCOL_SHARE",
+      "type": "u16",
+      "value": "500"
     }
   ]
 }

--- a/idl/meteora_dynamic_bonding_curve.json
+++ b/idl/meteora_dynamic_bonding_curve.json
@@ -1,0 +1,6964 @@
+{
+  "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN",
+  "metadata": {
+    "name": "dynamic_bonding_curve",
+    "version": "0.2.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "claim_creator_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        82,
+        220,
+        250,
+        189,
+        3,
+        85,
+        107,
+        45
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_creator_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        238,
+        247,
+        213,
+        94,
+        110,
+        145,
+        88,
+        142
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_partner_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        250,
+        238,
+        26,
+        4,
+        139,
+        10,
+        101,
+        248
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "fee_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        165,
+        228,
+        133,
+        48,
+        99,
+        249,
+        255,
+        33
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "token_base_account",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint"
+        },
+        {
+          "name": "quote_mint"
+        },
+        {
+          "name": "token_base_program"
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        114,
+        205,
+        83,
+        188,
+        240,
+        153,
+        25,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "treasury",
+          "writable": true,
+          "address": "6aYhxiNGmG8AyU25rh2R7iFu4pBrqnQHpNUGhmsEXRcm"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        8,
+        236,
+        89,
+        49,
+        152,
+        125,
+        177,
+        81
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        84,
+        191,
+        71,
+        50,
+        9,
+        162,
+        55,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_claim_protocol_fee_operator",
+      "discriminator": [
+        8,
+        41,
+        87,
+        35,
+        80,
+        48,
+        121,
+        26
+      ],
+      "accounts": [
+        {
+          "name": "claim_fee_operator",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_operator_account",
+      "discriminator": [
+        171,
+        9,
+        213,
+        74,
+        120,
+        23,
+        3,
+        29
+      ],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_config",
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer"
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "quote mint"
+          ]
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_config_with_transfer_hook",
+      "discriminator": [
+        216,
+        37,
+        1,
+        57,
+        88,
+        226,
+        25,
+        41
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer"
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "quote mint"
+          ]
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_locker",
+      "docs": [
+        "PERMISSIONLESS FUNCTIONS ///",
+        "create locker",
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        167,
+        90,
+        137,
+        154,
+        75,
+        47,
+        17,
+        84
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "writable": true
+        },
+        {
+          "name": "base",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  97,
+                  115,
+                  101,
+                  95,
+                  108,
+                  111,
+                  99,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "escrow",
+          "writable": true
+        },
+        {
+          "name": "escrow_token",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "locker_program",
+          "address": "LocpQgucEQHbqNABEYvBvwoxCPsSbG91A1QaQhQQqjn"
+        },
+        {
+          "name": "locker_event_authority"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_operator_account",
+      "discriminator": [
+        221,
+        64,
+        246,
+        149,
+        240,
+        153,
+        229,
+        163
+      ],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_address"
+              }
+            ]
+          }
+        },
+        {
+          "name": "whitelisted_address"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "create_partner_metadata",
+      "docs": [
+        "PARTNER FUNCTIONS ///"
+      ],
+      "discriminator": [
+        192,
+        168,
+        234,
+        191,
+        188,
+        226,
+        227,
+        255
+      ],
+      "accounts": [
+        {
+          "name": "partner_metadata",
+          "docs": [
+            "Partner metadata"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  97,
+                  114,
+                  116,
+                  110,
+                  101,
+                  114,
+                  95,
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "fee_claimer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Payer of the partner metadata."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer",
+          "docs": [
+            "Fee claimer for partner"
+          ],
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata",
+          "type": {
+            "defined": {
+              "name": "CreatePartnerMetadataParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_virtual_pool_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        45,
+        97,
+        187,
+        103,
+        254,
+        109,
+        124,
+        134
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "virtual_pool_metadata",
+          "docs": [
+            "Virtual pool metadata"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  105,
+                  114,
+                  116,
+                  117,
+                  97,
+                  108,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Payer of the virtual pool metadata."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata",
+          "type": {
+            "defined": {
+              "name": "CreateVirtualPoolMetadataParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "creator_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        165,
+        3,
+        137,
+        7,
+        28,
+        134,
+        76,
+        80
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_virtual_pool_with_spl_token",
+      "docs": [
+        "POOL CREATOR FUNCTIONS ////",
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        140,
+        85,
+        215,
+        176,
+        102,
+        54,
+        104,
+        79
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "Token a vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_virtual_pool_with_token2022",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        169,
+        118,
+        51,
+        78,
+        145,
+        110,
+        220,
+        155
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "Token quote vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token program for base mint"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_virtual_pool_with_token2022_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        182,
+        13,
+        233,
+        177,
+        42,
+        145,
+        135,
+        2
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Transfer hook config — contains the transfer hook program set by partner"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "migrate_meteora_damm",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        27,
+        1,
+        48,
+        22,
+        180,
+        63,
+        118,
+        217
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "docs": [
+            "virtual pool"
+          ],
+          "writable": true,
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "writable": true
+        },
+        {
+          "name": "config",
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "damm_config",
+          "docs": [
+            "pool config"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "writable": true
+        },
+        {
+          "name": "token_b_mint"
+        },
+        {
+          "name": "a_vault",
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "quote_vault",
+          "writable": true,
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "virtual_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "amm_program",
+          "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB"
+        },
+        {
+          "name": "vault_program"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_meteora_damm_claim_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        139,
+        133,
+        2,
+        30,
+        91,
+        145,
+        127,
+        154
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "docs": [
+            "migration metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "lp_mint",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "source_token",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pool_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "destination_token",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_meteora_damm_lock_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        177,
+        55,
+        238,
+        157,
+        251,
+        88,
+        165,
+        42
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "docs": [
+            "migration_metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "lock_escrow"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "lock_escrow",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "relations": [
+            "lock_escrow"
+          ]
+        },
+        {
+          "name": "source_tokens",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pool_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "escrow_vault",
+          "writable": true
+        },
+        {
+          "name": "amm_program",
+          "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB"
+        },
+        {
+          "name": "a_vault"
+        },
+        {
+          "name": "b_vault"
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "b_vault_lp"
+        },
+        {
+          "name": "a_vault_lp_mint"
+        },
+        {
+          "name": "b_vault_lp_mint"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_damm_v2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        156,
+        169,
+        230,
+        103,
+        53,
+        228,
+        80,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "migration_metadata"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "first_position_nft_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "first_position_nft_account",
+          "writable": true
+        },
+        {
+          "name": "first_position",
+          "writable": true
+        },
+        {
+          "name": "second_position_nft_mint",
+          "writable": true,
+          "signer": true,
+          "optional": true
+        },
+        {
+          "name": "second_position_nft_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "second_position",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "damm_pool_authority"
+        },
+        {
+          "name": "amm_program",
+          "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG"
+        },
+        {
+          "name": "base_mint",
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "writable": true
+        },
+        {
+          "name": "token_a_vault",
+          "writable": true
+        },
+        {
+          "name": "token_b_vault",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_base_program"
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "damm_event_authority"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_damm_v2_create_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        109,
+        189,
+        19,
+        36,
+        195,
+        183,
+        222,
+        82
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "migration_metadata"
+        },
+        {
+          "name": "payer"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_meteora_damm_create_metadata",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        47,
+        94,
+        126,
+        115,
+        221,
+        226,
+        194,
+        133
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  101,
+                  111,
+                  114,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "partner_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        168,
+        173,
+        72,
+        100,
+        201,
+        98,
+        38,
+        92
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "swap",
+      "docs": [
+        "TRADING BOTS FUNCTIONS ////",
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "swap2",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        65,
+        75,
+        63,
+        76,
+        235,
+        91,
+        91,
+        136
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "swap2_with_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        183,
+        93,
+        153,
+        40,
+        24,
+        230,
+        194,
+        151
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token",
+            "must be mutable so we can revoke the transfer hook after the last swap is performed"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "transfer_pool_creator",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        20,
+        7,
+        169,
+        33,
+        58,
+        147,
+        166,
+        33
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "new_creator"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdraw_leftover",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        20,
+        198,
+        202,
+        237,
+        235,
+        243,
+        183,
+        66
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_base_account",
+          "docs": [
+            "The receiver token account, withdraw to ATA"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "leftover_receiver"
+              },
+              {
+                "kind": "account",
+                "path": "token_base_program"
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdraw_migration_fee",
+      "docs": [
+        "BOTH partner and creator FUNCTIONS ///",
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        237,
+        142,
+        45,
+        23,
+        129,
+        6,
+        222,
+        162
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "flag",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        213,
+        155,
+        187,
+        34,
+        56,
+        182,
+        91,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_vault",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "zap claim fee operator"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ]
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ClaimFeeOperator",
+      "discriminator": [
+        166,
+        48,
+        134,
+        86,
+        34,
+        200,
+        188,
+        150
+      ]
+    },
+    {
+      "name": "ConfigWithTransferHook",
+      "discriminator": [
+        40,
+        220,
+        194,
+        251,
+        41,
+        199,
+        123,
+        253
+      ]
+    },
+    {
+      "name": "MeteoraDammMigrationMetadata",
+      "discriminator": [
+        17,
+        155,
+        141,
+        215,
+        207,
+        4,
+        133,
+        156
+      ]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [
+        219,
+        31,
+        188,
+        145,
+        69,
+        139,
+        204,
+        117
+      ]
+    },
+    {
+      "name": "PartnerMetadata",
+      "discriminator": [
+        68,
+        68,
+        130,
+        19,
+        16,
+        209,
+        98,
+        156
+      ]
+    },
+    {
+      "name": "PoolConfig",
+      "discriminator": [
+        26,
+        108,
+        14,
+        123,
+        116,
+        230,
+        129,
+        43
+      ]
+    },
+    {
+      "name": "TransferHookPool",
+      "discriminator": [
+        237,
+        219,
+        184,
+        23,
+        42,
+        189,
+        169,
+        35
+      ]
+    },
+    {
+      "name": "VirtualPool",
+      "discriminator": [
+        213,
+        224,
+        5,
+        209,
+        98,
+        69,
+        119,
+        92
+      ]
+    },
+    {
+      "name": "VirtualPoolMetadata",
+      "discriminator": [
+        217,
+        37,
+        82,
+        250,
+        43,
+        47,
+        228,
+        254
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "EvtClaimCreatorTradingFee",
+      "discriminator": [
+        154,
+        228,
+        215,
+        202,
+        133,
+        155,
+        214,
+        138
+      ]
+    },
+    {
+      "name": "EvtClaimPoolCreationFee",
+      "discriminator": [
+        149,
+        111,
+        149,
+        44,
+        136,
+        64,
+        175,
+        62
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "discriminator": [
+        186,
+        244,
+        75,
+        251,
+        188,
+        13,
+        25,
+        33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
+      ]
+    },
+    {
+      "name": "EvtClaimTradingFee",
+      "discriminator": [
+        26,
+        83,
+        117,
+        240,
+        92,
+        202,
+        112,
+        254
+      ]
+    },
+    {
+      "name": "EvtCloseClaimFeeOperator",
+      "discriminator": [
+        111,
+        39,
+        37,
+        55,
+        110,
+        216,
+        194,
+        23
+      ]
+    },
+    {
+      "name": "EvtCreateClaimFeeOperator",
+      "discriminator": [
+        21,
+        6,
+        153,
+        120,
+        68,
+        116,
+        28,
+        177
+      ]
+    },
+    {
+      "name": "EvtCreateConfig",
+      "discriminator": [
+        131,
+        207,
+        180,
+        174,
+        180,
+        73,
+        165,
+        54
+      ]
+    },
+    {
+      "name": "EvtCreateConfigV2",
+      "discriminator": [
+        163,
+        74,
+        66,
+        187,
+        119,
+        195,
+        26,
+        144
+      ]
+    },
+    {
+      "name": "EvtCreateConfigV2WithTransferHook",
+      "discriminator": [
+        182,
+        81,
+        135,
+        4,
+        39,
+        46,
+        132,
+        253
+      ]
+    },
+    {
+      "name": "EvtCreateMeteoraMigrationMetadata",
+      "discriminator": [
+        99,
+        167,
+        133,
+        63,
+        214,
+        143,
+        175,
+        139
+      ]
+    },
+    {
+      "name": "EvtCreatorWithdrawSurplus",
+      "discriminator": [
+        152,
+        73,
+        21,
+        15,
+        66,
+        87,
+        53,
+        157
+      ]
+    },
+    {
+      "name": "EvtCurveComplete",
+      "discriminator": [
+        229,
+        231,
+        86,
+        84,
+        156,
+        134,
+        75,
+        24
+      ]
+    },
+    {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "discriminator": [
+        59,
+        47,
+        109,
+        205,
+        13,
+        31,
+        44,
+        159
+      ]
+    },
+    {
+      "name": "EvtInitializePool",
+      "discriminator": [
+        228,
+        50,
+        246,
+        85,
+        203,
+        66,
+        134,
+        37
+      ]
+    },
+    {
+      "name": "EvtInitializePoolWithTransferHook",
+      "discriminator": [
+        213,
+        137,
+        164,
+        53,
+        193,
+        74,
+        15,
+        110
+      ]
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "discriminator": [
+        174,
+        223,
+        44,
+        150,
+        145,
+        98,
+        89,
+        195
+      ]
+    },
+    {
+      "name": "EvtPartnerMetadata",
+      "discriminator": [
+        200,
+        127,
+        6,
+        55,
+        13,
+        32,
+        8,
+        150
+      ]
+    },
+    {
+      "name": "EvtPartnerWithdrawSurplus",
+      "discriminator": [
+        195,
+        56,
+        152,
+        9,
+        232,
+        72,
+        35,
+        22
+      ]
+    },
+    {
+      "name": "EvtSwap",
+      "discriminator": [
+        27,
+        60,
+        21,
+        213,
+        138,
+        170,
+        187,
+        147
+      ]
+    },
+    {
+      "name": "EvtSwap2",
+      "discriminator": [
+        189,
+        66,
+        51,
+        168,
+        38,
+        80,
+        117,
+        153
+      ]
+    },
+    {
+      "name": "EvtSwap2WithTransferHook",
+      "discriminator": [
+        134,
+        59,
+        168,
+        120,
+        94,
+        51,
+        114,
+        231
+      ]
+    },
+    {
+      "name": "EvtUpdatePoolCreator",
+      "discriminator": [
+        107,
+        225,
+        165,
+        237,
+        91,
+        158,
+        213,
+        220
+      ]
+    },
+    {
+      "name": "EvtVirtualPoolMetadata",
+      "discriminator": [
+        188,
+        18,
+        72,
+        76,
+        195,
+        91,
+        38,
+        74
+      ]
+    },
+    {
+      "name": "EvtWithdrawLeftover",
+      "discriminator": [
+        191,
+        189,
+        104,
+        143,
+        111,
+        156,
+        94,
+        229
+      ]
+    },
+    {
+      "name": "EvtWithdrawMigrationFee",
+      "discriminator": [
+        26,
+        203,
+        84,
+        85,
+        161,
+        23,
+        100,
+        214
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "ExceededSlippage",
+      "msg": "Exceeded slippage tolerance"
+    },
+    {
+      "code": 6003,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
+    },
+    {
+      "code": 6005,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6006,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidQuoteMint",
+      "msg": "Invalid quote mint"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidMigrationFeeOption",
+      "msg": "Invalid migration fee option"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidInput",
+      "msg": "Invalid input"
+    },
+    {
+      "code": 6012,
+      "name": "NotEnoughLiquidity",
+      "msg": "Not enough liquidity"
+    },
+    {
+      "code": 6013,
+      "name": "PoolIsCompleted",
+      "msg": "Pool is completed"
+    },
+    {
+      "code": 6014,
+      "name": "PoolIsIncompleted",
+      "msg": "Pool is incompleted"
+    },
+    {
+      "code": 6015,
+      "name": "InvalidMigrationOption",
+      "msg": "Invalid migration option"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidTokenDecimals",
+      "msg": "Invalid token decimals"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidTokenType",
+      "msg": "Invalid token type"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidFeePercentage",
+      "msg": "Invalid fee percentage"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidQuoteThreshold",
+      "msg": "Invalid quote threshold"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidTokenSupply",
+      "msg": "Invalid token supply"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidCurve",
+      "msg": "Invalid curve"
+    },
+    {
+      "code": 6022,
+      "name": "NotPermitToDoThisAction",
+      "msg": "Not permit to do this action"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidOwnerAccount",
+      "msg": "Invalid owner account"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidConfigAccount",
+      "msg": "Invalid config account"
+    },
+    {
+      "code": 6025,
+      "name": "SurplusHasBeenWithdraw",
+      "msg": "Surplus has been withdraw"
+    },
+    {
+      "code": 6026,
+      "name": "LeftoverHasBeenWithdraw",
+      "msg": "Leftover has been withdraw"
+    },
+    {
+      "code": 6027,
+      "name": "TotalBaseTokenExceedMaxSupply",
+      "msg": "Total base token is exceeded max supply"
+    },
+    {
+      "code": 6028,
+      "name": "UnsupportNativeMintToken2022",
+      "msg": "Unsupport native mint token 2022"
+    },
+    {
+      "code": 6029,
+      "name": "InsufficientLiquidityForMigration",
+      "msg": "Insufficient liquidity for migration"
+    },
+    {
+      "code": 6030,
+      "name": "MissingPoolConfigInRemainingAccount",
+      "msg": "Missing pool config in remaining account"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidVestingParameters",
+      "msg": "Invalid vesting parameters"
+    },
+    {
+      "code": 6032,
+      "name": "InvalidLeftoverAddress",
+      "msg": "Invalid leftover address"
+    },
+    {
+      "code": 6033,
+      "name": "InsufficientLiquidity",
+      "msg": "Liquidity in bonding curve is insufficient"
+    },
+    {
+      "code": 6034,
+      "name": "InvalidFeeScheduler",
+      "msg": "Invalid fee scheduler"
+    },
+    {
+      "code": 6035,
+      "name": "InvalidCreatorTradingFeePercentage",
+      "msg": "Invalid creator trading fee percentage"
+    },
+    {
+      "code": 6036,
+      "name": "InvalidNewCreator",
+      "msg": "Invalid new creator"
+    },
+    {
+      "code": 6037,
+      "name": "InvalidTokenAuthorityOption",
+      "msg": "Invalid token authority option"
+    },
+    {
+      "code": 6038,
+      "name": "InvalidAccount",
+      "msg": "Invalid account for the instruction"
+    },
+    {
+      "code": 6039,
+      "name": "InvalidMigratorFeePercentage",
+      "msg": "Invalid migrator fee percentage"
+    },
+    {
+      "code": 6040,
+      "name": "MigrationFeeHasBeenWithdraw",
+      "msg": "Migration fee has been withdraw"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidBaseFeeMode",
+      "msg": "Invalid base fee mode"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidFeeRateLimiter",
+      "msg": "Invalid fee rate limiter"
+    },
+    {
+      "code": 6043,
+      "name": "FailToValidateSingleSwapInstruction",
+      "msg": "Fail to validate single swap instruction in rate limiter"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidMigratedPoolFee",
+      "msg": "Invalid migrated pool fee params"
+    },
+    {
+      "code": 6045,
+      "name": "UndeterminedError",
+      "msg": "Undertermined error"
+    },
+    {
+      "code": 6046,
+      "name": "RateLimiterNotSupported",
+      "msg": "Rate limiter not supported"
+    },
+    {
+      "code": 6047,
+      "name": "AmountLeftIsNotZero",
+      "msg": "Amount left is not zero"
+    },
+    {
+      "code": 6048,
+      "name": "NextSqrtPriceIsSmallerThanStartSqrtPrice",
+      "msg": "Next sqrt price is smaller than start sqrt price"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidMinBaseFee",
+      "msg": "Invalid min base fee"
+    },
+    {
+      "code": 6050,
+      "name": "AccountInvariantViolation",
+      "msg": "Account invariant violation"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidPoolCreationFee",
+      "msg": "Invalid pool creation fee"
+    },
+    {
+      "code": 6052,
+      "name": "PoolCreationFeeHasBeenClaimed",
+      "msg": "Pool creation fee has been claimed"
+    },
+    {
+      "code": 6053,
+      "name": "Unauthorized",
+      "msg": "Not permit to do this action"
+    },
+    {
+      "code": 6054,
+      "name": "ZeroPoolCreationFee",
+      "msg": "Pool creation fee is zero"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidMigrationLockedLiquidity",
+      "msg": "Invalid migration locked liquidity"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidFeeMarketCapScheduler",
+      "msg": "Invalid fee market cap scheduler"
+    },
+    {
+      "code": 6057,
+      "name": "FirstSwapValidationFailed",
+      "msg": "Fail to validate first swap with minimum fee"
+    },
+    {
+      "code": 6058,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6059,
+      "name": "InsufficientPoolLamports",
+      "msg": "Pool has insufficient lamports to perform the operation"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6062,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6063,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6064,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6065,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6066,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingParameters",
+      "msg": "Invalid compounding parameters"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidInstructionsSysvar",
+      "msg": "Invalid instructions sysvar account"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidRemainingAccountsLength",
+      "msg": "Invalid remaining accounts length"
+    },
+    {
+      "code": 6071,
+      "name": "MissingRemainingAccountForTransferHook",
+      "msg": "Missing remaining account for transfer hook"
+    },
+    {
+      "code": 6072,
+      "name": "NoTransferHookProgram",
+      "msg": "No transfer hook program"
+    },
+    {
+      "code": 6073,
+      "name": "DuplicatedRemainingAccountTypes",
+      "msg": "Duplicated remaining account types"
+    },
+    {
+      "code": 6074,
+      "name": "InvalidTransferHookProgram",
+      "msg": "Invalid transfer hook program"
+    },
+    {
+      "code": 6075,
+      "name": "InvalidPoolAccount",
+      "msg": "Invalid pool account"
+    },
+    {
+      "code": 6076,
+      "name": "PoolTypeMismatch",
+      "msg": "Pool type does not match instruction"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccountsType",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookBase"
+          },
+          {
+            "name": "TransferHookBaseReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "second_factor",
+            "type": "u64"
+          },
+          {
+            "name": "third_factor",
+            "type": "u64"
+          },
+          {
+            "name": "first_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "first_factor",
+            "type": "u16"
+          },
+          {
+            "name": "second_factor",
+            "type": "u64"
+          },
+          {
+            "name": "third_factor",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFeeOperator",
+      "docs": [
+        "Parameter that set by the protocol"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "docs": [
+              "operator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                219
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_start_price",
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting",
+            "type": {
+              "defined": {
+                "name": "LockedVestingParams"
+              }
+            }
+          },
+          {
+            "name": "migration_fee_option",
+            "type": "u8"
+          },
+          {
+            "name": "token_supply",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "TokenSupplyParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "creator_trading_fee_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "token_update_authority",
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee",
+            "type": {
+              "defined": {
+                "name": "MigrationFee"
+              }
+            }
+          },
+          {
+            "name": "migrated_pool_fee",
+            "type": {
+              "defined": {
+                "name": "MigratedPoolFee"
+              }
+            }
+          },
+          {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in SOL lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_pool_market_cap_fee_scheduler_params",
+            "type": {
+              "defined": {
+                "name": "MigratedPoolMarketCapFeeSchedulerParams"
+              }
+            }
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "bool"
+          },
+          {
+            "name": "compounding_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "curve",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "LiquidityDistributionParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigWithTransferHook",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "PoolConfig"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreatePartnerMetadataParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateVirtualPoolMetadataParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "initialized",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimCreatorTradingFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimTradingFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCloseClaimFeeOperator",
+      "docs": [
+        "Close claim fee operator"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "claim_fee_operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateClaimFeeOperator",
+      "docs": [
+        "Create claim fee operator"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfig",
+      "docs": [
+        "Create config"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "swap_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "migration_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_start_price",
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting",
+            "type": {
+              "defined": {
+                "name": "LockedVestingParams"
+              }
+            }
+          },
+          {
+            "name": "migration_fee_option",
+            "type": "u8"
+          },
+          {
+            "name": "fixed_token_supply_flag",
+            "type": "u8"
+          },
+          {
+            "name": "pre_migration_token_supply",
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "type": "u64"
+          },
+          {
+            "name": "curve",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "LiquidityDistributionParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfigV2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_parameters",
+            "type": {
+              "defined": {
+                "name": "ConfigParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfigV2WithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_parameters",
+            "type": {
+              "defined": {
+                "name": "ConfigParameters"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateMeteoraMigrationMetadata",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreatorWithdrawSurplus",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "surplus_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCurveComplete",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtInitializePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtInitializePoolWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          },
+          {
+            "name": "fee_receiver",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerMetadata",
+      "docs": [
+        "Create partner metadata"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "partner_metadata",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerWithdrawSurplus",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "surplus_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "SwapParameters"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult"
+              }
+            }
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "swap_parameters",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "quote_reserve_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap2WithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "swap_parameters",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "quote_reserve_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtUpdatePoolCreator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_creator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtVirtualPoolMetadata",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool_metadata",
+            "type": "pubkey"
+          },
+          {
+            "name": "virtual_pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawLeftover",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawMigrationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "flag",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializePoolParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "name": "uri",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityDistributionConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityDistributionParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_initialized",
+            "type": "u8"
+          },
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfoParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockEscrow",
+      "docs": [
+        "State of lock escrow account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "escrow_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "total_locked_amount",
+            "type": "u64"
+          },
+          {
+            "name": "lp_per_token",
+            "type": "u128"
+          },
+          {
+            "name": "unclaimed_fee_pending",
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockedVestingConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_per_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u64"
+          },
+          {
+            "name": "frequency",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_amount",
+            "type": "u64"
+          },
+          {
+            "name": "_padding",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockedVestingParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_per_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u64"
+          },
+          {
+            "name": "frequency",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MeteoraDammMigrationMetadata",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "docs": [
+              "pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "!!! BE CAREFUL to use tombstone field, previous is pool creator"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "partner",
+            "docs": [
+              "partner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_mint",
+            "docs": [
+              "lp mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "partner_locked_liquidity",
+            "docs": [
+              "partner locked liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_liquidity",
+            "docs": [
+              "partner liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_locked_liquidity",
+            "docs": [
+              "creator locked liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_liquidity",
+            "docs": [
+              "creator liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "padding"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_locked_status",
+            "docs": [
+              "flag to check whether liquidity token is locked for creator"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_locked_status",
+            "docs": [
+              "flag to check whether liquidity token is locked for partner"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_claim_status",
+            "docs": [
+              "flag to check whether creator has claimed liquidity token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_claim_status",
+            "docs": [
+              "flag to check whether partner has claimed liquidity token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                107
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigratedPoolFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "dynamic_fee",
+            "type": "u8"
+          },
+          {
+            "name": "pool_fee_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigratedPoolMarketCapFeeSchedulerParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u16"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_fee_percentage",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whitelisted_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerMetadata",
+      "docs": [
+        "Metadata for a partner."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_claimer",
+            "docs": [
+              "fee claimer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Name of partner."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "docs": [
+              "Website of partner."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "docs": [
+              "Logo of partner"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "quote_mint",
+            "docs": [
+              "quote mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "docs": [
+              "Address to get the fee"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "docs": [
+              "Address to receive extra base token after migration, in case token is fixed supply"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "docs": [
+              "Pool fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeesConfig"
+              }
+            }
+          },
+          {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "Padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": [
+              "Previously was protocol and referral fee percent. Beware of tombstone."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "Collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "docs": [
+              "migration option"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "whether mode slot or timestamp"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "docs": [
+              "token decimals"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "version",
+            "docs": [
+              "version"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "docs": [
+              "token type of base token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "quote_token_flag",
+            "docs": [
+              "quote token flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "docs": [
+              "partner locked liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "docs": [
+              "partner liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "docs": [
+              "creator post migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "docs": [
+              "creator liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_option",
+            "docs": [
+              "migration fee option"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fixed_token_supply_flag",
+            "docs": [
+              "flag to indicate whether token is dynamic supply (0) or fixed supply (1)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_trading_fee_percentage",
+            "docs": [
+              "creator trading fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_update_authority",
+            "docs": [
+              "token update authority"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_percentage",
+            "docs": [
+              "migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_migration_fee_percentage",
+            "docs": [
+              "creator migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_2",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "swap_base_amount",
+            "docs": [
+              "swap base amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "docs": [
+              "migration quote threshold (in quote token)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_base_threshold",
+            "docs": [
+              "migration base threshold (in base token)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_sqrt_price",
+            "docs": [
+              "migration sqrt price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting_config",
+            "docs": [
+              "locked vesting config"
+            ],
+            "type": {
+              "defined": {
+                "name": "LockedVestingConfig"
+              }
+            }
+          },
+          {
+            "name": "pre_migration_token_supply",
+            "docs": [
+              "pre migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "docs": [
+              "post migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migrated_collect_fee_mode",
+            "docs": [
+              "migrated pool collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migrated_dynamic_fee",
+            "docs": [
+              "migrated dynamic fee option."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migrated_pool_fee_bps",
+            "docs": [
+              "migrated pool fee in bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_compounding_fee_bps",
+            "docs": [
+              "compounding fee bps for migrated DAMM v2 pool, should only be non-zero if migrated_collect_fee_mode is 2 (Compounding)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migrated_pool_base_fee_bytes",
+            "docs": [
+              "serialized MigratedPoolMarketCapFeeSchedulerParams, only used when migrated_pool_base_fee_mode is market cap scheduler"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "sqrt_start_price",
+            "docs": [
+              "minimum price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "curve",
+            "docs": [
+              "curve, only use 20 point firstly, we can extend that latter"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "LiquidityDistributionConfig"
+                  }
+                },
+                20
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFeeParameters",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_fee",
+            "docs": [
+              "Base fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "BaseFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "docs": [
+              "dynamic fee"
+            ],
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "DynamicFeeParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFees",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFeesConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_fee",
+            "type": {
+              "defined": {
+                "name": "BaseFeeConfig"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "type": {
+              "defined": {
+                "name": "DynamicFeeConfig"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolMetrics",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "total_protocol_base_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_protocol_quote_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_trading_base_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_trading_quote_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolState",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "volatility_tracker",
+            "docs": [
+              "volatility tracker"
+            ],
+            "type": {
+              "defined": {
+                "name": "VolatilityTracker"
+              }
+            }
+          },
+          {
+            "name": "config",
+            "docs": [
+              "config key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "docs": [
+              "base mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_vault",
+            "docs": [
+              "base vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_vault",
+            "docs": [
+              "quote vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "docs": [
+              "base reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "docs": [
+              "quote reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_base_fee",
+            "docs": [
+              "protocol base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_quote_fee",
+            "docs": [
+              "protocol quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_base_fee",
+            "docs": [
+              "partner base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_quote_fee",
+            "docs": [
+              "trading quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_price",
+            "docs": [
+              "current price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "Activation point"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pool_type",
+            "docs": [
+              "pool type, spl token or token2022"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_migrated",
+            "docs": [
+              "is migrated"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_partner_withdraw_surplus",
+            "docs": [
+              "is partner withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_protocol_withdraw_surplus",
+            "docs": [
+              "is protocol withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_progress",
+            "docs": [
+              "migration progress"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_withdraw_leftover",
+            "docs": [
+              "is withdraw leftover"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_creator_withdraw_surplus",
+            "docs": [
+              "is creator withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_withdraw_status",
+            "docs": [
+              "migration fee withdraw status",
+              "bit 1 (0b010) creator",
+              "bit 2 (0b100) partner"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "metrics",
+            "docs": [
+              "pool metrics"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolMetrics"
+              }
+            }
+          },
+          {
+            "name": "finish_curve_timestamp",
+            "docs": [
+              "The time curve is finished"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_base_fee",
+            "docs": [
+              "creator base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_quote_fee",
+            "docs": [
+              "creator quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "legacy_creation_fee_bits",
+            "docs": [
+              "legacy creation fee bits, we dont use this now"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creation_fee_bits",
+            "docs": [
+              "pool creation fee claim status"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_swap",
+            "docs": [
+              "Cached flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "protocol_liquidity_migration_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "protocol_migration_base_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_migration_quote_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "_padding_2",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": {
+              "defined": {
+                "name": "AccountsType"
+              }
+            }
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "minimum_amount_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_0",
+            "docs": [
+              "When it's exact in, partial fill, this will be amount_in. When it's exact out, this will be amount_out"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "When it's exact in, partial fill, this will be minimum_amount_out. When it's exact out, this will be maximum_amount_in"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "swap_mode",
+            "docs": [
+              "Swap mode, refer [SwapMode]"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult",
+      "docs": [
+        "Encodes all results of swapping"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "actual_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "included_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenSupplyParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pre_migration_token_supply",
+            "docs": [
+              "pre migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "docs": [
+              "post migration token supply",
+              "because DBC allow user to swap over the migration quote threshold, so in extreme case user may swap more than allowed buffer on curve",
+              "that result the total supply in post migration may be increased a bit (between pre_migration_token_supply and post_migration_token_supply)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualPoolMetadata",
+      "docs": [
+        "Metadata for a virtual pool."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "docs": [
+              "virtual pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Name of project."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "docs": [
+              "Website of project."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "docs": [
+              "Logo of project"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VolatilityTracker",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_update_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "sqrt_price_reference",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_accumulator",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_reference",
+            "type": "u128"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/idl/orca_whirlpool.json
+++ b/idl/orca_whirlpool.json
@@ -1,4326 +1,7608 @@
 {
-  "version": "0.3.6",
-  "name": "whirlpool",
-  "instructions": [
-    {
-      "name": "initializeConfig",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
+    "address": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+    "metadata": {
+        "name": "whirlpool",
+        "version": "0.9.0",
+        "spec": "0.1.0"
     },
-    {
-      "name": "initializePool",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "WhirlpoolBumps"
-          }
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeTickArray",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tickArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "startTickIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "initializeFeeTier",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissions",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "openPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithMetadata",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionMetadataAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionWithMetadataBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "updateFeesAndRewards",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectFees",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectReward",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFees",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "swap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setDefaultFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "protocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setCollectProtocolFeesAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newCollectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setRewardAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardAuthorityBySuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsSuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "twoHopSwap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializePositionBundleWithMetadata",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleMetadata",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deletePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "openBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "closeBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        },
-        {
-          "name": "withTokenMetadataExtension",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "lockPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "lockType",
-          "type": {
-            "defined": "LockType"
-          }
-        }
-      ]
-    },
-    {
-      "name": "resetPositionRange",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "newTickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "newTickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "transferLockedPosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "destinationTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeAdaptiveFeeTier",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeTierIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initializePoolAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        },
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultBaseFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newDelegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setInitializePoolAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newInitializePoolAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setPresetAdaptiveFeeConstants",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializePoolWithAdaptiveFee",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "initializePoolAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        },
-        {
-          "name": "tradeEnableTimestamp",
-          "type": {
-            "option": "u64"
-          }
-        }
-      ]
-    },
-    {
-      "name": "setFeeRateByDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "collectFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectRewardV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializePoolV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeRewardV2",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenBadge",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "swapV2",
-      "accounts": [
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "twoHopSwapV2",
-      "accounts": [
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeConfigExtension",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "configExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setConfigExtensionAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newConfigExtensionAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setTokenBadgeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newTokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deleteTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    }
-  ],
-  "accounts": [
-    {
-      "name": "AdaptiveFeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeTierIndex",
-            "type": "u16"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "initializePoolAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "delegatedFeeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultBaseFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "collectProtocolFeesAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardEmissionsSuperAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultProtocolFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfigExtension",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "configExtensionAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBadgeAuthority",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "defaultFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "position",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionOwner",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "lockedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lockType",
-            "type": {
-              "defined": "LockTypeLabel"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Oracle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "tradeEnableTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "adaptiveFeeConstants",
-            "type": {
-              "defined": "AdaptiveFeeConstants"
-            }
-          },
-          {
-            "name": "adaptiveFeeVariables",
-            "type": {
-              "defined": "AdaptiveFeeVariables"
-            }
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "tickLowerIndex",
-            "type": "i32"
-          },
-          {
-            "name": "tickUpperIndex",
-            "type": "i32"
-          },
-          {
-            "name": "feeGrowthCheckpointA",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "feeGrowthCheckpointB",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+    "instructions": [
+        {
+            "name": "close_bundled_position",
+            "docs": [
+                "Close a bundled position in a Whirlpool.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to close.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                41,
+                36,
+                216,
+                245,
+                27,
+                85,
+                103,
+                67
+            ],
+            "accounts": [
                 {
-                  "defined": "PositionRewardInfo"
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionBundle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBundleMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionBitmap",
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "TickArray",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "startTickIndex",
-            "type": "i32"
-          },
-          {
-            "name": "ticks",
-            "type": {
-              "array": [
                 {
-                  "defined": "Tick"
+                    "name": "position_bundle",
+                    "writable": true
                 },
-                88
-              ]
-            }
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenBadge",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenMint",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Whirlpool",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpoolBump",
-            "type": {
-              "array": [
-                "u8",
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "close_position",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                123,
+                134,
+                81,
+                0,
+                49,
+                68,
+                98,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "close_position_with_token_extensions",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "Mint and TokenAccount are based on Token-2022. And Mint accout will be also closed.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                1,
+                182,
+                135,
+                59,
+                155,
+                25,
+                99,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                164,
+                152,
+                207,
+                99,
+                30,
+                186,
+                19,
+                182
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees_v2",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                207,
+                117,
+                95,
+                191,
+                229,
+                180,
+                226,
+                15
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_protocol_fees",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                22,
+                67,
+                23,
+                98,
+                150,
+                178,
+                70,
+                220
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_protocol_fees_v2",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                103,
+                128,
+                222,
+                134,
+                114,
+                200,
+                22,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_reward",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                70,
+                5,
+                132,
+                87,
+                86,
+                235,
+                177,
+                34
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "collect_reward_v2",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                177,
+                107,
+                37,
+                180,
+                160,
+                19,
+                49,
+                209
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                160,
+                38,
+                208,
+                111,
+                104,
+                91,
+                44,
                 1
-              ]
-            }
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "feeTierIndexSeed",
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "feeRate",
-            "type": "u16"
-          },
-          {
-            "name": "protocolFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "sqrtPrice",
-            "type": "u128"
-          },
-          {
-            "name": "tickCurrentIndex",
-            "type": "i32"
-          },
-          {
-            "name": "protocolFeeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "protocolFeeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "tokenMintA",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultA",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalA",
-            "type": "u128"
-          },
-          {
-            "name": "tokenMintB",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultB",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardLastUpdatedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+            ],
+            "accounts": [
                 {
-                  "defined": "WhirlpoolRewardInfo"
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "LockType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockTypeLabel",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeConstants",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeVariables",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lastReferenceUpdateTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lastMajorSwapTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "volatilityReference",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupIndexReference",
-            "type": "i32"
-          },
-          {
-            "name": "volatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionWithMetadataBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          },
-          {
-            "name": "metadataBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "growthInsideCheckpoint",
-            "type": "u128"
-          },
-          {
-            "name": "amountOwed",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Tick",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "initialized",
-            "type": "bool"
-          },
-          {
-            "name": "liquidityNet",
-            "type": "i128"
-          },
-          {
-            "name": "liquidityGross",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideA",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardGrowthsOutside",
-            "type": {
-              "array": [
-                "u128",
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mint",
-            "type": "publicKey"
-          },
-          {
-            "name": "vault",
-            "type": "publicKey"
-          },
-          {
-            "name": "authority",
-            "type": "publicKey"
-          },
-          {
-            "name": "emissionsPerSecondX64",
-            "type": "u128"
-          },
-          {
-            "name": "growthGlobalX64",
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AccountsType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TransferHookA"
-          },
-          {
-            "name": "TransferHookB"
-          },
-          {
-            "name": "TransferHookReward"
-          },
-          {
-            "name": "TransferHookInput"
-          },
-          {
-            "name": "TransferHookIntermediate"
-          },
-          {
-            "name": "TransferHookOutput"
-          },
-          {
-            "name": "SupplementalTickArrays"
-          },
-          {
-            "name": "SupplementalTickArraysOne"
-          },
-          {
-            "name": "SupplementalTickArraysTwo"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slices",
-            "type": {
-              "vec": {
-                "defined": "RemainingAccountsSlice"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsSlice",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "accountsType",
-            "type": {
-              "defined": "AccountsType"
-            }
-          },
-          {
-            "name": "length",
-            "type": "u8"
-          }
-        ]
-      }
-    }
-  ],
-  "events": [
-    {
-      "name": "LiquidityDecreased",
-      "fields": [
-        {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "decrease_liquidity_v2",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                58,
+                127,
+                188,
+                62,
+                79,
+                82,
+                196,
+                96
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_position_bundle",
+            "docs": [
+                "Delete a PositionBundle account. Burns the position bundle token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- `position_bundle_owner` - The owner that owns the position bundle token.",
+                "",
+                "### Special Errors",
+                "- `PositionBundleNotDeletable` - The provided position bundle has open positions."
+            ],
+            "discriminator": [
+                100,
+                25,
+                99,
+                2,
+                217,
+                239,
+                124,
+                173
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_owner",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_token_badge",
+            "docs": [
+                "Delete a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                53,
+                146,
+                68,
+                8,
+                18,
+                117,
+                17,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": []
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "idl_include",
+            "discriminator": [
+                223,
+                253,
+                121,
+                121,
+                60,
+                193,
+                129,
+                31
+            ],
+            "accounts": [
+                {
+                    "name": "tick_array"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                46,
+                156,
+                243,
+                118,
+                13,
+                205,
+                251,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_by_token_amounts_v2",
+            "docs": [
+                "Add liquidity to a position by specifying token maxima, not liquidity.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "NOTE: This instruction is only implemented in Pinocchio, not Anchor.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "- `min_sqrt_price` - The minimum sqrt price allowed.",
+                "- `max_sqrt_price` - The maximum sqrt price allowed.",
+                "",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Computed liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Computed liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                239,
+                251,
+                9,
+                124,
+                210,
+                198,
+                53,
+                43
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "IncreaseLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_v2",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                133,
+                29,
+                89,
+                223,
+                69,
+                238,
+                176,
+                10
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "initialize_adaptive_fee_tier",
+            "docs": [
+                "Initializes an adaptive_fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_tier_index` - The index of the fee-tier that this adaptive fee tier will be initialized.",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `initialize_pool_authority` - The authority that can initialize pools with this adaptive fee-tier.",
+                "- `delegated_fee_authority` - The authority that can set the base fee rate for pools using this adaptive fee-tier.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `InvalidFeeTierIndex` - If the provided fee_tier_index is same to tick_spacing.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE.",
+                "- `InvalidAdaptiveFeeConstants` - If the provided adaptive fee constants are invalid."
+            ],
+            "discriminator": [
+                77,
+                99,
+                208,
+                200,
+                141,
+                123,
+                117,
+                48
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config"
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "fee_tier_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_tier_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                },
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config",
+            "docs": [
+                "Initializes a WhirlpoolsConfig account that hosts info & authorities",
+                "required to govern a set of Whirlpools.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `fee_authority` - Authority authorized to initialize fee-tiers and set customs fees.",
+                "- `collect_protocol_fees_authority` - Authority authorized to collect protocol fees.",
+                "- `reward_emissions_super_authority` - Authority authorized to set reward authorities in pools."
+            ],
+            "discriminator": [
+                208,
+                127,
+                21,
+                1,
+                194,
+                190,
+                196,
+                70
+            ],
+            "accounts": [
+                {
+                    "name": "config",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config_extension",
+            "docs": [
+                "Initializes a WhirlpoolConfigExtension account that hosts info & authorities.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                55,
+                9,
+                53,
+                9,
+                114,
+                57,
+                209,
+                52
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "config_extension",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103,
+                                    95,
+                                    101,
+                                    120,
+                                    116,
+                                    101,
+                                    110,
+                                    115,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_dynamic_tick_array",
+            "docs": [
+                "Initialize a variable-length tick array for a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "- `idempotent` - If true, the instruction will not fail if the tick array already exists.",
+                "Note: The idempotent option exits successfully if a FixedTickArray is present as well as a DynamicTickArray.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                41,
+                33,
+                165,
+                200,
+                120,
+                231,
+                142,
+                50
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "idempotent",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "initialize_fee_tier",
+            "docs": [
+                "Initializes a fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                183,
+                74,
+                156,
+                160,
+                112,
+                2,
+                42,
+                30
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                95,
+                180,
+                10,
+                172,
+                84,
+                174,
+                232,
+                40
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "WhirlpoolBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_v2",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "This instruction works with both Token and Token-2022.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                207,
+                45,
+                87,
+                242,
+                27,
+                63,
+                204,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_with_adaptive_fee",
+            "docs": [
+                "Initializes a Whirlpool account and Oracle account with adaptive fee.",
+                "",
+                "### Parameters",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "- `trade_enable_timestamp` - The timestamp when trading is enabled for this pool (within 72 hours)",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                "`InvalidTradeEnableTimestamp` - provided trade_enable_timestamp is not within 72 hours or the adaptive fee-tier is permission-less",
+                "`UnsupportedTokenMint` - The provided token mint is not supported by the program (e.g. it has risky token extensions)",
+                ""
+            ],
+            "discriminator": [
+                143,
+                94,
+                96,
+                76,
+                172,
+                124,
+                119,
+                199
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "adaptive_fee_tier.fee_tier_index",
+                                "account": "AdaptiveFeeTier"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                },
+                {
+                    "name": "trade_enable_timestamp",
+                    "type": {
+                        "option": "u64"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_position_bundle",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet."
+            ],
+            "discriminator": [
+                117,
+                45,
+                241,
+                149,
+                24,
+                18,
+                194,
+                65
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_position_bundle_with_metadata",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet.",
+                "Additional Metaplex metadata is appended to identify the token."
+            ],
+            "discriminator": [
+                93,
+                124,
+                16,
+                179,
+                249,
+                131,
+                115,
+                245
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_metadata",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/metaplex-program-library/blob/773a574c4b34e5b9f248a81306ec24db064e255f/token-metadata/program/src/utils/metadata.rs#L100"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_reward",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                95,
+                135,
+                192,
+                196,
+                242,
+                129,
+                230,
+                68
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_reward_v2",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                91,
+                1,
+                77,
+                50,
+                235,
+                229,
+                133,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_token_badge",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool.whirlpools_config",
+                                "account": "Whirlpool"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "reward_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_tick_array",
+            "docs": [
+                "Initializes a fixed-length tick_array account to represent a tick-range in a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                11,
+                188,
+                193,
+                214,
+                141,
+                91,
+                149,
+                184
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "initialize_token_badge",
+            "docs": [
+                "Initialize a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                253,
+                77,
+                205,
+                95,
+                27,
+                224,
+                89,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "lock_position",
+            "docs": [
+                "Lock the position to prevent any liquidity changes.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `PositionAlreadyLocked` - The provided position is already locked.",
+                "- `PositionNotLockable` - The provided position is not lockable (e.g. An empty position)."
+            ],
+            "discriminator": [
+                227,
+                62,
+                2,
+                252,
+                247,
+                10,
+                171,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    108,
+                                    111,
+                                    99,
+                                    107,
+                                    95,
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "lock_type",
+                    "type": {
+                        "defined": {
+                            "name": "LockType"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "migrate_repurpose_reward_authority_space",
+            "docs": [
+                "Migration instruction to repurpose the reward authority space in the Whirlpool.",
+                "TODO: This instruction should be removed once all pools have been migrated."
+            ],
+            "discriminator": [
+                214,
+                161,
+                248,
+                79,
+                152,
+                98,
+                172,
+                231
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "open_bundled_position",
+            "docs": [
+                "Open a bundled position in a Whirlpool. No new tokens are issued",
+                "because the owner of the position bundle becomes the owner of the position.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to open.",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                169,
+                113,
+                126,
+                171,
+                213,
+                172,
+                212,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                135,
+                128,
+                47,
+                77,
+                15,
+                152,
+                240,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_metadata",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional Metaplex metadata is appended to identify the token.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                242,
+                29,
+                134,
+                48,
+                58,
+                110,
+                14,
+                60
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_metadata_account",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/mpl-token-metadata/blob/master/programs/token-metadata/program/src/utils/metadata.rs#L78"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionWithMetadataBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_token_extensions",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional TokenMetadata extension is initialized to identify the token.",
+                "Mint and TokenAccount are based on Token-2022.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "- `with_token_metadata_extension` - If true, the token metadata extension will be initialized.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                212,
+                47,
+                95,
+                92,
+                114,
+                102,
+                131,
+                250
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "with_token_metadata_extension",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "reposition_liquidity_v2",
+            "docs": [
+                "An atomic instruction that repositions liquidity for a position through the following steps:",
+                "- Withdraws liquidity from the current position range",
+                "- Resets the position to a new tick range",
+                "- Adds liquidity to the new position range",
+                "- Restores fees and rewards",
+                "",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick index for the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick index for the upper end of the position range.",
+                "- `new_liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `existing_range_token_min_a` - The minimum amount of tokenA the user is willing to withdraw from the existing range.",
+                "- `existing_range_token_min_b` - The minimum amount of tokenB the user is willing to withdraw from the existing range.",
+                "- `new_range_token_max_a` - The maximum amount of tokenA the user is willing to deposit into the new range.",
+                "- `new_range_token_max_b` - The maximum amount of tokenB the user is willing to deposit into the new range.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                191,
+                169,
+                224,
+                11,
+                131,
+                19,
+                158,
+                253
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "RepositionLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "reset_position_range",
+            "docs": [
+                "Reset the position range to a new range.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick specifying the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                164,
+                123,
+                180,
+                141,
+                194,
+                100,
+                160,
+                175
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "set_adaptive_fee_constants",
+            "docs": [
+                "Sets specific adaptive fee constants for a pool. Only the provided constants will be updated,",
+                "others remain unchanged. Caller should avoid invoking this instruction when a pool's adaptive",
+                "fee is high to prevent LP revenue loss",
+                "",
+                "### Authority",
+                "- `fee_authority` - Set authority in the WhirlpoolsConfig",
+                "",
+                "### Parameters",
+                "All parameters are optional. Only provided values will be updated.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidAdaptiveFeeConstants` - If the resulting constants are invalid for the pool's tick_spacing.",
+                "- `AdaptiveFeeConstantsUnchanged` - If the provided adaptive fee constants are unchanged from the existing constants."
+            ],
+            "discriminator": [
+                133,
+                158,
+                212,
+                189,
+                237,
+                12,
+                73,
+                39
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "oracle"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "oracle",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "decay_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": {
+                        "option": "u16"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_collect_protocol_fees_authority",
+            "docs": [
+                "Sets the fee authority to collect protocol fees for a WhirlpoolConfig.",
+                "Only the current collect protocol fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can collect protocol fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                34,
+                150,
+                93,
+                244,
+                139,
+                225,
+                233,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_collect_protocol_fees_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_extension_authority",
+            "docs": [
+                "Sets the config extension authority for a WhirlpoolsConfigExtension.",
+                "Only the current config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                44,
+                94,
+                241,
+                116,
+                24,
+                188,
+                60,
+                143
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_config_extension_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_feature_flag",
+            "docs": [
+                "Sets the feature flag for a WhirlpoolConfig.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `feature_flag` - The feature flag that the WhirlpoolConfig will use."
+            ],
+            "discriminator": [
+                71,
+                173,
+                228,
+                18,
+                67,
+                247,
+                210,
+                57
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "feature_flag",
+                    "type": {
+                        "defined": {
+                            "name": "ConfigFeatureFlag"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_default_base_fee_rate",
+            "docs": [
+                "Set the default_base_fee_rate for an AdaptiveFeeTier",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_base_fee_rate` - The default base fee rate that a pool will use if the pool uses this",
+                "adaptive fee-tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                229,
+                66,
+                84,
+                251,
+                164,
+                134,
+                183,
+                7
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_fee_rate",
+            "docs": [
+                "Set the default_fee_rate for a FeeTier",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                118,
+                215,
+                214,
+                157,
+                182,
+                229,
+                208,
+                228
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_protocol_fee_rate",
+            "docs": [
+                "Sets the default protocol fee rate for a WhirlpoolConfig",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_protocol_fee_rate` - Rate that is referenced during the initialization of a Whirlpool using this config.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                107,
+                205,
+                249,
+                226,
+                151,
+                35,
+                86,
+                0
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_delegated_fee_authority",
+            "docs": [
+                "Sets the delegated fee authority for an AdaptiveFeeTier.",
+                "The delegated fee authority can set the fee rate for individual pools initialized with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                193,
+                234,
+                231,
+                147,
+                138,
+                57,
+                3,
+                122
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_delegated_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_authority",
+            "docs": [
+                "Sets the fee authority for a WhirlpoolConfig.",
+                "The fee authority can set the fee & protocol fee rate for individual pools or",
+                "set the default fee rate for newly minted pools.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                31,
+                1,
+                50,
+                87,
+                237,
+                101,
+                97,
+                132
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_rate",
+            "docs": [
+                "Sets the fee rate for a Whirlpool.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                53,
+                243,
+                137,
+                65,
+                8,
+                140,
+                158,
+                6
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_fee_rate_by_delegated_fee_authority",
+            "docs": [
+                "Sets the fee rate for a Whirlpool by the delegated fee authority in AdaptiveFeeTier.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "",
+                "### Authority",
+                "- \"delegated_fee_authority\" - Set authority that can modify pool fees in the AdaptiveFeeTier",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                121,
+                121,
+                54,
+                114,
+                131,
+                230,
+                162,
+                104
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_initialize_pool_authority",
+            "docs": [
+                "Sets the initialize pool authority for an AdaptiveFeeTier.",
+                "Only the initialize pool authority can initialize pools with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                125,
+                43,
+                127,
+                235,
+                149,
+                26,
+                106,
+                236
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_initialize_pool_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_preset_adaptive_fee_constants",
+            "docs": [
+                "Sets the adaptive fee constants for an AdaptiveFeeTier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap."
+            ],
+            "discriminator": [
+                132,
+                185,
+                66,
+                148,
+                83,
+                88,
+                134,
+                198
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_protocol_fee_rate",
+            "docs": [
+                "Sets the protocol fee rate for a Whirlpool.",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `protocol_fee_rate` - The rate that the pool will use to calculate protocol fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                95,
+                7,
+                4,
+                50,
+                154,
+                79,
+                156,
+                131
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward authority for this reward index has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                34,
+                39,
+                183,
+                252,
+                83,
+                28,
+                85,
+                127
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority_by_super_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                240,
+                154,
+                201,
+                198,
+                148,
+                93,
+                56,
+                25
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                13,
+                197,
+                86,
+                168,
+                109,
+                176,
+                27,
+                244
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions_super_authority",
+            "docs": [
+                "Set the whirlpool reward super authority for a WhirlpoolConfig",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "This instruction will not change the authority on any `WhirlpoolRewardInfo` whirlpool rewards.",
+                "",
+                "### Authority",
+                "- \"reward_emissions_super_authority\" - Set authority that can control reward authorities for all pools in this config space."
+            ],
+            "discriminator": [
+                207,
+                5,
+                200,
+                209,
+                122,
+                56,
+                82,
+                183
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_emissions_super_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_reward_emissions_v2",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                114,
+                228,
+                72,
+                32,
+                193,
+                48,
+                160,
+                102
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_attribute",
+            "docs": [
+                "Set an attribute on a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Parameters",
+                "- `attribute` - The attribute to set on the TokenBadge account.",
+                "",
+                "#### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                224,
+                88,
+                65,
+                33,
+                138,
+                147,
+                246,
+                137
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint",
+                    "relations": [
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "attribute",
+                    "type": {
+                        "defined": {
+                            "name": "TokenBadgeAttribute"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_authority",
+            "docs": [
+                "Sets the token badge authority for a WhirlpoolsConfigExtension.",
+                "Only the config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                207,
+                202,
+                4,
+                32,
+                205,
+                79,
+                13,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_token_badge_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "swap",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                248,
+                198,
+                158,
+                145,
+                225,
+                117,
+                135,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "swap_v2",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                43,
+                4,
+                237,
+                11,
+                26,
+                201,
+                30,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "transfer_locked_position",
+            "docs": [
+                "Transfer a locked position to a different token account.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token."
+            ],
+            "discriminator": [
+                179,
+                121,
+                229,
+                46,
+                67,
+                138,
+                194,
+                138
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    },
+                    "relations": [
+                        "lock_config"
+                    ]
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "destination_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "two_hop_swap",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                195,
+                96,
+                237,
+                108,
+                68,
+                162,
+                219,
+                230
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "two_hop_swap_v2",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                186,
+                143,
+                209,
+                29,
+                254,
+                2,
+                194,
+                117
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_input"
+                },
+                {
+                    "name": "token_mint_intermediate"
+                },
+                {
+                    "name": "token_mint_output"
+                },
+                {
+                    "name": "token_program_input"
+                },
+                {
+                    "name": "token_program_intermediate"
+                },
+                {
+                    "name": "token_program_output"
+                },
+                {
+                    "name": "token_owner_account_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "update_fees_and_rewards",
+            "docs": [
+                "Update the accrued fees and rewards for a position.",
+                "",
+                "#### Special Errors",
+                "- `TickNotFound` - Provided tick array account does not contain the tick for this position.",
+                "- `LiquidityZero` - Position has zero liquidity and therefore already has the most updated fees and reward values."
+            ],
+            "discriminator": [
+                154,
+                230,
+                250,
+                13,
+                236,
+                209,
+                75,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower"
+                },
+                {
+                    "name": "tick_array_upper"
+                }
+            ],
+            "args": []
         }
-      ]
-    },
-    {
-      "name": "LiquidityIncreased",
-      "fields": [
+    ],
+    "accounts": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "AdaptiveFeeTier",
+            "discriminator": [
+                147,
+                16,
+                144,
+                116,
+                47,
+                146,
+                149,
+                46
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "DynamicTickArray",
+            "discriminator": [
+                17,
+                216,
+                246,
+                142,
+                225,
+                199,
+                218,
+                56
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "FeeTier",
+            "discriminator": [
+                56,
+                75,
+                159,
+                76,
+                142,
+                68,
+                190,
+                105
+            ]
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "LockConfig",
+            "discriminator": [
+                106,
+                47,
+                238,
+                159,
+                124,
+                12,
+                160,
+                192
+            ]
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "Oracle",
+            "discriminator": [
+                139,
+                194,
+                131,
+                179,
+                140,
+                179,
+                229,
+                244
+            ]
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "Position",
+            "discriminator": [
+                170,
+                188,
+                143,
+                228,
+                122,
+                64,
+                247,
+                208
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "PositionBundle",
+            "discriminator": [
+                129,
+                169,
+                175,
+                65,
+                185,
+                95,
+                32,
+                100
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TickArray",
+            "discriminator": [
+                69,
+                97,
+                189,
+                190,
+                110,
+                7,
+                66,
+                187
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TokenBadge",
+            "discriminator": [
+                116,
+                219,
+                204,
+                229,
+                249,
+                116,
+                255,
+                150
+            ]
+        },
+        {
+            "name": "Whirlpool",
+            "discriminator": [
+                63,
+                149,
+                209,
+                12,
+                225,
+                128,
+                99,
+                9
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "discriminator": [
+                157,
+                20,
+                49,
+                224,
+                217,
+                87,
+                193,
+                254
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "discriminator": [
+                2,
+                99,
+                215,
+                163,
+                240,
+                26,
+                153,
+                58
+            ]
         }
-      ]
-    },
-    {
-      "name": "PoolInitialized",
-      "fields": [
+    ],
+    "events": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityDecreased",
+            "discriminator": [
+                166,
+                1,
+                36,
+                71,
+                112,
+                202,
+                181,
+                171
+            ]
         },
         {
-          "name": "whirlpoolsConfig",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityIncreased",
+            "discriminator": [
+                30,
+                7,
+                144,
+                181,
+                102,
+                254,
+                155,
+                161
+            ]
         },
         {
-          "name": "tokenMintA",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityRepositioned",
+            "discriminator": [
+                95,
+                130,
+                181,
+                132,
+                251,
+                50,
+                195,
+                38
+            ]
         },
         {
-          "name": "tokenMintB",
-          "type": "publicKey",
-          "index": false
+            "name": "PoolInitialized",
+            "discriminator": [
+                100,
+                118,
+                173,
+                87,
+                12,
+                198,
+                254,
+                229
+            ]
         },
         {
-          "name": "tickSpacing",
-          "type": "u16",
-          "index": false
+            "name": "PositionOpened",
+            "discriminator": [
+                237,
+                175,
+                243,
+                230,
+                147,
+                117,
+                101,
+                121
+            ]
         },
         {
-          "name": "tokenProgramA",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenProgramB",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "decimalsA",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "decimalsB",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128",
-          "index": false
+            "name": "Traded",
+            "discriminator": [
+                225,
+                202,
+                73,
+                175,
+                147,
+                43,
+                160,
+                150
+            ]
         }
-      ]
-    },
-    {
-      "name": "Traded",
-      "fields": [
+    ],
+    "errors": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "code": 6000,
+            "name": "InvalidEnum",
+            "msg": "Enum value could not be converted"
         },
         {
-          "name": "aToB",
-          "type": "bool",
-          "index": false
+            "code": 6001,
+            "name": "InvalidStartTick",
+            "msg": "Invalid start tick index provided."
         },
         {
-          "name": "preSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6002,
+            "name": "TickArrayExistInPool",
+            "msg": "Tick-array already exists in this whirlpool"
         },
         {
-          "name": "postSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6003,
+            "name": "TickArrayIndexOutofBounds",
+            "msg": "Attempt to search for a tick-array failed"
         },
         {
-          "name": "inputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6004,
+            "name": "InvalidTickSpacing",
+            "msg": "Tick-spacing is not supported"
         },
         {
-          "name": "outputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6005,
+            "name": "ClosePositionNotEmpty",
+            "msg": "Position is not empty It cannot be closed"
         },
         {
-          "name": "inputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6006,
+            "name": "DivideByZero",
+            "msg": "Unable to divide by zero"
         },
         {
-          "name": "outputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6007,
+            "name": "NumberCastError",
+            "msg": "Unable to cast number into BigInt"
         },
         {
-          "name": "lpFee",
-          "type": "u64",
-          "index": false
+            "code": 6008,
+            "name": "NumberDownCastError",
+            "msg": "Unable to down cast number"
         },
         {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
+            "code": 6009,
+            "name": "TickNotFound",
+            "msg": "Tick not found within tick array"
+        },
+        {
+            "code": 6010,
+            "name": "InvalidTickIndex",
+            "msg": "Provided tick index is either out of bounds or uninitializable"
+        },
+        {
+            "code": 6011,
+            "name": "SqrtPriceOutOfBounds",
+            "msg": "Provided sqrt price out of bounds"
+        },
+        {
+            "code": 6012,
+            "name": "LiquidityZero",
+            "msg": "Liquidity amount must be greater than zero"
+        },
+        {
+            "code": 6013,
+            "name": "LiquidityTooHigh",
+            "msg": "Liquidity amount must be less than i64::MAX"
+        },
+        {
+            "code": 6014,
+            "name": "LiquidityOverflow",
+            "msg": "Liquidity overflow"
+        },
+        {
+            "code": 6015,
+            "name": "LiquidityUnderflow",
+            "msg": "Liquidity underflow"
+        },
+        {
+            "code": 6016,
+            "name": "LiquidityNetError",
+            "msg": "Tick liquidity net underflowed or overflowed"
+        },
+        {
+            "code": 6017,
+            "name": "TokenMaxExceeded",
+            "msg": "Exceeded token max"
+        },
+        {
+            "code": 6018,
+            "name": "TokenMinSubceeded",
+            "msg": "Did not meet token min"
+        },
+        {
+            "code": 6019,
+            "name": "MissingOrInvalidDelegate",
+            "msg": "Position token account has a missing or invalid delegate"
+        },
+        {
+            "code": 6020,
+            "name": "InvalidPositionTokenAmount",
+            "msg": "Position token amount must be 1"
+        },
+        {
+            "code": 6021,
+            "name": "InvalidTimestampConversion",
+            "msg": "Timestamp should be convertible from i64 to u64"
+        },
+        {
+            "code": 6022,
+            "name": "InvalidTimestamp",
+            "msg": "Timestamp should be greater than the last updated timestamp"
+        },
+        {
+            "code": 6023,
+            "name": "InvalidTickArraySequence",
+            "msg": "Invalid tick array sequence provided for instruction."
+        },
+        {
+            "code": 6024,
+            "name": "InvalidTokenMintOrder",
+            "msg": "Token Mint in wrong order"
+        },
+        {
+            "code": 6025,
+            "name": "RewardNotInitialized",
+            "msg": "Reward not initialized"
+        },
+        {
+            "code": 6026,
+            "name": "InvalidRewardIndex",
+            "msg": "Invalid reward index"
+        },
+        {
+            "code": 6027,
+            "name": "RewardVaultAmountInsufficient",
+            "msg": "Reward vault requires amount to support emissions for at least one day"
+        },
+        {
+            "code": 6028,
+            "name": "FeeRateMaxExceeded",
+            "msg": "Exceeded max fee rate"
+        },
+        {
+            "code": 6029,
+            "name": "ProtocolFeeRateMaxExceeded",
+            "msg": "Exceeded max protocol fee rate"
+        },
+        {
+            "code": 6030,
+            "name": "MultiplicationShiftRightOverflow",
+            "msg": "Multiplication with shift right overflow"
+        },
+        {
+            "code": 6031,
+            "name": "MulDivOverflow",
+            "msg": "Muldiv overflow"
+        },
+        {
+            "code": 6032,
+            "name": "MulDivInvalidInput",
+            "msg": "Invalid div_u256 input"
+        },
+        {
+            "code": 6033,
+            "name": "MultiplicationOverflow",
+            "msg": "Multiplication overflow"
+        },
+        {
+            "code": 6034,
+            "name": "InvalidSqrtPriceLimitDirection",
+            "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
+        },
+        {
+            "code": 6035,
+            "name": "ZeroTradableAmount",
+            "msg": "There are no tradable amount to swap."
+        },
+        {
+            "code": 6036,
+            "name": "AmountOutBelowMinimum",
+            "msg": "Amount out below minimum threshold"
+        },
+        {
+            "code": 6037,
+            "name": "AmountInAboveMaximum",
+            "msg": "Amount in above maximum threshold"
+        },
+        {
+            "code": 6038,
+            "name": "TickArraySequenceInvalidIndex",
+            "msg": "Invalid index for tick array sequence"
+        },
+        {
+            "code": 6039,
+            "name": "AmountCalcOverflow",
+            "msg": "Amount calculated overflows"
+        },
+        {
+            "code": 6040,
+            "name": "AmountRemainingOverflow",
+            "msg": "Amount remaining overflows"
+        },
+        {
+            "code": 6041,
+            "name": "InvalidIntermediaryMint",
+            "msg": "Invalid intermediary mint"
+        },
+        {
+            "code": 6042,
+            "name": "DuplicateTwoHopPool",
+            "msg": "Duplicate two hop pool"
+        },
+        {
+            "code": 6043,
+            "name": "InvalidBundleIndex",
+            "msg": "Bundle index is out of bounds"
+        },
+        {
+            "code": 6044,
+            "name": "BundledPositionAlreadyOpened",
+            "msg": "Position has already been opened"
+        },
+        {
+            "code": 6045,
+            "name": "BundledPositionAlreadyClosed",
+            "msg": "Position has already been closed"
+        },
+        {
+            "code": 6046,
+            "name": "PositionBundleNotDeletable",
+            "msg": "Unable to delete PositionBundle with open positions"
+        },
+        {
+            "code": 6047,
+            "name": "UnsupportedTokenMint",
+            "msg": "Token mint has unsupported attributes"
+        },
+        {
+            "code": 6048,
+            "name": "RemainingAccountsInvalidSlice",
+            "msg": "Invalid remaining accounts"
+        },
+        {
+            "code": 6049,
+            "name": "RemainingAccountsInsufficient",
+            "msg": "Insufficient remaining accounts"
+        },
+        {
+            "code": 6050,
+            "name": "NoExtraAccountsForTransferHook",
+            "msg": "Unable to call transfer hook without extra accounts"
+        },
+        {
+            "code": 6051,
+            "name": "IntermediateTokenAmountMismatch",
+            "msg": "Output and input amount mismatch"
+        },
+        {
+            "code": 6052,
+            "name": "TransferFeeCalculationError",
+            "msg": "Transfer fee calculation failed"
+        },
+        {
+            "code": 6053,
+            "name": "RemainingAccountsDuplicatedAccountsType",
+            "msg": "Same accounts type is provided more than once"
+        },
+        {
+            "code": 6054,
+            "name": "FullRangeOnlyPool",
+            "msg": "This whirlpool only supports full-range positions"
+        },
+        {
+            "code": 6055,
+            "name": "TooManySupplementalTickArrays",
+            "msg": "Too many supplemental tick arrays provided"
+        },
+        {
+            "code": 6056,
+            "name": "DifferentWhirlpoolTickArrayAccount",
+            "msg": "TickArray account for different whirlpool provided"
+        },
+        {
+            "code": 6057,
+            "name": "PartialFillError",
+            "msg": "Trade resulted in partial fill"
+        },
+        {
+            "code": 6058,
+            "name": "PositionNotLockable",
+            "msg": "Position is not lockable"
+        },
+        {
+            "code": 6059,
+            "name": "OperationNotAllowedOnLockedPosition",
+            "msg": "Operation not allowed on locked position"
+        },
+        {
+            "code": 6060,
+            "name": "SameTickRangeNotAllowed",
+            "msg": "Cannot reset position range with same tick range"
+        },
+        {
+            "code": 6061,
+            "name": "InvalidAdaptiveFeeConstants",
+            "msg": "Invalid adaptive fee constants"
+        },
+        {
+            "code": 6062,
+            "name": "InvalidFeeTierIndex",
+            "msg": "Invalid fee tier index"
+        },
+        {
+            "code": 6063,
+            "name": "InvalidTradeEnableTimestamp",
+            "msg": "Invalid trade enable timestamp"
+        },
+        {
+            "code": 6064,
+            "name": "TradeIsNotEnabled",
+            "msg": "Trade is not enabled yet"
+        },
+        {
+            "code": 6065,
+            "name": "RentCalculationError",
+            "msg": "Rent calculation error"
+        },
+        {
+            "code": 6066,
+            "name": "FeatureIsNotEnabled",
+            "msg": "Feature is not enabled"
+        },
+        {
+            "code": 6067,
+            "name": "PositionWithTokenExtensionsRequired",
+            "msg": "This whirlpool only supports open_position_with_token_extensions instruction"
+        },
+        {
+            "code": 6068,
+            "name": "AdaptiveFeeConstantsUnchanged",
+            "msg": "Provided adaptive fee constants are unchanged"
+        },
+        {
+            "code": 6069,
+            "name": "PriceSlippageOutOfBounds",
+            "msg": "Price outside slippage bounds"
         }
-      ]
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "InvalidEnum",
-      "msg": "Enum value could not be converted"
-    },
-    {
-      "code": 6001,
-      "name": "InvalidStartTick",
-      "msg": "Invalid start tick index provided."
-    },
-    {
-      "code": 6002,
-      "name": "TickArrayExistInPool",
-      "msg": "Tick-array already exists in this whirlpool"
-    },
-    {
-      "code": 6003,
-      "name": "TickArrayIndexOutofBounds",
-      "msg": "Attempt to search for a tick-array failed"
-    },
-    {
-      "code": 6004,
-      "name": "InvalidTickSpacing",
-      "msg": "Tick-spacing is not supported"
-    },
-    {
-      "code": 6005,
-      "name": "ClosePositionNotEmpty",
-      "msg": "Position is not empty It cannot be closed"
-    },
-    {
-      "code": 6006,
-      "name": "DivideByZero",
-      "msg": "Unable to divide by zero"
-    },
-    {
-      "code": 6007,
-      "name": "NumberCastError",
-      "msg": "Unable to cast number into BigInt"
-    },
-    {
-      "code": 6008,
-      "name": "NumberDownCastError",
-      "msg": "Unable to down cast number"
-    },
-    {
-      "code": 6009,
-      "name": "TickNotFound",
-      "msg": "Tick not found within tick array"
-    },
-    {
-      "code": 6010,
-      "name": "InvalidTickIndex",
-      "msg": "Provided tick index is either out of bounds or uninitializable"
-    },
-    {
-      "code": 6011,
-      "name": "SqrtPriceOutOfBounds",
-      "msg": "Provided sqrt price out of bounds"
-    },
-    {
-      "code": 6012,
-      "name": "LiquidityZero",
-      "msg": "Liquidity amount must be greater than zero"
-    },
-    {
-      "code": 6013,
-      "name": "LiquidityTooHigh",
-      "msg": "Liquidity amount must be less than i64::MAX"
-    },
-    {
-      "code": 6014,
-      "name": "LiquidityOverflow",
-      "msg": "Liquidity overflow"
-    },
-    {
-      "code": 6015,
-      "name": "LiquidityUnderflow",
-      "msg": "Liquidity underflow"
-    },
-    {
-      "code": 6016,
-      "name": "LiquidityNetError",
-      "msg": "Tick liquidity net underflowed or overflowed"
-    },
-    {
-      "code": 6017,
-      "name": "TokenMaxExceeded",
-      "msg": "Exceeded token max"
-    },
-    {
-      "code": 6018,
-      "name": "TokenMinSubceeded",
-      "msg": "Did not meet token min"
-    },
-    {
-      "code": 6019,
-      "name": "MissingOrInvalidDelegate",
-      "msg": "Position token account has a missing or invalid delegate"
-    },
-    {
-      "code": 6020,
-      "name": "InvalidPositionTokenAmount",
-      "msg": "Position token amount must be 1"
-    },
-    {
-      "code": 6021,
-      "name": "InvalidTimestampConversion",
-      "msg": "Timestamp should be convertible from i64 to u64"
-    },
-    {
-      "code": 6022,
-      "name": "InvalidTimestamp",
-      "msg": "Timestamp should be greater than the last updated timestamp"
-    },
-    {
-      "code": 6023,
-      "name": "InvalidTickArraySequence",
-      "msg": "Invalid tick array sequence provided for instruction."
-    },
-    {
-      "code": 6024,
-      "name": "InvalidTokenMintOrder",
-      "msg": "Token Mint in wrong order"
-    },
-    {
-      "code": 6025,
-      "name": "RewardNotInitialized",
-      "msg": "Reward not initialized"
-    },
-    {
-      "code": 6026,
-      "name": "InvalidRewardIndex",
-      "msg": "Invalid reward index"
-    },
-    {
-      "code": 6027,
-      "name": "RewardVaultAmountInsufficient",
-      "msg": "Reward vault requires amount to support emissions for at least one day"
-    },
-    {
-      "code": 6028,
-      "name": "FeeRateMaxExceeded",
-      "msg": "Exceeded max fee rate"
-    },
-    {
-      "code": 6029,
-      "name": "ProtocolFeeRateMaxExceeded",
-      "msg": "Exceeded max protocol fee rate"
-    },
-    {
-      "code": 6030,
-      "name": "MultiplicationShiftRightOverflow",
-      "msg": "Multiplication with shift right overflow"
-    },
-    {
-      "code": 6031,
-      "name": "MulDivOverflow",
-      "msg": "Muldiv overflow"
-    },
-    {
-      "code": 6032,
-      "name": "MulDivInvalidInput",
-      "msg": "Invalid div_u256 input"
-    },
-    {
-      "code": 6033,
-      "name": "MultiplicationOverflow",
-      "msg": "Multiplication overflow"
-    },
-    {
-      "code": 6034,
-      "name": "InvalidSqrtPriceLimitDirection",
-      "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
-    },
-    {
-      "code": 6035,
-      "name": "ZeroTradableAmount",
-      "msg": "There are no tradable amount to swap."
-    },
-    {
-      "code": 6036,
-      "name": "AmountOutBelowMinimum",
-      "msg": "Amount out below minimum threshold"
-    },
-    {
-      "code": 6037,
-      "name": "AmountInAboveMaximum",
-      "msg": "Amount in above maximum threshold"
-    },
-    {
-      "code": 6038,
-      "name": "TickArraySequenceInvalidIndex",
-      "msg": "Invalid index for tick array sequence"
-    },
-    {
-      "code": 6039,
-      "name": "AmountCalcOverflow",
-      "msg": "Amount calculated overflows"
-    },
-    {
-      "code": 6040,
-      "name": "AmountRemainingOverflow",
-      "msg": "Amount remaining overflows"
-    },
-    {
-      "code": 6041,
-      "name": "InvalidIntermediaryMint",
-      "msg": "Invalid intermediary mint"
-    },
-    {
-      "code": 6042,
-      "name": "DuplicateTwoHopPool",
-      "msg": "Duplicate two hop pool"
-    },
-    {
-      "code": 6043,
-      "name": "InvalidBundleIndex",
-      "msg": "Bundle index is out of bounds"
-    },
-    {
-      "code": 6044,
-      "name": "BundledPositionAlreadyOpened",
-      "msg": "Position has already been opened"
-    },
-    {
-      "code": 6045,
-      "name": "BundledPositionAlreadyClosed",
-      "msg": "Position has already been closed"
-    },
-    {
-      "code": 6046,
-      "name": "PositionBundleNotDeletable",
-      "msg": "Unable to delete PositionBundle with open positions"
-    },
-    {
-      "code": 6047,
-      "name": "UnsupportedTokenMint",
-      "msg": "Token mint has unsupported attributes"
-    },
-    {
-      "code": 6048,
-      "name": "RemainingAccountsInvalidSlice",
-      "msg": "Invalid remaining accounts"
-    },
-    {
-      "code": 6049,
-      "name": "RemainingAccountsInsufficient",
-      "msg": "Insufficient remaining accounts"
-    },
-    {
-      "code": 6050,
-      "name": "NoExtraAccountsForTransferHook",
-      "msg": "Unable to call transfer hook without extra accounts"
-    },
-    {
-      "code": 6051,
-      "name": "IntermediateTokenAmountMismatch",
-      "msg": "Output and input amount mismatch"
-    },
-    {
-      "code": 6052,
-      "name": "TransferFeeCalculationError",
-      "msg": "Transfer fee calculation failed"
-    },
-    {
-      "code": 6053,
-      "name": "RemainingAccountsDuplicatedAccountsType",
-      "msg": "Same accounts type is provided more than once"
-    },
-    {
-      "code": 6054,
-      "name": "FullRangeOnlyPool",
-      "msg": "This whirlpool only supports full-range positions"
-    },
-    {
-      "code": 6055,
-      "name": "TooManySupplementalTickArrays",
-      "msg": "Too many supplemental tick arrays provided"
-    },
-    {
-      "code": 6056,
-      "name": "DifferentWhirlpoolTickArrayAccount",
-      "msg": "TickArray account for different whirlpool provided"
-    },
-    {
-      "code": 6057,
-      "name": "PartialFillError",
-      "msg": "Trade resulted in partial fill"
-    },
-    {
-      "code": 6058,
-      "name": "PositionNotLockable",
-      "msg": "Position is not lockable"
-    },
-    {
-      "code": 6059,
-      "name": "OperationNotAllowedOnLockedPosition",
-      "msg": "Operation not allowed on locked position"
-    },
-    {
-      "code": 6060,
-      "name": "SameTickRangeNotAllowed",
-      "msg": "Cannot reset position range with same tick range"
-    },
-    {
-      "code": 6061,
-      "name": "InvalidAdaptiveFeeConstants",
-      "msg": "Invalid adaptive fee constants"
-    },
-    {
-      "code": 6062,
-      "name": "InvalidFeeTierIndex",
-      "msg": "Invalid fee tier index"
-    },
-    {
-      "code": 6063,
-      "name": "InvalidTradeEnableTimestamp",
-      "msg": "Invalid trade enable timestamp"
-    },
-    {
-      "code": 6064,
-      "name": "TradeIsNotEnabled",
-      "msg": "Trade is not enabled yet"
-    }
-  ]
+    ],
+    "types": [
+        {
+            "name": "AccountsType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TransferHookA"
+                    },
+                    {
+                        "name": "TransferHookB"
+                    },
+                    {
+                        "name": "TransferHookReward"
+                    },
+                    {
+                        "name": "TransferHookInput"
+                    },
+                    {
+                        "name": "TransferHookIntermediate"
+                    },
+                    {
+                        "name": "TransferHookOutput"
+                    },
+                    {
+                        "name": "SupplementalTickArrays"
+                    },
+                    {
+                        "name": "SupplementalTickArraysOne"
+                    },
+                    {
+                        "name": "SupplementalTickArraysTwo"
+                    },
+                    {
+                        "name": "TransferHookDepositA"
+                    },
+                    {
+                        "name": "TransferHookDepositB"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalA"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalB"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeConstants",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_tier_index",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "initialize_pool_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "delegated_fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_base_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeVariables",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "last_reference_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "last_major_swap_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_index_reference",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "ConfigFeatureFlag",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TokenBadge",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTick",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Uninitialized"
+                    },
+                    {
+                        "name": "Initialized",
+                        "fields": [
+                            {
+                                "defined": {
+                                    "name": "DynamicTickData"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickArray",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_bitmap",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "DynamicTick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickData",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "FeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "default_fee_rate",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "IncreaseLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByTokenAmounts",
+                        "fields": [
+                            {
+                                "name": "token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "token_max_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "min_sqrt_price",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "max_sqrt_price",
+                                "type": "u128"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityDecreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityIncreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityRepositioned",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "existing_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "new_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "existing_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "existing_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_a_transfer_from_owner",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "token_b_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_b_transfer_from_owner",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_owner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "locked_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lock_type",
+                        "type": {
+                            "defined": {
+                                "name": "LockTypeLabel"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockTypeLabel",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionWithMetadataBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "metadata_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Oracle",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "trade_enable_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "adaptive_fee_constants",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeConstants"
+                            }
+                        }
+                    },
+                    {
+                        "name": "adaptive_fee_variables",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeVariables"
+                            }
+                        }
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                128
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolInitialized",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "token_program_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_program_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "decimals_a",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "decimals_b",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "initial_sqrt_price",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Position",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "PositionRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionBundle",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bundle_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_bitmap",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionOpened",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionRewardInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "growth_inside_checkpoint",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "amount_owed",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "slices",
+                        "type": {
+                            "vec": {
+                                "defined": {
+                                    "name": "RemainingAccountsSlice"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsSlice",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "accounts_type",
+                        "type": {
+                            "defined": {
+                                "name": "AccountsType"
+                            }
+                        }
+                    },
+                    {
+                        "name": "length",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RepositionLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByLiquidity",
+                        "fields": [
+                            {
+                                "name": "new_liquidity_amount",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "existing_range_token_min_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "existing_range_token_min_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_b",
+                                "type": "u64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Tick",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TickArray",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "Tick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadge",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "attribute_require_non_transferable_position",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadgeAttribute",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "RequireNonTransferablePosition",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Traded",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "a_to_b",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "pre_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "post_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "input_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "input_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lp_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Whirlpool",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool_bump",
+                        "type": {
+                            "array": [
+                                "u8",
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "fee_tier_index_seed",
+                        "type": {
+                            "array": [
+                                "u8",
+                                2
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_current_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "protocol_fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_last_updated_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "WhirlpoolRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolRewardInfo",
+            "docs": [
+                "Stores the state relevant for tracking liquidity mining rewards at the `Whirlpool` level.",
+                "These values are used in conjunction with `PositionRewardInfo`, `Tick.reward_growths_outside`,",
+                "and `Whirlpool.reward_last_updated_timestamp` to determine how many rewards are earned by open",
+                "positions."
+            ],
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "mint",
+                        "docs": [
+                            "Reward token mint."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "vault",
+                        "docs": [
+                            "Reward vault token account."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "extension",
+                        "docs": [
+                            "reward_infos[0]: Authority account that has permission to initialize the reward and set emissions.",
+                            "reward_infos[1]: used for a struct that contains fields for extending the functionality of Whirlpool.",
+                            "reward_infos[2]: reserved for future use.",
+                            "",
+                            "Historical notes:",
+                            "Originally, this was a field named \"authority\", but it was found that there was no opportunity",
+                            "to set different authorities for the three rewards. Therefore, the use of this field was changed for Whirlpool's future extensibility."
+                        ],
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "emissions_per_second_x64",
+                        "docs": [
+                            "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+                        ],
+                        "type": "u128"
+                    },
+                    {
+                        "name": "growth_global_x64",
+                        "docs": [
+                            "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+                            "emissions were turned on."
+                        ],
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "collect_protocol_fees_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "reward_emissions_super_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "feature_flags",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "config_extension_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_badge_authority",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        }
+    ]
 }

--- a/idl/raydium_cpmm.json
+++ b/idl/raydium_cpmm.json
@@ -1,192 +1,337 @@
 {
-  "version": "0.1.0",
-  "name": "raydium_cp_swap",
+  "address": "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C",
   "metadata": {
-    "address": "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C"
+    "name": "raydium_cp_swap",
+    "version": "0.2.0",
+    "spec": "0.1.0",
+    "description": "Raydium constant product AMM, supports Token2022 and without Openbook"
   },
   "instructions": [
     {
-      "name": "createAmmConfig",
+      "name": "close_permission_pda",
       "docs": [
+        "Close a permission account",
+        "",
         "# Arguments",
         "",
-        "* `ctx`- The accounts needed by instruction.",
-        "* `index` - The index of amm config, there may be multiple config.",
-        "* `trade_fee_rate` - Trade fee rate, can be changed.",
-        "* `protocol_fee_rate` - The rate of protocol fee within tarde fee.",
-        "* `fund_fee_rate` - The rate of fund fee within tarde fee.",
+        "* `ctx`- The context of accounts",
         ""
+      ],
+      "discriminator": [
+        156,
+        84,
+        32,
+        118,
+        69,
+        135,
+        70,
+        123
       ],
       "accounts": [
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Address to be set as protocol owner."]
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
         },
         {
-          "name": "ammConfig",
-          "isMut": true,
-          "isSigner": false,
+          "name": "permission_authority"
+        },
+        {
+          "name": "permission",
           "docs": [
             "Initialize config state account to store protocol owner address and fee rates."
-          ]
-        },
-        { "name": "systemProgram", "isMut": false, "isSigner": false }
-      ],
-      "args": [
-        { "name": "index", "type": "u16" },
-        { "name": "tradeFeeRate", "type": "u64" },
-        { "name": "protocolFeeRate", "type": "u64" },
-        { "name": "fundFeeRate", "type": "u64" },
-        { "name": "createPoolFee", "type": "u64" }
-      ]
-    },
-    {
-      "name": "updateAmmConfig",
-      "docs": [
-        "Updates the owner of the amm config",
-        "Must be called by the current owner or admin",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `trade_fee_rate`- The new trade fee rate of amm config, be set when `param` is 0",
-        "* `protocol_fee_rate`- The new protocol fee rate of amm config, be set when `param` is 1",
-        "* `fund_fee_rate`- The new fund fee rate of amm config, be set when `param` is 2",
-        "* `new_owner`- The config's new owner, be set when `param` is 3",
-        "* `new_fund_owner`- The config's new fund owner, be set when `param` is 4",
-        "* `param`- The vaule can be 0 | 1 | 2 | 3 | 4, otherwise will report a error",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["The amm config owner or admin"]
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "permission_authority"
+              }
+            ]
+          }
         },
         {
-          "name": "ammConfig",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Amm config account to be changed"]
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [
-        { "name": "param", "type": "u8" },
-        { "name": "value", "type": "u64" }
-      ]
+      "args": []
     },
     {
-      "name": "updatePoolStatus",
+      "name": "collect_creator_fee",
       "docs": [
-        "Update pool status for given vaule",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `status` - The vaule of status",
-        ""
-      ],
-      "accounts": [
-        { "name": "authority", "isMut": false, "isSigner": true },
-        { "name": "poolState", "isMut": true, "isSigner": false }
-      ],
-      "args": [{ "name": "status", "type": "u8" }]
-    },
-    {
-      "name": "collectProtocolFee",
-      "docs": [
-        "Collect the protocol fee accrued to the pool",
+        "Collect the creator fee",
         "",
         "# Arguments",
         "",
         "* `ctx` - The context of accounts",
-        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
-        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
         ""
+      ],
+      "discriminator": [
+        20,
+        22,
+        86,
+        123,
+        198,
+        28,
+        219,
+        132
       ],
       "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Only admin or owner can collect fee now"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool state stores accumulated protocol fee amount"]
-        },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Amm config account stores owner"]
-        },
-        {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
-        },
-        {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
-        },
-        {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
-        },
-        {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
-        },
-        {
-          "name": "recipientToken0Account",
-          "isMut": true,
-          "isSigner": false,
+          "name": "creator",
           "docs": [
-            "The address that receives the collected token_0 protocol fees"
+            "Only pool creator can collect fee"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores fund_owner"
           ]
         },
         {
-          "name": "recipientToken1Account",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_0_vault",
           "docs": [
-            "The address that receives the collected token_1 protocol fees"
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program to perform token transfers"]
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program 2022 to perform token transfers"]
+          "name": "creator_token_0",
+          "docs": [
+            "The address that receives the collected token_0 fund fees"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "account",
+                "path": "token_0_program"
+              },
+              {
+                "kind": "account",
+                "path": "vault_0_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "creator_token_1",
+          "docs": [
+            "The address that receives the collected token_1 fund fees"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "account",
+                "path": "token_1_program"
+              },
+              {
+                "kind": "account",
+                "path": "vault_1_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_0_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_1_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [
-        { "name": "amount0Requested", "type": "u64" },
-        { "name": "amount1Requested", "type": "u64" }
-      ]
+      "args": []
     },
     {
-      "name": "collectFundFee",
+      "name": "collect_fund_fee",
       "docs": [
         "Collect the fund fee accrued to the pool",
         "",
@@ -197,78 +342,607 @@
         "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
         ""
       ],
+      "discriminator": [
+        167,
+        138,
+        78,
+        149,
+        223,
+        194,
+        6,
+        126
+      ],
       "accounts": [
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Only admin or fund_owner can collect fee now"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool state stores accumulated protocol fee amount"]
+          "docs": [
+            "Only admin or fund_owner can collect fee now"
+          ],
+          "signer": true
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Amm config account stores fund_owner"]
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
         },
         {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores fund_owner"
+          ]
         },
         {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
         },
         {
-          "name": "recipientToken0Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that receives the collected token_0 fund fees"]
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
         },
         {
-          "name": "recipientToken1Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that receives the collected token_1 fund fees"]
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program to perform token transfers"]
+          "name": "recipient_token_0_account",
+          "docs": [
+            "The address that receives the collected token_0 fund fees"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program 2022 to perform token transfers"]
+          "name": "recipient_token_1_account",
+          "docs": [
+            "The address that receives the collected token_1 fund fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The SPL program to perform token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "The SPL program 2022 to perform token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         }
       ],
       "args": [
-        { "name": "amount0Requested", "type": "u64" },
-        { "name": "amount1Requested", "type": "u64" }
+        {
+          "name": "amount_0_requested",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_requested",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "collect_protocol_fee",
+      "docs": [
+        "Collect the protocol fee accrued to the pool",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
+        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
+        ""
+      ],
+      "discriminator": [
+        136,
+        136,
+        252,
+        221,
+        194,
+        66,
+        126,
+        89
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Only admin or owner can collect fee now"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores owner"
+          ]
+        },
+        {
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
+        },
+        {
+          "name": "recipient_token_0_account",
+          "docs": [
+            "The address that receives the collected token_0 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_1_account",
+          "docs": [
+            "The address that receives the collected token_1 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The SPL program to perform token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "The SPL program 2022 to perform token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount_0_requested",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_requested",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_amm_config",
+      "docs": [
+        "# Arguments",
+        "",
+        "* `ctx`- The accounts needed by instruction.",
+        "* `index` - The index of amm config, there may be multiple config.",
+        "* `trade_fee_rate` - Trade fee rate, can be changed.",
+        "* `protocol_fee_rate` - The rate of protocol fee within trade fee.",
+        "* `fund_fee_rate` - The rate of fund fee within trade fee.",
+        ""
+      ],
+      "discriminator": [
+        137,
+        52,
+        237,
+        212,
+        215,
+        117,
+        108,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as protocol owner."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Initialize config state account to store protocol owner address and fee rates."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  109,
+                  109,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u16"
+        },
+        {
+          "name": "trade_fee_rate",
+          "type": "u64"
+        },
+        {
+          "name": "protocol_fee_rate",
+          "type": "u64"
+        },
+        {
+          "name": "fund_fee_rate",
+          "type": "u64"
+        },
+        {
+          "name": "create_pool_fee",
+          "type": "u64"
+        },
+        {
+          "name": "creator_fee_rate",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_permission_pda",
+      "docs": [
+        "Create a permission account",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        135,
+        136,
+        2,
+        216,
+        137,
+        169,
+        181,
+        202
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "permission_authority"
+        },
+        {
+          "name": "permission",
+          "docs": [
+            "Initialize config state account to store protocol owner address and fee rates."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "permission_authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "deposit",
+      "docs": [
+        "Deposit lp token to the pool",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `lp_token_amount` - Increased number of LPs",
+        "* `maximum_token_0_amount` -  Maximum token 0 amount to deposit, prevents excessive slippage",
+        "* `maximum_token_1_amount` - Maximum token 1 amount to deposit, prevents excessive slippage",
+        ""
+      ],
+      "discriminator": [
+        242,
+        35,
+        198,
+        137,
+        82,
+        225,
+        242,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "owner_lp_token",
+          "docs": [
+            "Owner lp token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_account",
+          "docs": [
+            "The payer's token account for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_account",
+          "docs": [
+            "The payer's token account for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token Program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "Lp token mint"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "lp_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_0_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_1_amount",
+          "type": "u64"
+        }
       ]
     },
     {
@@ -284,310 +958,832 @@
         "* `open_time` - the timestamp allowed for swap",
         ""
       ],
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
       "accounts": [
         {
           "name": "creator",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Address paying to create the pool. Can be anyone"]
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Which config the pool belongs to."]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Initialize an account to store the pool state"]
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
         },
         {
-          "name": "token0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token_0 mint, the key must smaller then token_1 mint."]
+          "name": "authority",
+          "docs": [
+            "pool vault and lp mint authority"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "token1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token_1 mint, the key must grater then token_0 mint."]
+          "name": "pool_state",
+          "docs": [
+            "PDA account:",
+            "seeds = [",
+            "POOL_SEED.as_bytes(),",
+            "amm_config.key().as_ref(),",
+            "token_0_mint.key().as_ref(),",
+            "token_1_mint.key().as_ref(),",
+            "],",
+            "",
+            "Or random account: must be signed by cli"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["pool lp mint"]
+          "name": "token_0_mint",
+          "docs": [
+            "Token_0 mint, the key must smaller than token_1 mint."
+          ]
         },
         {
-          "name": "creatorToken0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["payer token0 account"]
+          "name": "token_1_mint",
+          "docs": [
+            "Token_1 mint, the key must grater then token_0 mint."
+          ]
         },
         {
-          "name": "creatorToken1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["creator token1 account"]
+          "name": "lp_mint",
+          "docs": [
+            "pool lp mint"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
         },
         {
-          "name": "creatorLpToken",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["creator lp token account"]
-        },
-        { "name": "token0Vault", "isMut": true, "isSigner": false },
-        { "name": "token1Vault", "isMut": true, "isSigner": false },
-        {
-          "name": "createPoolFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["create pool fee account"]
+          "name": "creator_token_0",
+          "docs": [
+            "payer token0 account"
+          ],
+          "writable": true
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["an account to store oracle observations"]
+          "name": "creator_token_1",
+          "docs": [
+            "creator token1 account"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Program to create mint account and mint tokens"]
+          "name": "creator_lp_token",
+          "docs": [
+            "creator lp token account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "lp_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
-          "name": "token0Program",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Spl token program or token program 2022"]
+          "name": "token_0_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_0_mint"
+              }
+            ]
+          }
         },
         {
-          "name": "token1Program",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Spl token program or token program 2022"]
+          "name": "token_1_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_1_mint"
+              }
+            ]
+          }
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Program to create an ATA for receiving position NFT"]
+          "name": "create_pool_fee",
+          "docs": [
+            "create pool fee account"
+          ],
+          "writable": true,
+          "address": "DNXgeM9EiiaAbaWvwjHj9fQQLAX5ZsfHyvmYUNRAdNC8"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["To create a new program account"]
+          "name": "observation_state",
+          "docs": [
+            "an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_0_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_1_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Sysvar for program account"]
+          "docs": [
+            "Sysvar for program account"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
         }
       ],
       "args": [
-        { "name": "initAmount0", "type": "u64" },
-        { "name": "initAmount1", "type": "u64" },
-        { "name": "openTime", "type": "u64" }
+        {
+          "name": "init_amount_0",
+          "type": "u64"
+        },
+        {
+          "name": "init_amount_1",
+          "type": "u64"
+        },
+        {
+          "name": "open_time",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "deposit",
+      "name": "initialize_with_permission",
       "docs": [
-        "Creates a pool for the given token pair and the initial price",
+        "Create a pool with permission",
         "",
         "# Arguments",
         "",
         "* `ctx`- The context of accounts",
-        "* `lp_token_amount` - Pool token amount to transfer. token_a and token_b amount are set by the current exchange rate and size of the pool",
-        "* `maximum_token_0_amount` -  Maximum token 0 amount to deposit, prevents excessive slippage",
-        "* `maximum_token_1_amount` - Maximum token 1 amount to deposit, prevents excessive slippage",
+        "* `init_amount_0` - the initial amount_0 to deposit",
+        "* `init_amount_1` - the initial amount_1 to deposit",
+        "* `open_time` - the timestamp allowed for swap",
+        "* `creator_fee_on` - creator fee model, 0：both token0 and token1 (depends on the input), 1: only token0, 2: only token1",
         ""
+      ],
+      "discriminator": [
+        63,
+        55,
+        254,
+        65,
+        49,
+        178,
+        89,
+        121
       ],
       "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Pays to mint the position"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        { "name": "poolState", "isMut": true, "isSigner": false },
-        {
-          "name": "ownerLpToken",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Owner lp tokan account"]
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "token0Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The payer's token account for token_0"]
+          "name": "creator"
         },
         {
-          "name": "token1Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The payer's token account for token_1"]
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
         },
         {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
+          "name": "authority",
+          "docs": [
+            "pool vault and lp mint authority"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
+          "name": "pool_state",
+          "docs": [
+            "PDA account:",
+            "seeds = [",
+            "POOL_SEED.as_bytes(),",
+            "amm_config.key().as_ref(),",
+            "token_0_mint.key().as_ref(),",
+            "token_1_mint.key().as_ref(),",
+            "],",
+            "",
+            "Or random account: must be signed by cli"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["token Program"]
+          "name": "token_0_mint",
+          "docs": [
+            "Token_0 mint, the key must smaller than token_1 mint."
+          ]
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program 2022"]
+          "name": "token_1_mint",
+          "docs": [
+            "Token_1 mint, the key must grater then token_0 mint."
+          ]
         },
         {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
+          "name": "lp_mint",
+          "docs": [
+            "pool lp mint"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
+          "name": "payer_token_0",
+          "docs": [
+            "payer token0 account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint"]
+          "name": "payer_token_1",
+          "docs": [
+            "payer token1 account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_lp_token",
+          "docs": [
+            "payer lp token account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "payer"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "lp_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_0_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_0_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_1_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_1_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "create_pool_fee",
+          "docs": [
+            "create pool fee account"
+          ],
+          "writable": true,
+          "address": "DNXgeM9EiiaAbaWvwjHj9fQQLAX5ZsfHyvmYUNRAdNC8"
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "permission",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "payer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_0_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_1_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
-        { "name": "lpTokenAmount", "type": "u64" },
-        { "name": "maximumToken0Amount", "type": "u64" },
-        { "name": "maximumToken1Amount", "type": "u64" }
-      ]
-    },
-    {
-      "name": "withdraw",
-      "docs": [
-        "Withdraw lp for token0 ande token1",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `lp_token_amount` - Amount of pool tokens to burn. User receives an output of token a and b based on the percentage of the pool tokens that are returned.",
-        "* `minimum_token_0_amount` -  Minimum amount of token 0 to receive, prevents excessive slippage",
-        "* `minimum_token_1_amount` -  Minimum amount of token 1 to receive, prevents excessive slippage",
-        ""
-      ],
-      "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Pays to mint the position"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool state account"]
+          "name": "init_amount_0",
+          "type": "u64"
         },
         {
-          "name": "ownerLpToken",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Owner lp token account"]
+          "name": "init_amount_1",
+          "type": "u64"
         },
         {
-          "name": "token0Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The owner's token account for receive token_0"]
+          "name": "open_time",
+          "type": "u64"
         },
         {
-          "name": "token1Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The owner's token account for receive token_1"]
-        },
-        {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
-        },
-        {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["token Program"]
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program 2022"]
-        },
-        {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
-        },
-        {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool lp token mint"]
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["memo program"]
+          "name": "creator_fee_on",
+          "type": {
+            "defined": {
+              "name": "CreatorFeeOn"
+            }
+          }
         }
-      ],
-      "args": [
-        { "name": "lpTokenAmount", "type": "u64" },
-        { "name": "minimumToken0Amount", "type": "u64" },
-        { "name": "minimumToken1Amount", "type": "u64" }
       ]
     },
     {
-      "name": "swapBaseInput",
+      "name": "swap_base_input",
       "docs": [
         "Swap the tokens in the pool base input amount",
         "",
@@ -598,90 +1794,149 @@
         "* `minimum_amount_out` -  Minimum amount of output token, prevents excessive slippage",
         ""
       ],
+      "discriminator": [
+        143,
+        190,
+        90,
+        218,
+        196,
+        30,
+        51,
+        222
+      ],
       "accounts": [
         {
           "name": "payer",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["The user performing the swap"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The factory state to read protocol fees"]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
-            "The program account of the pool in which the swap will be performed"
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "The factory state to read protocol fees"
           ]
         },
         {
-          "name": "inputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for input token"]
+          "name": "pool_state",
+          "docs": [
+            "The program account of the pool in which the swap will be performed"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for output token"]
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for input token"]
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for output token"]
+          "name": "input_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for input token transfers"]
+          "name": "output_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for output token transfers"]
+          "name": "input_token_program",
+          "docs": [
+            "SPL program for input token transfers"
+          ]
         },
         {
-          "name": "inputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of input token"]
+          "name": "output_token_program",
+          "docs": [
+            "SPL program for output token transfers"
+          ]
         },
         {
-          "name": "outputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of output token"]
+          "name": "input_token_mint",
+          "docs": [
+            "The mint of input token"
+          ]
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The program account for the most recent oracle observation"]
+          "name": "output_token_mint",
+          "docs": [
+            "The mint of output token"
+          ]
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "The program account for the most recent oracle observation"
+          ],
+          "writable": true
         }
       ],
       "args": [
-        { "name": "amountIn", "type": "u64" },
-        { "name": "minimumAmountOut", "type": "u64" }
+        {
+          "name": "amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_amount_out",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "swapBaseOutput",
+      "name": "swap_base_output",
       "docs": [
         "Swap the tokens in the pool base output amount",
         "",
@@ -692,377 +1947,513 @@
         "* `amount_out` -  amount of output token",
         ""
       ],
+      "discriminator": [
+        55,
+        217,
+        98,
+        86,
+        163,
+        74,
+        180,
+        173
+      ],
       "accounts": [
         {
           "name": "payer",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["The user performing the swap"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The factory state to read protocol fees"]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
-            "The program account of the pool in which the swap will be performed"
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "The factory state to read protocol fees"
           ]
         },
         {
-          "name": "inputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for input token"]
+          "name": "pool_state",
+          "docs": [
+            "The program account of the pool in which the swap will be performed"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for output token"]
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for input token"]
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for output token"]
+          "name": "input_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for input token transfers"]
+          "name": "output_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for output token transfers"]
+          "name": "input_token_program",
+          "docs": [
+            "SPL program for input token transfers"
+          ]
         },
         {
-          "name": "inputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of input token"]
+          "name": "output_token_program",
+          "docs": [
+            "SPL program for output token transfers"
+          ]
         },
         {
-          "name": "outputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of output token"]
+          "name": "input_token_mint",
+          "docs": [
+            "The mint of input token"
+          ]
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The program account for the most recent oracle observation"]
+          "name": "output_token_mint",
+          "docs": [
+            "The mint of output token"
+          ]
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "The program account for the most recent oracle observation"
+          ],
+          "writable": true
         }
       ],
       "args": [
-        { "name": "maxAmountIn", "type": "u64" },
-        { "name": "amountOut", "type": "u64" }
+        {
+          "name": "max_amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "amount_out",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_amm_config",
+      "docs": [
+        "Updates the owner of the amm config",
+        "Must be called by the current owner or admin",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `trade_fee_rate`- The new trade fee rate of amm config, be set when `param` is 0",
+        "* `protocol_fee_rate`- The new protocol fee rate of amm config, be set when `param` is 1",
+        "* `fund_fee_rate`- The new fund fee rate of amm config, be set when `param` is 2",
+        "* `new_owner`- The config's new owner, be set when `param` is 3",
+        "* `new_fund_owner`- The config's new fund owner, be set when `param` is 4",
+        "* `param`- The value can be 0 | 1 | 2 | 3 | 4, otherwise will report a error",
+        ""
+      ],
+      "discriminator": [
+        49,
+        60,
+        174,
+        136,
+        154,
+        28,
+        116,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The amm config owner or admin"
+          ],
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account to be changed"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "param",
+          "type": "u8"
+        },
+        {
+          "name": "value",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_pool_status",
+      "docs": [
+        "Update pool status for given value",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `status` - The value of status",
+        ""
+      ],
+      "discriminator": [
+        130,
+        87,
+        108,
+        6,
+        46,
+        224,
+        117,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "withdraw",
+      "docs": [
+        "Withdraw lp for token0 and token1",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `lp_token_amount` - Amount of pool tokens to burn. User receives an output of token a and b based on the percentage of the pool tokens that are returned.",
+        "* `minimum_token_0_amount` -  Minimum amount of token 0 to receive, prevents excessive slippage",
+        "* `minimum_token_1_amount` -  Minimum amount of token 1 to receive, prevents excessive slippage",
+        ""
+      ],
+      "discriminator": [
+        183,
+        18,
+        70,
+        156,
+        148,
+        109,
+        161,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "owner_lp_token",
+          "docs": [
+            "Owner lp token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_account",
+          "docs": [
+            "The token account for receive token_0,"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_account",
+          "docs": [
+            "The token account for receive token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token Program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "Pool lp token mint"
+          ],
+          "writable": true
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        }
+      ],
+      "args": [
+        {
+          "name": "lp_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_token_0_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_token_1_amount",
+          "type": "u64"
+        }
       ]
     }
   ],
   "accounts": [
     {
       "name": "AmmConfig",
-      "docs": ["Holds the current owner of the factory"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          { "name": "bump", "docs": ["Bump to identify PDA"], "type": "u8" },
-          {
-            "name": "disableCreatePool",
-            "docs": ["Status to control if new pool can be create"],
-            "type": "bool"
-          },
-          { "name": "index", "docs": ["Config index"], "type": "u16" },
-          {
-            "name": "tradeFeeRate",
-            "docs": [
-              "The trade fee, denominated in hundredths of a bip (10^-6)"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "protocolFeeRate",
-            "docs": ["The protocol fee"],
-            "type": "u64"
-          },
-          {
-            "name": "fundFeeRate",
-            "docs": [
-              "The fund fee, denominated in hundredths of a bip (10^-6)"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "createPoolFee",
-            "docs": ["Fee for create a new pool"],
-            "type": "u64"
-          },
-          {
-            "name": "protocolOwner",
-            "docs": ["Address of the protocol fee owner"],
-            "type": "publicKey"
-          },
-          {
-            "name": "fundOwner",
-            "docs": ["Address of the fund fee owner"],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": ["padding"],
-            "type": { "array": ["u64", 16] }
-          }
-        ]
-      }
+      "discriminator": [
+        218,
+        244,
+        33,
+        104,
+        203,
+        203,
+        43,
+        111
+      ]
     },
     {
       "name": "ObservationState",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "initialized",
-            "docs": ["Whether the ObservationState is initialized"],
-            "type": "bool"
-          },
-          {
-            "name": "observationIndex",
-            "docs": [
-              "the most-recently updated index of the observations array"
-            ],
-            "type": "u16"
-          },
-          { "name": "poolId", "type": "publicKey" },
-          {
-            "name": "observations",
-            "docs": ["observation array"],
-            "type": { "array": [{ "defined": "Observation" }, 100] }
-          },
-          {
-            "name": "padding",
-            "docs": ["padding for feature update"],
-            "type": { "array": ["u64", 4] }
-          }
-        ]
-      }
+      "discriminator": [
+        122,
+        174,
+        197,
+        53,
+        129,
+        9,
+        165,
+        132
+      ]
+    },
+    {
+      "name": "Permission",
+      "discriminator": [
+        224,
+        83,
+        28,
+        79,
+        10,
+        253,
+        161,
+        28
+      ]
     },
     {
       "name": "PoolState",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "ammConfig",
-            "docs": ["Which config the pool belongs"],
-            "type": "publicKey"
-          },
-          {
-            "name": "poolCreator",
-            "docs": ["pool creator"],
-            "type": "publicKey"
-          },
-          { "name": "token0Vault", "docs": ["Token A"], "type": "publicKey" },
-          { "name": "token1Vault", "docs": ["Token B"], "type": "publicKey" },
-          {
-            "name": "lpMint",
-            "docs": [
-              "Pool tokens are issued when A or B tokens are deposited.",
-              "Pool tokens can be withdrawn back to the original A or B token."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "token0Mint",
-            "docs": ["Mint information for token A"],
-            "type": "publicKey"
-          },
-          {
-            "name": "token1Mint",
-            "docs": ["Mint information for token B"],
-            "type": "publicKey"
-          },
-          {
-            "name": "token0Program",
-            "docs": ["token_0 program"],
-            "type": "publicKey"
-          },
-          {
-            "name": "token1Program",
-            "docs": ["token_1 program"],
-            "type": "publicKey"
-          },
-          {
-            "name": "observationKey",
-            "docs": ["observation account to store oracle data"],
-            "type": "publicKey"
-          },
-          { "name": "authBump", "type": "u8" },
-          {
-            "name": "status",
-            "docs": [
-              "Bitwise representation of the state of the pool",
-              "bit0, 1: disable deposit(vaule is 1), 0: normal",
-              "bit1, 1: disable withdraw(vaule is 2), 0: normal",
-              "bit2, 1: disable swap(vaule is 4), 0: normal"
-            ],
-            "type": "u8"
-          },
-          { "name": "lpMintDecimals", "type": "u8" },
-          {
-            "name": "mint0Decimals",
-            "docs": ["mint0 and mint1 decimals"],
-            "type": "u8"
-          },
-          { "name": "mint1Decimals", "type": "u8" },
-          { "name": "lpSupply", "docs": ["lp mint supply"], "type": "u64" },
-          {
-            "name": "protocolFeesToken0",
-            "docs": [
-              "The amounts of token_0 and token_1 that are owed to the liquidity provider."
-            ],
-            "type": "u64"
-          },
-          { "name": "protocolFeesToken1", "type": "u64" },
-          { "name": "fundFeesToken0", "type": "u64" },
-          { "name": "fundFeesToken1", "type": "u64" },
-          {
-            "name": "openTime",
-            "docs": ["The timestamp allowed for swap in the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "docs": ["padding for future updates"],
-            "type": { "array": ["u64", 32] }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "Observation",
-      "docs": ["The element of observations in ObservationState"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "blockTimestamp",
-            "docs": ["The block timestamp of the observation"],
-            "type": "u64"
-          },
-          {
-            "name": "cumulativeToken0PriceX32",
-            "docs": [
-              "the cumulative of token0 price during the duration time, Q32.32, the remaining 64 bit for overflow"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "cumulativeToken1PriceX32",
-            "docs": [
-              "the cumulative of token1 price during the duration time, Q32.32, the remaining 64 bit for overflow"
-            ],
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TradeDirection",
-      "docs": [
-        "The direction of a trade, since curves can be specialized to treat each",
-        "token differently (by adding offsets or weights)"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "ZeroForOne" }, { "name": "OneForZero" }]
-      }
-    },
-    {
-      "name": "RoundDirection",
-      "docs": [
-        "The direction to round.  Used for pool token to trading token conversions to",
-        "avoid losing value on any deposit or withdrawal."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Floor" }, { "name": "Ceiling" }]
-      }
-    },
-    {
-      "name": "PoolStatusBitIndex",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "Deposit" },
-          { "name": "Withdraw" },
-          { "name": "Swap" }
-        ]
-      }
-    },
-    {
-      "name": "PoolStatusBitFlag",
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Enable" }, { "name": "Disable" }]
-      }
+      "discriminator": [
+        247,
+        237,
+        227,
+        245,
+        215,
+        195,
+        222,
+        70
+      ]
     }
   ],
   "events": [
     {
       "name": "LpChangeEvent",
-      "fields": [
-        { "name": "poolId", "type": "publicKey", "index": true },
-        { "name": "lpAmountBefore", "type": "u64", "index": false },
-        { "name": "token0VaultBefore", "type": "u64", "index": false },
-        { "name": "token1VaultBefore", "type": "u64", "index": false },
-        { "name": "token0Amount", "type": "u64", "index": false },
-        { "name": "token1Amount", "type": "u64", "index": false },
-        { "name": "token0TransferFee", "type": "u64", "index": false },
-        { "name": "token1TransferFee", "type": "u64", "index": false },
-        { "name": "changeType", "type": "u8", "index": false }
+      "discriminator": [
+        121,
+        163,
+        205,
+        201,
+        57,
+        218,
+        117,
+        60
       ]
     },
     {
       "name": "SwapEvent",
-      "fields": [
-        { "name": "poolId", "type": "publicKey", "index": true },
-        { "name": "inputVaultBefore", "type": "u64", "index": false },
-        { "name": "outputVaultBefore", "type": "u64", "index": false },
-        { "name": "inputAmount", "type": "u64", "index": false },
-        { "name": "outputAmount", "type": "u64", "index": false },
-        { "name": "inputTransferFee", "type": "u64", "index": false },
-        { "name": "outputTransferFee", "type": "u64", "index": false },
-        { "name": "baseInput", "type": "bool", "index": false }
+      "discriminator": [
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
       ]
     }
   ],
   "errors": [
-    { "code": 6000, "name": "NotApproved", "msg": "Not approved" },
+    {
+      "code": 6000,
+      "name": "NotApproved",
+      "msg": "Not approved"
+    },
     {
       "code": 6001,
       "name": "InvalidOwner",
       "msg": "Input account owner is not the program address"
     },
-    { "code": 6002, "name": "EmptySupply", "msg": "Input token account empty" },
-    { "code": 6003, "name": "InvalidInput", "msg": "InvalidInput" },
+    {
+      "code": 6002,
+      "name": "EmptySupply",
+      "msg": "Input token account empty"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidInput",
+      "msg": "InvalidInput"
+    },
     {
       "code": 6004,
       "name": "IncorrectLpMint",
@@ -1083,11 +2474,618 @@
       "name": "NotSupportMint",
       "msg": "Not support token_2022 mint extension"
     },
-    { "code": 6008, "name": "InvalidVault", "msg": "invaild vault" },
+    {
+      "code": 6008,
+      "name": "InvalidVault",
+      "msg": "invaild vault"
+    },
     {
       "code": 6009,
       "name": "InitLpAmountTooLess",
       "msg": "Init lp amount is too less(Because 100 amount lp will be locked)"
+    },
+    {
+      "code": 6010,
+      "name": "TransferFeeCalculateNotMatch",
+      "msg": "TransferFee calculate not match"
+    },
+    {
+      "code": 6011,
+      "name": "MathOverflow",
+      "msg": "Math overflow"
+    },
+    {
+      "code": 6012,
+      "name": "InsufficientVault",
+      "msg": "Insufficient vault"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidFeeModel",
+      "msg": "Invalid fee model"
+    },
+    {
+      "code": 6014,
+      "name": "NoFeeCollect",
+      "msg": "Fee is zero"
+    }
+  ],
+  "types": [
+    {
+      "name": "AmmConfig",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "disable_create_pool",
+            "docs": [
+              "Status to control if new pool can be create"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "index",
+            "docs": [
+              "Config index"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "trade_fee_rate",
+            "docs": [
+              "The trade fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee_rate",
+            "docs": [
+              "The protocol fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fund_fee_rate",
+            "docs": [
+              "The fund fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "create_pool_fee",
+            "docs": [
+              "Fee for create a new pool"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_owner",
+            "docs": [
+              "Address of the protocol fee owner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fund_owner",
+            "docs": [
+              "Address of the fund fee owner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator_fee_rate",
+            "docs": [
+              "The pool creator fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                15
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreatorFeeOn",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "BothToken"
+          },
+          {
+            "name": "OnlyToken0"
+          },
+          {
+            "name": "OnlyToken1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpChangeEvent",
+      "docs": [
+        "Emitted when deposit and withdraw"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_amount_before",
+            "type": "u64"
+          },
+          {
+            "name": "token_0_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_1_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_0_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_1_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_0_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "token_1_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "change_type",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Observation",
+      "docs": [
+        "The element of observations in ObservationState"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "block_timestamp",
+            "docs": [
+              "The block timestamp of the observation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_token_0_price_x32",
+            "docs": [
+              "the cumulative of token0 price during the duration time, Q32.32, the remaining 64 bit for overflow"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_token_1_price_x32",
+            "docs": [
+              "the cumulative of token1 price during the duration time, Q32.32, the remaining 64 bit for overflow"
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObservationState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "initialized",
+            "docs": [
+              "Whether the ObservationState is initialized"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "observation_index",
+            "docs": [
+              "the most-recently updated index of the observations array"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "observations",
+            "docs": [
+              "observation array"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Observation"
+                  }
+                },
+                100
+              ]
+            }
+          },
+          {
+            "name": "last_update_timestamp",
+            "docs": [
+              "the last update timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for feature update"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permission",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "authority"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                30
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amm_config",
+            "docs": [
+              "Which config the pool belongs"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator",
+            "docs": [
+              "pool creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_0_vault",
+            "docs": [
+              "Token A"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_1_vault",
+            "docs": [
+              "Token B"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_mint",
+            "docs": [
+              "Pool tokens are issued when A or B tokens are deposited.",
+              "Pool tokens can be withdrawn back to the original A or B token."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_0_mint",
+            "docs": [
+              "Mint information for token A"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_1_mint",
+            "docs": [
+              "Mint information for token B"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_0_program",
+            "docs": [
+              "token_0 program"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_1_program",
+            "docs": [
+              "token_1 program"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "observation_key",
+            "docs": [
+              "observation account to store oracle data"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Bitwise representation of the state of the pool",
+              "bit0, 1: disable deposit(value is 1), 0: normal",
+              "bit1, 1: disable withdraw(value is 2), 0: normal",
+              "bit2, 1: disable swap(value is 4), 0: normal"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "lp_mint_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "mint_0_decimals",
+            "docs": [
+              "mint0 and mint1 decimals"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint_1_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "lp_supply",
+            "docs": [
+              "True circulating supply without burns and lock ups"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fees_token_0",
+            "docs": [
+              "The amounts of token_0 and token_1 that are owed to the liquidity provider."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "fund_fees_token_0",
+            "type": "u64"
+          },
+          {
+            "name": "fund_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "open_time",
+            "docs": [
+              "The timestamp allowed for swap in the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "recent_epoch",
+            "docs": [
+              "recent epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_fee_on",
+            "docs": [
+              "Creator fee collect mode",
+              "0: both token_0 and token_1 can be used as trade fees. It depends on what the input token is when swapping",
+              "1: only token_0 as trade fee",
+              "2: only token_1 as trade fee"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "enable_creator_fee",
+            "type": "bool"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "creator_fees_token_0",
+            "type": "u64"
+          },
+          {
+            "name": "creator_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future updates"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                28
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapEvent",
+      "docs": [
+        "Emitted when swap"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "input_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "output_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "input_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "input_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "output_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "base_input",
+            "type": "bool"
+          },
+          {
+            "name": "input_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "output_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_fee",
+            "type": "u64"
+          },
+          {
+            "name": "creator_fee",
+            "docs": [
+              "Amount of fee tokens going to creator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_fee_on_input",
+            "type": "bool"
+          }
+        ]
+      }
     }
   ]
 }

--- a/idl/raydium_launchpad.json
+++ b/idl/raydium_launchpad.json
@@ -36,6 +36,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -225,6 +226,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -1107,6 +1109,79 @@
       "args": []
     },
     {
+      "name": "close_platform_global_access",
+      "docs": [
+        "Close a platform's permission to use a global config."
+      ],
+      "discriminator": [
+        123,
+        180,
+        184,
+        129,
+        111,
+        185,
+        187,
+        59
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "collect_fee",
       "docs": [
         "Collects accumulated fees from the pool",
@@ -1521,6 +1596,9 @@
         },
         {
           "name": "transfer_fee_extension_authority"
+        },
+        {
+          "name": "platform_vesting_wallet"
         }
       ],
       "args": [
@@ -1533,6 +1611,182 @@
           }
         }
       ]
+    },
+    {
+      "name": "create_platform_global_access",
+      "docs": [
+        "Create a platform permission to use a global config when authorization is enabled."
+      ],
+      "discriminator": [
+        162,
+        91,
+        146,
+        199,
+        93,
+        133,
+        234,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_platform_vesting_account",
+      "docs": [
+        "Create vesting account",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `share` - The share amount of base token to be vested",
+        ""
+      ],
+      "discriminator": [
+        146,
+        71,
+        173,
+        69,
+        98,
+        19,
+        15,
+        106
+      ],
+      "accounts": [
+        {
+          "name": "platform_vesting_wallet",
+          "docs": [
+            "The account paying for the initialization costs",
+            "This can be any account with sufficient SOL to cover the transaction"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "beneficiary",
+          "docs": [
+            "The beneficiary is used to receive the allocated linear release of tokens.",
+            "Once this account is set, it cannot be modified, so please ensure the validity of this account,",
+            "otherwise, the unlocked tokens will not be claimable."
+          ],
+          "writable": true
+        },
+        {
+          "name": "platform_config",
+          "docs": [
+            "Platform config account to be changed"
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "The pool state account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "platform_vesting_record",
+          "docs": [
+            "The vesting record account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  101,
+                  115,
+                  116,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "beneficiary"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Required for account creation"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     },
     {
       "name": "create_vesting_account",
@@ -3650,6 +3904,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -3840,6 +4095,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -4011,6 +4267,7 @@
         "* `param` - Parameter to update:",
         "- 0: Update trade_fee_rate",
         "- 1: Update fee owner",
+        "- 12: Toggle whether explicit platform authorization is required",
         "* `value` - New value for the selected parameter",
         ""
       ],
@@ -4250,6 +4507,19 @@
       ]
     },
     {
+      "name": "PlatformGlobalAccess",
+      "discriminator": [
+        174,
+        147,
+        132,
+        240,
+        137,
+        219,
+        243,
+        16
+      ]
+    },
+    {
       "name": "PoolState",
       "discriminator": [
         247,
@@ -4435,6 +4705,21 @@
       "code": 6020,
       "name": "CurveParamIsNotExist",
       "msg": "Curve param is not exist"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidTotalLockedAmount",
+      "msg": "Total locked amount must great or equal to the platform vesting share amount"
+    },
+    {
+      "code": 6022,
+      "name": "PlatformGlobalAccessDenied",
+      "msg": "Platform is not authorized to use this global config"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidPlatformGlobalAccess",
+      "msg": "Invalid platform-global access account"
     }
   ],
   "types": [
@@ -4787,6 +5072,25 @@
             "type": "pubkey"
           },
           {
+            "name": "requires_platform_auth",
+            "docs": [
+              "Whether a platform must be explicitly authorized before using this global config"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_alignment",
+            "docs": [
+              "padding alignment"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -4794,7 +5098,7 @@
             "type": {
               "array": [
                 "u64",
-                16
+                15
               ]
             }
           }
@@ -4996,6 +5300,22 @@
             "type": "pubkey"
           },
           {
+            "name": "platform_vesting_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_vesting_scale",
+            "type": "u64"
+          },
+          {
+            "name": "platform_cp_creator",
+            "docs": [
+              "If a valid platform_cp_creator is configured for the platform,",
+              "it will be used as the creator for the AMM pool during migration to cpswap pool."
+            ],
+            "type": "pubkey"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -5003,7 +5323,7 @@
             "type": {
               "array": [
                 "u8",
-                180
+                108
               ]
             }
           },
@@ -5067,6 +5387,14 @@
           {
             "name": "creator_fee_rate",
             "type": "u64"
+          },
+          {
+            "name": "platform_vesting_scale",
+            "type": "u64"
+          },
+          {
+            "name": "vesting_wallet",
+            "type": "pubkey"
           }
         ]
       }
@@ -5134,6 +5462,24 @@
                 }
               }
             ]
+          },
+          {
+            "name": "VestingWallet",
+            "fields": [
+              "pubkey"
+            ]
+          },
+          {
+            "name": "PlatformVestingScale",
+            "fields": [
+              "u64"
+            ]
+          },
+          {
+            "name": "PlatformCPCreator",
+            "fields": [
+              "pubkey"
+            ]
           }
         ]
       }
@@ -5191,6 +5537,38 @@
       }
     },
     {
+      "name": "PlatformGlobalAccess",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "global_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future updates"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "PlatformParams",
       "docs": [
         "Represents the parameters for initializing a platform config account",
@@ -5231,6 +5609,10 @@
           },
           {
             "name": "creator_fee_rate",
+            "type": "u64"
+          },
+          {
+            "name": "platform_vesting_scale",
             "type": "u64"
           }
         ]
@@ -5509,6 +5891,13 @@
             }
           },
           {
+            "name": "platform_vesting_share",
+            "docs": [
+              "platform vesting token amount"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -5516,7 +5905,7 @@
             "type": {
               "array": [
                 "u8",
-                62
+                54
               ]
             }
           }

--- a/idls/meteora_amm.json
+++ b/idls/meteora_amm.json
@@ -1,2322 +1,3111 @@
 {
-  "version": "0.4.12",
-  "name": "amm",
-  "docs": ["Program for AMM"],
+  "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB",
+  "metadata": {
+    "name": "dynamic_amm",
+    "version": "0.5.2",
+    "spec": "0.1.0"
+  },
+  "docs": [
+    "Program for AMM"
+  ],
   "instructions": [
     {
-      "name": "initializePermissionedPool",
-      "docs": ["Initialize a new permissioned pool."],
+      "name": "initialize_permissioned_pool",
+      "docs": [
+        "Initialize a new permissioned pool."
+      ],
+      "discriminator": [
+        77,
+        85,
+        178,
+        157,
+        50,
+        48,
+        212,
+        126
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Pool account (arbitrary address)"]
+          "docs": [
+            "Pool account (arbitrary address)"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_a",
           "docs": [
             "Admin token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_pool_lp",
           "docs": [
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)",
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
+        {
+          "name": "fee_owner"
+        },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
+          "docs": [
+            "Rent account."
+          ]
         },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
-        }
-      ],
-      "args": [{ "name": "curveType", "type": { "defined": "CurveType" } }]
-    },
-    {
-      "name": "initializePermissionlessPool",
-      "docs": ["Initialize a new permissionless pool."],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA address)"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
-        },
-        {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
-        },
-        {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
-        },
-        {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
-            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+            "Token program."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
-            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+            "Associated token program."
           ]
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
-        },
-        {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
-        },
-        {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
-        },
-        {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
-            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            "System program."
           ]
-        },
-        {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
-        },
-        {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        { "name": "payerPoolLp", "isMut": true, "isSigner": false },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
-        },
-        {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
-        },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
-        },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
-        {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Vault program. The pool will deposit/withdraw liquidity from the vault."
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
         }
       ],
       "args": [
-        { "name": "curveType", "type": { "defined": "CurveType" } },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        }
       ]
     },
     {
-      "name": "initializePermissionlessPoolWithFeeTier",
-      "docs": ["Initialize a new permissionless pool with customized fee tier"],
+      "name": "initialize_permissionless_pool",
+      "docs": [
+        "Initialize a new permissionless pool."
+      ],
+      "discriminator": [
+        118,
+        173,
+        41,
+        157,
+        173,
+        72,
+        97,
+        103
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA address)"]
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        { "name": "payerPoolLp", "isMut": true, "isSigner": false },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
+        {
+          "name": "fee_owner"
+        },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
+          "docs": [
+            "Rent account."
+          ]
         },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         }
       ],
       "args": [
-        { "name": "curveType", "type": { "defined": "CurveType" } },
-        { "name": "tradeFeeBps", "type": "u64" },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "enableOrDisablePool",
+      "name": "initialize_permissionless_pool_with_fee_tier",
+      "docs": [
+        "Initialize a new permissionless pool with customized fee tier"
+      ],
+      "discriminator": [
+        6,
+        135,
+        68,
+        147,
+        229,
+        82,
+        169,
+        113
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_owner"
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        },
+        {
+          "name": "trade_fee_bps",
+          "type": "u64"
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "enable_or_disable_pool",
       "docs": [
         "Enable or disable a pool. A disabled pool allow only remove balanced liquidity operation."
       ],
+      "discriminator": [
+        128,
+        6,
+        228,
+        131,
+        55,
+        161,
+        52,
+        169
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "docs": [
+            "Admin account. Must be owner of the pool."
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "enable", "type": "bool" }]
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
     },
     {
       "name": "swap",
       "docs": [
         "Swap token A to B, or vice versa. An amount of trading fee will be charged for liquidity provider, and the admin of the pool."
       ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "userSourceToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_source_token",
           "docs": [
             "User token account. Token from this account will be transfer into the vault by the pool in exchange for another token of the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account. The exchanged token will be transfer into this account from the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "Lp token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "Lp token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_fee",
           "docs": [
-            "Admin fee token account. Used to receive trading fee. It's mint field must matched with user_source_token mint field."
-          ]
+            "Protocol fee token account. Used to receive trading fee. It's mint field must matched with user_source_token mint field."
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["User account. Must be owner of user_source_token."]
+          "docs": [
+            "User account. Must be owner of user_source_token."
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "inAmount", "type": "u64" },
-        { "name": "minimumOutAmount", "type": "u64" }
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_out_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "removeLiquiditySingleSide",
+      "name": "remove_liquidity_single_side",
       "docs": [
         "Withdraw only single token from the pool. Only supported by pool with stable swap curve."
+      ],
+      "discriminator": [
+        84,
+        84,
+        177,
+        66,
+        254,
+        185,
+        10,
+        251
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "User pool lp token account. LP will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account to receive token upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["User account. Must be owner of the user_pool_lp account."]
+          "docs": [
+            "User account. Must be owner of the user_pool_lp account."
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "minimumOutAmount", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_out_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "addImbalanceLiquidity",
+      "name": "add_imbalance_liquidity",
       "docs": [
         "Deposit tokens to the pool in an imbalance ratio. Only supported by pool with stable swap curve."
       ],
+      "discriminator": [
+        79,
+        35,
+        122,
+        84,
+        173,
+        15,
+        93,
+        191
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "minimumPoolTokenAmount", "type": "u64" },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "minimum_pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "removeBalanceLiquidity",
+      "name": "remove_balance_liquidity",
       "docs": [
         "Withdraw tokens from the pool in a balanced ratio. User will still able to withdraw from pool even the pool is disabled. This allow user to exit their liquidity when there's some unforeseen event happen."
       ],
+      "discriminator": [
+        133,
+        109,
+        44,
+        179,
+        56,
+        238,
+        114,
+        33
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "minimumATokenOut", "type": "u64" },
-        { "name": "minimumBTokenOut", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_a_token_out",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_b_token_out",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "addBalanceLiquidity",
-      "docs": ["Deposit tokens to the pool in a balanced ratio."],
+      "name": "add_balance_liquidity",
+      "docs": [
+        "Deposit tokens to the pool in a balanced ratio."
+      ],
+      "discriminator": [
+        168,
+        227,
+        50,
+        62,
+        189,
+        171,
+        84,
+        176
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "maximumTokenAAmount", "type": "u64" },
-        { "name": "maximumTokenBAmount", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "setPoolFees",
-      "docs": ["Update trading fee charged for liquidity provider, and admin."],
+      "name": "set_pool_fees",
+      "docs": [
+        "Update trading fee charged for liquidity provider, and admin."
+      ],
+      "discriminator": [
+        102,
+        44,
+        158,
+        54,
+        205,
+        37,
+        126,
+        78
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "name": "fee_operator",
+          "docs": [
+            "Fee operator account"
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "fees", "type": { "defined": "PoolFees" } }]
+      "args": [
+        {
+          "name": "fees",
+          "type": {
+            "defined": {
+              "name": "PoolFees"
+            }
+          }
+        },
+        {
+          "name": "new_partner_fee_numerator",
+          "type": "u64"
+        }
+      ]
     },
     {
-      "name": "overrideCurveParam",
+      "name": "override_curve_param",
       "docs": [
         "Update swap curve parameters. This function do not allow update of curve type. For example: stable swap curve to constant product curve. Only supported by pool with stable swap curve.",
         "Only amp is allowed to be override. The other attributes of stable swap curve will be ignored."
       ],
+      "discriminator": [
+        98,
+        86,
+        204,
+        51,
+        94,
+        71,
+        69,
+        187
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "docs": [
+            "Admin account."
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "curveType", "type": { "defined": "CurveType" } }]
+      "args": [
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        }
+      ]
     },
     {
-      "name": "transferAdmin",
-      "docs": ["Transfer the admin of the pool to new admin."],
+      "name": "get_pool_info",
+      "docs": [
+        "Get the general information of the pool."
+      ],
+      "discriminator": [
+        9,
+        48,
+        220,
+        101,
+        22,
+        240,
+        78,
+        200
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ]
         },
         {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
-          "name": "newAdmin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["New admin account."]
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "getPoolInfo",
-      "docs": ["Get the general information of the pool."],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ]
         }
       ],
       "args": []
     },
     {
-      "name": "bootstrapLiquidity",
-      "docs": ["Bootstrap the pool when liquidity is depleted."],
+      "name": "bootstrap_liquidity",
+      "docs": [
+        "Bootstrap the pool when liquidity is depleted."
+      ],
+      "discriminator": [
+        4,
+        228,
+        215,
+        71,
+        225,
+        253,
+        119,
+        206
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "migrateFeeAccount",
-      "docs": ["Migrate old token fee owner to PDA"],
+      "name": "create_mint_metadata",
+      "docs": [
+        "Create mint metadata account for old pools"
+      ],
+      "discriminator": [
+        13,
+        70,
+        168,
+        41,
+        250,
+        100,
+        148,
+        90
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["A vault LP token account of the pool."]
-        },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
+            "Pool account"
           ]
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
+            "LP mint account of the pool"
           ]
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint"]
+          "name": "a_vault_lp",
+          "docs": [
+            "Vault A LP account of the pool"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint"]
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "newAdminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token fee account. Controlled by pool a_vault_lp PDA."]
+          "name": "metadata_program"
         },
         {
-          "name": "newAdminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token fee account. Controlled by pool a_vault_lp PDA."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         },
         {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
-        },
-        {
-          "name": "treasuryTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Treasury token a fee ATA."]
-        },
-        {
-          "name": "treasuryTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Treasury token b fee ATA."]
-        },
-        {
-          "name": "treasury",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Treasury signer"]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "payer",
+          "docs": [
+            "Payer"
+          ],
+          "writable": true,
+          "signer": true
         }
       ],
       "args": []
     },
     {
-      "name": "createMintMetadata",
-      "docs": ["Create mint metadata account for old pools"],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP mint account of the pool"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Vault A LP account of the pool"]
-        },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
-        },
-        { "name": "payer", "isMut": true, "isSigner": true, "docs": ["Payer"] }
+      "name": "create_lock_escrow",
+      "docs": [
+        "Create lock account"
       ],
-      "args": []
-    },
-    {
-      "name": "createLockEscrow",
-      "docs": ["Create lock account"],
+      "discriminator": [
+        54,
+        87,
+        165,
+        19,
+        69,
+        227,
+        218,
+        224
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
-        { "name": "owner", "isMut": false, "isSigner": false },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "owner"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Payer account"]
+          "docs": [
+            "Payer account"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         }
       ],
       "args": []
     },
     {
       "name": "lock",
-      "docs": ["Lock Lp token"],
+      "docs": [
+        "Lock Lp token"
+      ],
+      "discriminator": [
+        21,
+        19,
+        208,
+        43,
+        237,
+        62,
+        255,
+        87
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Owner of lock account"]
+          "docs": [
+            "Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["owner lp token account"]
+          "name": "source_tokens",
+          "docs": [
+            "owner lp token account"
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Escrow vault"]
+          "name": "escrow_vault",
+          "docs": [
+            "Escrow vault"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ]
         }
       ],
-      "args": [{ "name": "amount", "type": "u64" }]
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
     },
     {
-      "name": "claimFee",
-      "docs": ["Claim fee"],
+      "name": "claim_fee",
+      "docs": [
+        "Claim fee"
+      ],
+      "discriminator": [
+        169,
+        32,
+        79,
+        137,
+        136,
+        232,
+        70,
+        137
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Owner of lock account"]
+          "docs": [
+            "Owner of lock account"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["owner lp token account"]
+          "name": "source_tokens",
+          "docs": [
+            "owner lp token account"
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Escrow vault"]
+          "name": "escrow_vault",
+          "docs": [
+            "Escrow vault"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         }
       ],
-      "args": [{ "name": "maxAmount", "type": "u64" }]
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_config",
+      "docs": [
+        "Create config"
+      ],
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_config",
+      "docs": [
+        "Close config"
+      ],
+      "discriminator": [
+        145,
+        9,
+        72,
+        157,
+        95,
+        125,
+        61,
+        85
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_permissionless_constant_product_pool_with_config",
+      "docs": [
+        "Initialize permissionless pool with config"
+      ],
+      "discriminator": [
+        7,
+        166,
+        138,
+        171,
+        206,
+        171,
+        236,
+        244
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize_permissionless_constant_product_pool_with_config2",
+      "docs": [
+        "Initialize permissionless pool with config 2"
+      ],
+      "discriminator": [
+        48,
+        149,
+        220,
+        130,
+        61,
+        11,
+        9,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        },
+        {
+          "name": "activation_point",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_customizable_permissionless_constant_product_pool",
+      "docs": [
+        "Initialize permissionless pool with customizable params"
+      ],
+      "discriminator": [
+        145,
+        24,
+        172,
+        194,
+        219,
+        125,
+        3,
+        190
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        },
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CustomizableParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_activation_point",
+      "docs": [
+        "Update activation slot"
+      ],
+      "discriminator": [
+        150,
+        62,
+        125,
+        219,
+        171,
+        220,
+        26,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "Admin account."
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_activation_point",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fees",
+      "docs": [
+        "Withdraw protocol fee"
+      ],
+      "discriminator": [
+        11,
+        68,
+        165,
+        98,
+        18,
+        208,
+        134,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ]
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "treasury_token_a",
+          "writable": true
+        },
+        {
+          "name": "treasury_token_b",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_whitelisted_vault",
+      "docs": [
+        "Set whitelisted vault"
+      ],
+      "discriminator": [
+        12,
+        148,
+        94,
+        42,
+        55,
+        57,
+        83,
+        247
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "whitelisted_vault",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "partner_claim_fee",
+      "docs": [
+        "Partner claim fee"
+      ],
+      "discriminator": [
+        57,
+        53,
+        176,
+        30,
+        123,
+        70,
+        52,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "partner_token_a",
+          "writable": true
+        },
+        {
+          "name": "partner_token_b",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "partner_authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
     }
   ],
   "accounts": [
     {
-      "name": "Pool",
-      "docs": ["State of pool account"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lpMint",
-            "docs": ["LP token mint of the pool"],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenAMint",
-            "docs": ["Token A mint of the pool. Eg: USDT"],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBMint",
-            "docs": ["Token B mint of the pool. Eg: USDC"],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVault",
-            "docs": [
-              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVault",
-            "docs": [
-              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLp",
-            "docs": [
-              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVaultLp",
-            "docs": [
-              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLpBump",
-            "docs": ["\"A\" vault lp bump. Used to create signer seeds."],
-            "type": "u8"
-          },
-          {
-            "name": "enabled",
-            "docs": [
-              "Flag to determine whether the pool is enabled, or disabled."
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "adminTokenAFee",
-            "docs": [
-              "Admin fee token account for token A. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "adminTokenBFee",
-            "docs": [
-              "Admin fee token account for token B. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "admin",
-            "docs": ["Owner of the pool."],
-            "type": "publicKey"
-          },
-          {
-            "name": "fees",
-            "docs": ["Store the fee charges setting."],
-            "type": { "defined": "PoolFees" }
-          },
-          {
-            "name": "poolType",
-            "docs": ["Pool type"],
-            "type": { "defined": "PoolType" }
-          },
-          {
-            "name": "stake",
-            "docs": ["Stake pubkey of SPL stake pool"],
-            "type": "publicKey"
-          },
-          {
-            "name": "totalLockedLp",
-            "docs": ["Total locked lp token"],
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "docs": ["Padding for future pool field"],
-            "type": { "defined": "Padding" }
-          },
-          {
-            "name": "curveType",
-            "docs": ["The type of the swap curve supported by the pool."],
-            "type": { "defined": "CurveType" }
-          }
-        ]
-      }
+      "name": "Config",
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
     },
     {
       "name": "LockEscrow",
-      "docs": ["State of lock escrow account"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          { "name": "pool", "docs": ["Pool address"], "type": "publicKey" },
-          { "name": "owner", "docs": ["Owner address"], "type": "publicKey" },
-          {
-            "name": "escrowVault",
-            "docs": ["Vault address, store the lock user lock"],
-            "type": "publicKey"
-          },
-          { "name": "bump", "docs": ["bump, used to sign"], "type": "u8" },
-          {
-            "name": "totalLockedAmount",
-            "docs": ["Total locked amount"],
-            "type": "u64"
-          },
-          {
-            "name": "lpPerToken",
-            "docs": ["Lp per token, virtual price of lp token"],
-            "type": "u128"
-          },
-          {
-            "name": "unclaimedFeePending",
-            "docs": ["Unclaimed fee pending"],
-            "type": "u64"
-          },
-          {
-            "name": "aFee",
-            "docs": ["Total a fee claimed so far"],
-            "type": "u64"
-          },
-          {
-            "name": "bFee",
-            "docs": ["Total b fee claimed so far"],
-            "type": "u64"
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "TokenMultiplier",
-      "docs": [
-        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenAMultiplier",
-            "docs": ["Multiplier for token A of the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "tokenBMultiplier",
-            "docs": ["Multiplier for token B of the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "precisionFactor",
-            "docs": [
-              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
-            ],
-            "type": "u8"
-          }
-        ]
-      }
+      "discriminator": [
+        190,
+        106,
+        121,
+        6,
+        200,
+        182,
+        21,
+        75
+      ]
     },
     {
-      "name": "PoolFees",
-      "docs": ["Information regarding fee charges"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tradeFeeNumerator",
-            "docs": [
-              "Trade fees are extra token amounts that are held inside the token",
-              "accounts during a trade, making the value of liquidity tokens rise.",
-              "Trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "tradeFeeDenominator",
-            "docs": ["Trade fee denominator"],
-            "type": "u64"
-          },
-          {
-            "name": "ownerTradeFeeNumerator",
-            "docs": [
-              "Owner trading fees are extra token amounts that are held inside the token",
-              "accounts during a trade, with the equivalent in pool tokens minted to",
-              "the owner of the program.",
-              "Owner trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "ownerTradeFeeDenominator",
-            "docs": ["Owner trade fee denominator"],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Depeg",
-      "docs": ["Contains information for depeg pool"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "baseVirtualPrice",
-            "docs": ["The virtual price of staking / interest bearing token"],
-            "type": "u64"
-          },
-          {
-            "name": "baseCacheUpdated",
-            "docs": ["The virtual price of staking / interest bearing token"],
-            "type": "u64"
-          },
-          {
-            "name": "depegType",
-            "docs": ["Type of the depeg pool"],
-            "type": { "defined": "DepegType" }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Padding",
-      "docs": ["Padding for future pool fields"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "padding0",
-            "docs": ["Padding 0"],
-            "type": { "array": ["u8", 7] }
-          },
-          {
-            "name": "padding",
-            "docs": ["Padding 1"],
-            "type": { "array": ["u128", 29] }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RoundDirection",
-      "docs": ["Rounding direction"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Floor" }, { "name": "Ceiling" }]
-      }
-    },
-    {
-      "name": "TradeDirection",
-      "docs": ["Trade (swap) direction"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "AtoB" }, { "name": "BtoA" }]
-      }
-    },
-    {
-      "name": "NewCurveType",
-      "docs": ["Type of the swap curve"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "ConstantProduct" },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": ["Amplification coefficient"],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": { "defined": "TokenMultiplier" }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": { "defined": "Depeg" }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          },
-          {
-            "name": "NewCurve",
-            "fields": [
-              { "name": "field_one", "type": "u64" },
-              { "name": "field_two", "type": "u64" }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "CurveType",
-      "docs": ["Type of the swap curve"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "ConstantProduct" },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": ["Amplification coefficient"],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": { "defined": "TokenMultiplier" }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": { "defined": "Depeg" }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "DepegType",
-      "docs": ["Type of depeg pool"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "None" },
-          { "name": "Marinade" },
-          { "name": "Lido" },
-          { "name": "SplStake" }
-        ]
-      }
-    },
-    {
-      "name": "Rounding",
-      "docs": ["Round up, down"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Up" }, { "name": "Down" }]
-      }
-    },
-    {
-      "name": "PoolType",
-      "docs": ["Pool type"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Permissioned" }, { "name": "Permissionless" }]
-      }
+      "name": "Pool",
+      "discriminator": [
+        241,
+        154,
+        109,
+        4,
+        17,
+        177,
+        109,
+        188
+      ]
     }
   ],
   "events": [
     {
       "name": "AddLiquidity",
-      "fields": [
-        { "name": "lpMintAmount", "type": "u64", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false }
+      "discriminator": [
+        31,
+        94,
+        125,
+        90,
+        227,
+        52,
+        61,
+        186
       ]
     },
     {
       "name": "RemoveLiquidity",
-      "fields": [
-        { "name": "lpUnmintAmount", "type": "u64", "index": false },
-        { "name": "tokenAOutAmount", "type": "u64", "index": false },
-        { "name": "tokenBOutAmount", "type": "u64", "index": false }
+      "discriminator": [
+        116,
+        244,
+        97,
+        232,
+        103,
+        31,
+        152,
+        58
       ]
     },
     {
       "name": "BootstrapLiquidity",
-      "fields": [
-        { "name": "lpMintAmount", "type": "u64", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        121,
+        127,
+        38,
+        136,
+        92,
+        55,
+        14,
+        247
       ]
     },
     {
       "name": "Swap",
-      "fields": [
-        { "name": "inAmount", "type": "u64", "index": false },
-        { "name": "outAmount", "type": "u64", "index": false },
-        { "name": "tradeFee", "type": "u64", "index": false },
-        { "name": "adminFee", "type": "u64", "index": false },
-        { "name": "hostFee", "type": "u64", "index": false }
+      "discriminator": [
+        81,
+        108,
+        227,
+        190,
+        205,
+        208,
+        10,
+        196
       ]
     },
     {
       "name": "SetPoolFees",
-      "fields": [
-        { "name": "tradeFeeNumerator", "type": "u64", "index": false },
-        { "name": "tradeFeeDenominator", "type": "u64", "index": false },
-        { "name": "ownerTradeFeeNumerator", "type": "u64", "index": false },
-        { "name": "ownerTradeFeeDenominator", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        245,
+        26,
+        198,
+        164,
+        88,
+        18,
+        75,
+        9
       ]
     },
     {
       "name": "PoolInfo",
-      "fields": [
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false },
-        { "name": "virtualPrice", "type": "f64", "index": false },
-        { "name": "currentTimestamp", "type": "u64", "index": false }
+      "discriminator": [
+        207,
+        20,
+        87,
+        97,
+        251,
+        212,
+        234,
+        45
       ]
     },
     {
       "name": "TransferAdmin",
-      "fields": [
-        { "name": "admin", "type": "publicKey", "index": false },
-        { "name": "newAdmin", "type": "publicKey", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
-      ]
-    },
-    {
-      "name": "SetAdminFeeAccount",
-      "fields": [
-        { "name": "adminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "adminTokenBFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenBFee", "type": "publicKey", "index": false }
+      "discriminator": [
+        228,
+        169,
+        131,
+        244,
+        61,
+        56,
+        65,
+        254
       ]
     },
     {
       "name": "OverrideCurveParam",
-      "fields": [
-        { "name": "newAmp", "type": "u64", "index": false },
-        { "name": "updatedTimestamp", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        247,
+        20,
+        165,
+        248,
+        75,
+        5,
+        54,
+        246
       ]
     },
     {
       "name": "PoolCreated",
-      "fields": [
-        { "name": "lpMint", "type": "publicKey", "index": false },
-        { "name": "tokenAMint", "type": "publicKey", "index": false },
-        { "name": "tokenBMint", "type": "publicKey", "index": false },
-        {
-          "name": "poolType",
-          "type": { "defined": "PoolType" },
-          "index": false
-        },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        202,
+        44,
+        41,
+        88,
+        104,
+        220,
+        157,
+        82
       ]
     },
     {
       "name": "PoolEnabled",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "enabled", "type": "bool", "index": false }
+      "discriminator": [
+        2,
+        151,
+        18,
+        83,
+        204,
+        134,
+        92,
+        191
       ]
     },
     {
       "name": "MigrateFeeAccount",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenBFee", "type": "publicKey", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false }
+      "discriminator": [
+        223,
+        234,
+        232,
+        26,
+        252,
+        105,
+        180,
+        125
       ]
     },
     {
       "name": "CreateLockEscrow",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false }
+      "discriminator": [
+        74,
+        94,
+        106,
+        141,
+        49,
+        17,
+        98,
+        109
       ]
     },
     {
       "name": "Lock",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false },
-        { "name": "amount", "type": "u64", "index": false }
+      "discriminator": [
+        220,
+        183,
+        67,
+        215,
+        153,
+        207,
+        56,
+        234
       ]
     },
     {
       "name": "ClaimFee",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false },
-        { "name": "amount", "type": "u64", "index": false },
-        { "name": "aFee", "type": "u64", "index": false },
-        { "name": "bFee", "type": "u64", "index": false }
+      "discriminator": [
+        75,
+        122,
+        154,
+        48,
+        140,
+        74,
+        123,
+        163
+      ]
+    },
+    {
+      "name": "CreateConfig",
+      "discriminator": [
+        199,
+        152,
+        10,
+        19,
+        39,
+        39,
+        157,
+        104
+      ]
+    },
+    {
+      "name": "CloseConfig",
+      "discriminator": [
+        249,
+        181,
+        108,
+        89,
+        4,
+        150,
+        90,
+        174
+      ]
+    },
+    {
+      "name": "WithdrawProtocolFees",
+      "discriminator": [
+        30,
+        240,
+        207,
+        196,
+        139,
+        239,
+        79,
+        28
+      ]
+    },
+    {
+      "name": "PartnerClaimFees",
+      "discriminator": [
+        135,
+        131,
+        10,
+        94,
+        119,
+        209,
+        202,
+        48
       ]
     }
   ],
   "errors": [
-    { "code": 6000, "name": "MathOverflow", "msg": "Math operation overflow" },
-    { "code": 6001, "name": "InvalidFee", "msg": "Invalid fee setup" },
-    { "code": 6002, "name": "InvalidInvariant", "msg": "Invalid invariant d" },
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidInvariant",
+      "msg": "Invalid invariant d"
+    },
     {
       "code": 6003,
       "name": "FeeCalculationFailure",
@@ -2352,7 +3141,11 @@
       "name": "MismatchedTokenMint",
       "msg": "Token mint mismatched"
     },
-    { "code": 6010, "name": "MismatchedLpMint", "msg": "LP mint mismatched" },
+    {
+      "code": 6010,
+      "name": "MismatchedLpMint",
+      "msg": "LP mint mismatched"
+    },
     {
       "code": 6011,
       "name": "MismatchedOwner",
@@ -2373,7 +3166,11 @@
       "name": "InvalidPoolLpMintAccount",
       "msg": "Invalid pool lp mint account"
     },
-    { "code": 6015, "name": "PoolDisabled", "msg": "Pool disabled" },
+    {
+      "code": 6015,
+      "name": "PoolDisabled",
+      "msg": "Pool disabled"
+    },
     {
       "code": 6016,
       "name": "InvalidAdminAccount",
@@ -2381,10 +3178,14 @@
     },
     {
       "code": 6017,
-      "name": "InvalidAdminFeeAccount",
-      "msg": "Invalid admin fee account"
+      "name": "InvalidProtocolFeeAccount",
+      "msg": "Invalid protocol fee account"
     },
-    { "code": 6018, "name": "SameAdminAccount", "msg": "Same admin account" },
+    {
+      "code": 6018,
+      "name": "SameAdminAccount",
+      "msg": "Same admin account"
+    },
     {
       "code": 6019,
       "name": "IdenticalSourceDestination",
@@ -2440,7 +3241,11 @@
       "name": "MismatchedDepegMint",
       "msg": "Token mint B doesn't matches depeg type token mint"
     },
-    { "code": 6030, "name": "InvalidApyAccount", "msg": "Invalid APY account" },
+    {
+      "code": 6030,
+      "name": "InvalidApyAccount",
+      "msg": "Invalid APY account"
+    },
     {
       "code": 6031,
       "name": "InvalidTokenMultiplier",
@@ -2456,28 +3261,1356 @@
       "name": "UpdateTimeConstraint",
       "msg": "Update time constraint violated"
     },
-    { "code": 6034, "name": "ExceedMaxFeeBps", "msg": "Exceeded max fee bps" },
+    {
+      "code": 6034,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
     {
       "code": 6035,
-      "name": "OwnerFeeOverHalfOfTradeFee",
-      "msg": "Owner fee exceed half of trade fee"
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
     },
-    { "code": 6036, "name": "InvalidAdmin", "msg": "Invalid admin" },
     {
-      "code": 6037,
+      "code": 6036,
       "name": "PoolIsNotPermissioned",
       "msg": "Pool is not permissioned"
     },
     {
-      "code": 6038,
+      "code": 6037,
       "name": "InvalidDepositAmount",
       "msg": "Invalid deposit amount"
     },
-    { "code": 6039, "name": "InvalidFeeOwner", "msg": "Invalid fee owner" },
-    { "code": 6040, "name": "NonDepletedPool", "msg": "Pool is not depleted" },
-    { "code": 6041, "name": "AmountNotPeg", "msg": "Token amount is not 1:1" },
-    { "code": 6042, "name": "AmountIsZero", "msg": "Amount is zero" },
-    { "code": 6043, "name": "TypeCastFailed", "msg": "Type cast error" },
-    { "code": 6044, "name": "AmountIsNotEnough", "msg": "Amount is not enough" }
+    {
+      "code": 6038,
+      "name": "InvalidFeeOwner",
+      "msg": "Invalid fee owner"
+    },
+    {
+      "code": 6039,
+      "name": "NonDepletedPool",
+      "msg": "Pool is not depleted"
+    },
+    {
+      "code": 6040,
+      "name": "AmountNotPeg",
+      "msg": "Token amount is not 1:1"
+    },
+    {
+      "code": 6041,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6042,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6043,
+      "name": "AmountIsNotEnough",
+      "msg": "Amount is not enough"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidActivationDuration",
+      "msg": "Invalid activation duration"
+    },
+    {
+      "code": 6045,
+      "name": "PoolIsNotLaunchPool",
+      "msg": "Pool is not launch pool"
+    },
+    {
+      "code": 6046,
+      "name": "UnableToModifyActivationPoint",
+      "msg": "Unable to modify activation point"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidAuthorityToCreateThePool",
+      "msg": "Invalid authority to create the pool"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidActivationPoint",
+      "msg": "Invalid activation point"
+    },
+    {
+      "code": 6050,
+      "name": "PreActivationSwapStarted",
+      "msg": "Pre activation swap window started"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidPoolType",
+      "msg": "Invalid pool type"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidQuoteMint",
+      "msg": "Quote token must be SOL,USDC"
+    }
+  ],
+  "types": [
+    {
+      "name": "TokenMultiplier",
+      "docs": [
+        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_multiplier",
+            "docs": [
+              "Multiplier for token A of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_multiplier",
+            "docs": [
+              "Multiplier for token B of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "precision_factor",
+            "docs": [
+              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFees",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trade fees are extra token amounts that are held inside the token",
+              "accounts during a trade, making the value of liquidity tokens rise.",
+              "Trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "docs": [
+              "Trade fee denominator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "docs": [
+              "Protocol trading fees are extra token amounts that are held inside the token",
+              "accounts during a trade, with the equivalent in pool tokens minted to",
+              "the protocol of the program.",
+              "Protocol trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "docs": [
+              "Protocol trade fee denominator"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Depeg",
+      "docs": [
+        "Contains information for depeg pool"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_virtual_price",
+            "docs": [
+              "The virtual price of staking / interest bearing token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_cache_updated",
+            "docs": [
+              "The last time base_virtual_price is updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depeg_type",
+            "docs": [
+              "Type of the depeg pool"
+            ],
+            "type": {
+              "defined": {
+                "name": "DepegType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trading fee."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "The pool start trading."
+            ],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": [
+              "Whether the pool support alpha vault"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                90
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Padding",
+      "docs": [
+        "Padding for future pool fields"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding0",
+            "docs": [
+              "Padding 0"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "docs": [
+              "Padding 1"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "docs": [
+              "Padding 2"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "partner_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "pending_fee_b",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bootstrapping",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "activation_point",
+            "docs": [
+              "Activation point, can be slot or timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "whitelisted_vault",
+            "docs": [
+              "Whitelisted vault to be able to buy pool before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator",
+            "docs": [
+              "Need to store pool creator in lauch pool, so they can modify liquidity before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type, 0 means by slot, 1 means by timestamp"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ActivationType",
+      "docs": [
+        "Type of the activation"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Slot"
+          },
+          {
+            "name": "Timestamp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RoundDirection",
+      "docs": [
+        "Rounding direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Floor"
+          },
+          {
+            "name": "Ceiling"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TradeDirection",
+      "docs": [
+        "Trade (swap) direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AtoB"
+          },
+          {
+            "name": "BtoA"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NewCurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          },
+          {
+            "name": "NewCurve",
+            "fields": [
+              {
+                "name": "field_one",
+                "type": "u64"
+              },
+              {
+                "name": "field_two",
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "CurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepegType",
+      "docs": [
+        "Type of depeg pool"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Marinade"
+          },
+          {
+            "name": "Lido"
+          },
+          {
+            "name": "SplStake"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rounding",
+      "docs": [
+        "Round up, down"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Up"
+          },
+          {
+            "name": "Down"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolType",
+      "docs": [
+        "Pool type"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Permissioned"
+          },
+          {
+            "name": "Permissionless"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "docs": [
+              "Only pool_creator_authority can use the current config to initialize new pool. When it's Pubkey::default, it's a public config."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                219
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockEscrow",
+      "docs": [
+        "State of lock escrow account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "docs": [
+              "Pool address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "escrow_vault",
+            "docs": [
+              "Vault address, store the lock user lock"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "bump, used to sign"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "total_locked_amount",
+            "docs": [
+              "Total locked amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lp_per_token",
+            "docs": [
+              "Lp per token, virtual price of lp token"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "unclaimed_fee_pending",
+            "docs": [
+              "Unclaimed fee pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "docs": [
+              "Total a fee claimed so far"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "docs": [
+              "Total b fee claimed so far"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Pool",
+      "docs": [
+        "State of pool account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "docs": [
+              "LP token mint of the pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "docs": [
+              "Token A mint of the pool. Eg: USDT"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "docs": [
+              "Token B mint of the pool. Eg: USDC"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault",
+            "docs": [
+              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault",
+            "docs": [
+              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp",
+            "docs": [
+              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault_lp",
+            "docs": [
+              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp_bump",
+            "docs": [
+              "\"A\" vault lp bump. Used to create signer seeds."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "enabled",
+            "docs": [
+              "Flag to determine whether the pool is enabled, or disabled."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "protocol_token_a_fee",
+            "docs": [
+              "Protocol fee token account for token A. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_token_b_fee",
+            "docs": [
+              "Protocol fee token account for token B. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_last_updated_at",
+            "docs": [
+              "Fee last updated timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Store the fee charges setting."
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "pool_type",
+            "docs": [
+              "Pool type"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "stake",
+            "docs": [
+              "Stake pubkey of SPL stake pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "total_locked_lp",
+            "docs": [
+              "Total locked lp token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bootstrapping",
+            "docs": [
+              "bootstrapping config"
+            ],
+            "type": {
+              "defined": {
+                "name": "Bootstrapping"
+              }
+            }
+          },
+          {
+            "name": "partner_info",
+            "type": {
+              "defined": {
+                "name": "PartnerInfo"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding for future pool field"
+            ],
+            "type": {
+              "defined": {
+                "name": "Padding"
+              }
+            }
+          },
+          {
+            "name": "curve_type",
+            "docs": [
+              "The type of the swap curve supported by the pool."
+            ],
+            "type": {
+              "defined": {
+                "name": "CurveType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_unmint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_out_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BootstrapLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "in_amount",
+            "type": "u64"
+          },
+          {
+            "name": "out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetPoolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "virtual_price",
+            "type": "f64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferAdmin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OverrideCurveParam",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_amp",
+            "type": "u64"
+          },
+          {
+            "name": "updated_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "enabled",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrateFeeAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_a_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_b_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateLockEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Lock",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawProtocolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_b_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_a_fee_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_b_fee_owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerClaimFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    }
   ]
 }

--- a/idls/meteora_damm_v2.json
+++ b/idls/meteora_damm_v2.json
@@ -2,7 +2,7 @@
   "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",
   "metadata": {
     "name": "cp_amm",
-    "version": "0.1.7",
+    "version": "0.2.2",
     "spec": "0.1.0",
     "description": "Created with Anchor"
   },
@@ -90,9 +90,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -109,33 +109,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -149,142 +123,6 @@
               "name": "AddLiquidityParameters"
             }
           }
-        }
-      ]
-    },
-    {
-      "name": "claim_partner_fee",
-      "discriminator": [
-        97,
-        206,
-        39,
-        105,
-        94,
-        94,
-        126,
-        148
-      ],
-      "accounts": [
-        {
-          "name": "pool_authority",
-          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
-        },
-        {
-          "name": "pool",
-          "writable": true
-        },
-        {
-          "name": "token_a_account",
-          "docs": [
-            "The treasury token a account"
-          ],
-          "writable": true
-        },
-        {
-          "name": "token_b_account",
-          "docs": [
-            "The treasury token b account"
-          ],
-          "writable": true
-        },
-        {
-          "name": "token_a_vault",
-          "docs": [
-            "The vault token account for input token"
-          ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_b_vault",
-          "docs": [
-            "The vault token account for output token"
-          ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_a_mint",
-          "docs": [
-            "The mint of token a"
-          ],
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_b_mint",
-          "docs": [
-            "The mint of token b"
-          ],
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "partner",
-          "signer": true,
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_a_program",
-          "docs": [
-            "Token a program"
-          ]
-        },
-        {
-          "name": "token_b_program",
-          "docs": [
-            "Token b program"
-          ]
-        },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "name": "program"
-        }
-      ],
-      "args": [
-        {
-          "name": "max_amount_a",
-          "type": "u64"
-        },
-        {
-          "name": "max_amount_b",
-          "type": "u64"
         }
       ]
     },
@@ -374,9 +212,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -393,33 +231,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -520,33 +332,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -559,6 +345,79 @@
         },
         {
           "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_a_program"
+        },
+        {
+          "name": "token_b_program"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
           "type": "u64"
         }
       ]
@@ -612,9 +471,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -622,33 +481,7 @@
           "name": "token_program"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -694,33 +527,7 @@
           "writable": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -754,33 +561,7 @@
           "writable": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -849,33 +630,7 @@
           "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -912,33 +667,7 @@
           "writable": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1002,33 +731,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1102,33 +805,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1207,33 +884,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1363,33 +1014,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1458,33 +1083,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1527,6 +1126,105 @@
       ]
     },
     {
+      "name": "fix_config_fee_params",
+      "discriminator": [
+        38,
+        30,
+        216,
+        81,
+        250,
+        177,
+        243,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_fee_params",
+      "discriminator": [
+        132,
+        98,
+        81,
+        196,
+        44,
+        58,
+        120,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_layout_version",
+      "discriminator": [
+        166,
+        158,
+        69,
+        35,
+        81,
+        167,
+        200,
+        215
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "fund_reward",
       "discriminator": [
         188,
@@ -1562,33 +1260,7 @@
           "name": "token_program"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1837,33 +1509,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2117,33 +1763,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2401,33 +2021,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2518,33 +2112,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2562,6 +2130,60 @@
         {
           "name": "funder",
           "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "lock_inner_position",
+      "discriminator": [
+        72,
+        19,
+        49,
+        204,
+        18,
+        122,
+        23,
+        90
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "VestingParameters"
+            }
+          }
         }
       ]
     },
@@ -2600,9 +2222,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -2616,33 +2238,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2690,40 +2286,14 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2858,9 +2428,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -2877,33 +2447,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3007,9 +2551,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -3026,33 +2570,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3094,33 +2612,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3195,33 +2687,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3300,33 +2766,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3437,33 +2877,7 @@
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3578,33 +2992,7 @@
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3618,6 +3006,47 @@
               "name": "SwapParameters2"
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "update_delegate_permission",
+      "discriminator": [
+        175,
+        165,
+        56,
+        64,
+        0,
+        251,
+        89,
+        47
+      ],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u32"
         }
       ]
     },
@@ -3646,33 +3075,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3711,33 +3114,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3776,33 +3153,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3816,6 +3167,59 @@
         {
           "name": "new_funder",
           "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_dead_liquidity_reward",
+      "discriminator": [
+        121,
+        99,
+        224,
+        91,
+        178,
+        14,
+        22,
+        132
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
         }
       ]
     },
@@ -3859,33 +3263,7 @@
           "name": "token_program"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -4083,19 +3461,6 @@
   ],
   "events": [
     {
-      "name": "EvtClaimPartnerFee",
-      "discriminator": [
-        118,
-        99,
-        77,
-        10,
-        226,
-        1,
-        1,
-        87
-      ]
-    },
-    {
       "name": "EvtClaimPositionFee",
       "discriminator": [
         198,
@@ -4119,6 +3484,19 @@
         13,
         25,
         33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
       ]
     },
     {
@@ -4317,6 +3695,19 @@
       ]
     },
     {
+      "name": "EvtSplitPosition3",
+      "discriminator": [
+        232,
+        117,
+        190,
+        218,
+        85,
+        162,
+        207,
+        78
+      ]
+    },
+    {
       "name": "EvtSwap2",
       "discriminator": [
         189,
@@ -4327,6 +3718,19 @@
         80,
         117,
         153
+      ]
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "discriminator": [
+        66,
+        188,
+        75,
+        151,
+        150,
+        232,
+        87,
+        93
       ]
     },
     {
@@ -4366,6 +3770,19 @@
         115,
         246,
         146
+      ]
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "discriminator": [
+        228,
+        66,
+        150,
+        195,
+        42,
+        62,
+        163,
+        13
       ]
     },
     {
@@ -4717,6 +4134,26 @@
       "code": 6066,
       "name": "InvalidZapAccounts",
       "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingFeeBps",
+      "msg": "Invalid compounding fee bps"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "TransferFeeExcludedAmountIsZero",
+      "msg": "Transfer fee excluded amount is zero"
+    },
+    {
+      "code": 6070,
+      "name": "DelegatedAmountNonZero",
+      "msg": "Delegated amount is not zero"
     }
   ],
   "types": [
@@ -4780,7 +4217,7 @@
             "type": {
               "array": [
                 "u8",
-                30
+                27
               ]
             }
           }
@@ -4839,15 +4276,6 @@
           {
             "name": "base_fee_mode",
             "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                3
-              ]
-            }
           }
         ]
       }
@@ -4893,15 +4321,6 @@
           {
             "name": "base_fee_mode",
             "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                3
-              ]
-            }
           }
         ]
       }
@@ -4930,15 +4349,6 @@
           {
             "name": "base_fee_mode",
             "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                3
-              ]
-            }
           }
         ]
       }
@@ -5259,26 +4669,6 @@
       }
     },
     {
-      "name": "EvtClaimPartnerFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "pool",
-            "type": "pubkey"
-          },
-          {
-            "name": "token_a_amount",
-            "type": "u64"
-          },
-          {
-            "name": "token_b_amount",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
       "name": "EvtClaimPositionFee",
       "type": {
         "kind": "struct",
@@ -5321,6 +4711,30 @@
           },
           {
             "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
             "type": "u64"
           }
         ]
@@ -5901,6 +5315,70 @@
       }
     },
     {
+      "name": "EvtSplitPosition3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "amount_splits",
+            "type": {
+              "defined": {
+                "name": "SplitAmountInfo2"
+              }
+            }
+          },
+          {
+            "name": "first_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "second_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "split_position_parameters",
+            "type": {
+              "defined": {
+                "name": "SplitPositionParameters3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "EvtSwap2",
       "type": {
         "kind": "struct",
@@ -5960,6 +5438,32 @@
           {
             "name": "reserve_b_amount",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u32"
+          },
+          {
+            "name": "delegate",
+            "type": {
+              "option": "pubkey"
+            }
           }
         ]
       }
@@ -6032,6 +5536,26 @@
           {
             "name": "new_funder",
             "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
           }
         ]
       }
@@ -6159,6 +5683,51 @@
             ],
             "type": {
               "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InnerVesting",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_point",
+            "type": "u64"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "total_released_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
             }
           }
         ]
@@ -6380,11 +5949,16 @@
             "type": "pubkey"
           },
           {
-            "name": "partner",
+            "name": "padding_0",
             "docs": [
-              "partner"
+              "padding, previously partner pubkey, be careful when using this field"
             ],
-            "type": "pubkey"
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "liquidity",
@@ -6394,7 +5968,7 @@
             "type": "u128"
           },
           {
-            "name": "_padding",
+            "name": "padding_1",
             "docs": [
               "padding, previous reserve amount, be careful to use that field"
             ],
@@ -6415,18 +5989,8 @@
             "type": "u64"
           },
           {
-            "name": "partner_a_fee",
-            "docs": [
-              "partner a fee"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "partner_b_fee",
-            "docs": [
-              "partner b fee"
-            ],
-            "type": "u64"
+            "name": "padding_2",
+            "type": "u128"
           },
           {
             "name": "sqrt_min_price",
@@ -6499,14 +6063,14 @@
             "type": "u8"
           },
           {
-            "name": "version",
+            "name": "fee_version",
             "docs": [
-              "pool version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"
+              "pool fee version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"
             ],
             "type": "u8"
           },
           {
-            "name": "_padding_0",
+            "name": "padding_3",
             "docs": [
               "padding"
             ],
@@ -6559,14 +6123,47 @@
             "type": "pubkey"
           },
           {
-            "name": "_padding_1",
+            "name": "token_a_amount",
+            "docs": [
+              "token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "docs": [
+              "token b amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "layout_version",
+            "docs": [
+              "layout version: version 0: haven't track token_a_amount and token_b_amount, version 1: track token_a_amount and token_b_amount"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_4",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "padding_5",
             "docs": [
               "Padding for further use"
             ],
             "type": {
               "array": [
                 "u64",
-                6
+                3
               ]
             }
           },
@@ -6607,6 +6204,20 @@
                 "name": "BaseFeeParameters"
               }
             }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only have value if CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": "u8"
           },
           {
             "name": "dynamic_fee",
@@ -6654,7 +6265,7 @@
             "type": "u8"
           },
           {
-            "name": "partner_fee_percent",
+            "name": "padding_0",
             "type": "u8"
           },
           {
@@ -6662,16 +6273,23 @@
             "type": "u8"
           },
           {
-            "name": "padding_0",
+            "name": "padding_1",
             "type": {
               "array": [
                 "u8",
-                5
+                3
               ]
             }
           },
           {
-            "name": "padding_1",
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee bps, only non-zero if collect_fee_mode is compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding_2",
             "type": {
               "array": [
                 "u64",
@@ -6688,8 +6306,7 @@
         "Information regarding fee charges",
         "trading_fee = amount * trade_fee_numerator / denominator",
         "protocol_fee = trading_fee * protocol_fee_percentage / 100",
-        "referral_fee = protocol_fee * referral_percentage / 100",
-        "partner_fee = (protocol_fee - referral_fee) * partner_fee_percentage / denominator"
+        "referral_fee = protocol_fee * referral_percentage / 100"
       ],
       "serialization": "bytemuck",
       "repr": {
@@ -6722,9 +6339,9 @@
             "type": "u8"
           },
           {
-            "name": "partner_fee_percent",
+            "name": "padding_0",
             "docs": [
-              "partner fee"
+              "padding for future use"
             ],
             "type": "u8"
           },
@@ -6736,16 +6353,23 @@
             "type": "u8"
           },
           {
-            "name": "padding_0",
+            "name": "padding_1",
             "docs": [
               "padding"
             ],
             "type": {
               "array": [
                 "u8",
-                5
+                3
               ]
             }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only non-zero in CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
           },
           {
             "name": "dynamic_fee",
@@ -6791,12 +6415,13 @@
             "type": "u64"
           },
           {
-            "name": "total_partner_a_fee",
-            "type": "u64"
-          },
-          {
-            "name": "total_partner_b_fee",
-            "type": "u64"
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
           },
           {
             "name": "total_position",
@@ -6916,14 +6541,32 @@
             }
           },
           {
+            "name": "inner_vesting",
+            "docs": [
+              "inner vesting info"
+            ],
+            "type": {
+              "defined": {
+                "name": "InnerVesting"
+              }
+            }
+          },
+          {
+            "name": "delegate_permission",
+            "docs": [
+              "delegate permission bitmask (paired with SPL token Approve)"
+            ],
+            "type": "u32"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future usage"
             ],
             "type": {
               "array": [
-                "u128",
-                6
+                "u8",
+                12
               ]
             }
           }
@@ -7018,16 +6661,11 @@
             }
           },
           {
-            "name": "_padding_1",
+            "name": "dead_liquidity_reward_checkpoint",
             "docs": [
-              "Padding to ensure `reward_rate: u128` is 16-byte aligned"
+              "Cumulative dead-liquidity reward (Compounding Pool only)"
             ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
+            "type": "u64"
           },
           {
             "name": "mint",
@@ -7134,12 +6772,84 @@
       }
     },
     {
+      "name": "SplitAmountInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "SplitPositionInfo",
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
             "type": "u128"
           },
           {
@@ -7209,6 +6919,13 @@
             "type": "u8"
           },
           {
+            "name": "inner_vesting_liquidity_percentage",
+            "docs": [
+              "Percentage of inner vesting liquidity"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future"
@@ -7216,7 +6933,7 @@
             "type": {
               "array": [
                 "u8",
-                16
+                15
               ]
             }
           }
@@ -7250,6 +6967,42 @@
           },
           {
             "name": "reward_1_numerator",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionParameters3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "permanent_locked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_a_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_b_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_0_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_1_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "inner_vesting_liquidity_numerator",
             "type": "u32"
           }
         ]
@@ -7366,7 +7119,7 @@
             "type": "u128"
           },
           {
-            "name": "trading_fee",
+            "name": "claiming_fee",
             "type": "u64"
           },
           {
@@ -7374,7 +7127,7 @@
             "type": "u64"
           },
           {
-            "name": "partner_fee",
+            "name": "compounding_fee",
             "type": "u64"
           },
           {
@@ -7449,6 +7202,17 @@
                 }
               }
             }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee update mode:",
+              "- None: skip compounding fee update",
+              "- Some: update compounding_fee_bps; pool must use CollectFeeMode::Compounding"
+            ],
+            "type": {
+              "option": "u16"
+            }
           }
         ]
       }
@@ -7505,36 +7269,11 @@
             "type": "pubkey"
           },
           {
-            "name": "cliff_point",
-            "type": "u64"
-          },
-          {
-            "name": "period_frequency",
-            "type": "u64"
-          },
-          {
-            "name": "cliff_unlock_liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "liquidity_per_period",
-            "type": "u128"
-          },
-          {
-            "name": "total_released_liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "number_of_period",
-            "type": "u16"
-          },
-          {
-            "name": "padding",
+            "name": "inner_vesting",
             "type": {
-              "array": [
-                "u8",
-                14
-              ]
+              "defined": {
+                "name": "InnerVesting"
+              }
             }
           },
           {
@@ -7597,6 +7336,11 @@
       "value": "[203, 16, 199, 186, 184, 141, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
     },
     {
+      "name": "CURRENT_POOL_VERSION",
+      "type": "u8",
+      "value": "1"
+    },
+    {
       "name": "CUSTOMIZABLE_POOL_PREFIX",
       "type": "bytes",
       "value": "[99, 112, 111, 111, 108]"
@@ -7614,8 +7358,18 @@
       "docs": [
         "Max basis point. 100% in pct"
       ],
-      "type": "u64",
+      "type": "u16",
       "value": "10000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V0",
+      "type": "u64",
+      "value": "500000000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V1",
+      "type": "u64",
+      "value": "990000000"
     },
     {
       "name": "MAX_SQRT_PRICE_LE_BYTES",
@@ -7626,6 +7380,11 @@
         ]
       },
       "value": "[155, 87, 105, 78, 169, 26, 92, 132, 177, 196, 254, 255, 0, 0, 0, 0]"
+    },
+    {
+      "name": "MIN_FEE_NUMERATOR",
+      "type": "u64",
+      "value": "100000"
     },
     {
       "name": "MIN_SQRT_PRICE_LE_BYTES",

--- a/idls/meteora_dlmm.json
+++ b/idls/meteora_dlmm.json
@@ -1,500 +1,1993 @@
 {
-  "version": "0.9.0",
-  "name": "lb_clmm",
-  "constants": [
-    {
-      "name": "BASIS_POINT_MAX",
-      "type": "i32",
-      "value": "10000"
-    },
-    {
-      "name": "MAX_BIN_PER_ARRAY",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "MAX_BIN_PER_POSITION",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "MAX_RESIZE_LENGTH",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "POSITION_MAX_LENGTH",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "1400"
-    },
-    {
-      "name": "MIN_BIN_ID",
-      "type": "i32",
-      "value": "- 443636"
-    },
-    {
-      "name": "MAX_BIN_ID",
-      "type": "i32",
-      "value": "443636"
-    },
-    {
-      "name": "MAX_FEE_RATE",
-      "type": "u64",
-      "value": "100_000_000"
-    },
-    {
-      "name": "FEE_PRECISION",
-      "type": "u64",
-      "value": "1_000_000_000"
-    },
-    {
-      "name": "MAX_PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "2_500"
-    },
-    {
-      "name": "HOST_FEE_BPS",
-      "type": "u16",
-      "value": "2_000"
-    },
-    {
-      "name": "NUM_REWARDS",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "2"
-    },
-    {
-      "name": "MIN_REWARD_DURATION",
-      "type": "u64",
-      "value": "1"
-    },
-    {
-      "name": "MAX_REWARD_DURATION",
-      "type": "u64",
-      "value": "31536000"
-    },
-    {
-      "name": "EXTENSION_BINARRAY_BITMAP_SIZE",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "12"
-    },
-    {
-      "name": "BIN_ARRAY_BITMAP_SIZE",
-      "type": "i32",
-      "value": "512"
-    },
-    {
-      "name": "MAX_REWARD_BIN_SPLIT",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "15"
-    },
-    {
-      "name": "ILM_PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "2000"
-    },
-    {
-      "name": "PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "500"
-    },
-    {
-      "name": "MAX_BIN_STEP",
-      "type": "u16",
-      "value": "400"
-    },
-    {
-      "name": "MAX_BASE_FEE",
-      "type": "u128",
-      "value": "100_000_000"
-    },
-    {
-      "name": "MIN_BASE_FEE",
-      "type": "u128",
-      "value": "100_000"
-    },
-    {
-      "name": "MINIMUM_LIQUIDITY",
-      "type": "u128",
-      "value": "1_000_000"
-    },
-    {
-      "name": "BIN_ARRAY",
-      "type": "bytes",
-      "value": "[98, 105, 110, 95, 97, 114, 114, 97, 121]"
-    },
-    {
-      "name": "ORACLE",
-      "type": "bytes",
-      "value": "[111, 114, 97, 99, 108, 101]"
-    },
-    {
-      "name": "BIN_ARRAY_BITMAP_SEED",
-      "type": "bytes",
-      "value": "[98, 105, 116, 109, 97, 112]"
-    },
-    {
-      "name": "PRESET_PARAMETER",
-      "type": "bytes",
-      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114]"
-    },
-    {
-      "name": "PRESET_PARAMETER2",
-      "type": "bytes",
-      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 50]"
-    },
-    {
-      "name": "POSITION",
-      "type": "bytes",
-      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
-    },
-    {
-      "name": "CLAIM_PROTOCOL_FEE_OPERATOR",
-      "type": "bytes",
-      "value": "[99, 102, 95, 111, 112, 101, 114, 97, 116, 111, 114]"
-    }
-  ],
+  "address": "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",
+  "metadata": {
+    "name": "lb_clmm",
+    "version": "0.12.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
   "instructions": [
     {
-      "name": "initializeLbPair",
+      "name": "add_liquidity",
+      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "position",
+          "writable": true
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "presetParameter",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "activeId",
-          "type": "i32"
-        },
-        {
-          "name": "binStep",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializePermissionLbPair",
-      "accounts": [
-        {
-          "name": "base",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ixData",
-          "type": {
-            "defined": "InitPermissionPairIx"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeCustomizablePermissionlessLbPair",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CustomizableParams"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeBinArrayBitmapExtension",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize an account to store if a bin array is initialized."
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
           ]
         },
         {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_x",
+          "writable": true
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity2",
+      "discriminator": [228, 162, 78, 28, 70, 219, 116, 115],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameter"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy",
+      "discriminator": [7, 3, 150, 127, 148, 40, 61, 200],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategy"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy2",
+      "discriminator": [3, 221, 149, 218, 111, 141, 118, 213],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategy"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy_one_side",
+      "discriminator": [41, 5, 238, 175, 100, 225, 6, 205],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategyOneSide"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_weight",
+      "discriminator": [28, 140, 238, 99, 231, 162, 21, 149],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByWeight"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_weight2",
+      "discriminator": [209, 59, 63, 91, 111, 200, 153, 228],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByWeight"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side",
+      "discriminator": [94, 155, 103, 151, 70, 95, 220, 165],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityOneSideParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side_precise",
+      "discriminator": [161, 194, 103, 84, 171, 71, 250, 154],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "parameter",
+          "type": {
+            "defined": {
+              "name": "AddLiquiditySingleSidePreciseParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side_precise2",
+      "discriminator": [33, 51, 163, 201, 117, 98, 125, 231],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "AddLiquiditySingleSidePreciseParameter2"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancel_limit_order",
+      "discriminator": [132, 156, 132, 31, 67, 40, 232, 97],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension", "limit_order"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner_token_x",
+          "docs": [
+            "When dont set it tokenAccount to prevent unnecessary create token account (rent fee) when user only withdraw token y"
+          ],
+          "writable": true
+        },
+        {
+          "name": "owner_token_y",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bins",
+          "type": {
+            "vec": "i32"
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_fee",
+      "discriminator": [169, 32, 79, 137, 136, 232, 70, 137],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
     },
     {
-      "name": "initializeBinArray",
+      "name": "claim_fee2",
+      "discriminator": [112, 191, 101, 171, 28, 144, 127, 187],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
         },
         {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "min_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "max_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_reward",
+      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_reward2",
+      "discriminator": [190, 3, 127, 119, 178, 87, 157, 183],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "min_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "max_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_bin_array",
+      "discriminator": [68, 174, 88, 80, 181, 204, 19, 224],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_claim_fee_operator_account",
+      "discriminator": [184, 213, 88, 31, 179, 101, 130, 36],
+      "accounts": [
+        {
+          "name": "claim_fee_operator",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_limit_order_if_empty",
+      "discriminator": [57, 124, 36, 155, 126, 249, 93, 171],
+      "accounts": [
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_operator_account",
+      "discriminator": [171, 9, 213, 74, 120, 23, 3, 29],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position",
+      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position2",
+      "discriminator": [174, 90, 35, 115, 186, 40, 147, 226],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position_if_empty",
+      "discriminator": [59, 124, 212, 118, 91, 152, 110, 157],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_preset_parameter",
+      "discriminator": [4, 148, 145, 100, 134, 26, 181, 61],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_preset_parameter2",
+      "discriminator": [39, 25, 95, 107, 116, 17, 115, 28],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_token_badge",
+      "discriminator": [108, 146, 86, 110, 179, 254, 10, 104],
+      "accounts": [
+        {
+          "name": "token_badge",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_operator_account",
+      "discriminator": [221, 64, 246, 149, 240, 153, 229, 163],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 112, 101, 114, 97, 116, 111, 114]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "whitelisted_signer"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "decrease_position_length",
+      "discriminator": [194, 219, 136, 32, 25, 96, 105, 37],
+      "accounts": [
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_remove",
+          "type": "u16"
+        },
+        {
+          "name": "side",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "for_idl_type_generation_do_not_call",
+      "discriminator": [180, 105, 69, 80, 95, 50, 73, 108],
+      "accounts": [
+        {
+          "name": "dummy_zc_account"
+        }
+      ],
+      "args": [
+        {
+          "name": "_ix",
+          "type": {
+            "defined": {
+              "name": "DummyIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fund_reward",
+      "discriminator": [188, 50, 249, 165, 93, 151, 38, 63],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
         },
         {
           "name": "funder",
-          "isMut": true,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "carry_forward",
+          "type": "bool"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "go_to_a_bin",
+      "discriminator": [146, 72, 174, 224, 40, 253, 84, 174],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "bin_array_bitmap_extension",
+            "from_bin_array",
+            "to_bin_array"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "optional": true
+        },
+        {
+          "name": "from_bin_array",
+          "optional": true
+        },
+        {
+          "name": "to_bin_array",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_id",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "increase_oracle_length",
+      "discriminator": [190, 61, 125, 87, 103, 79, 158, 173],
+      "accounts": [
+        {
+          "name": "oracle",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_add",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_position_length",
+      "discriminator": [80, 83, 117, 211, 66, 13, 33, 149],
+      "accounts": [
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_add",
+          "type": "u16"
+        },
+        {
+          "name": "side",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "increase_position_length2",
+      "discriminator": [255, 210, 204, 71, 115, 137, 225, 113],
+      "accounts": [
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "minimum_upper_bin_id",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "initialize_bin_array",
+      "discriminator": [35, 86, 19, 185, 78, 212, 75, 211],
+      "accounts": [
+        {
+          "name": "lb_pair"
+        },
+        {
+          "name": "bin_array",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 110, 95, 97, 114, 114, 97, 121]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -505,578 +1998,762 @@
       ]
     },
     {
-      "name": "addLiquidity",
+      "name": "initialize_bin_array_bitmap_extension",
+      "discriminator": [47, 157, 226, 180, 12, 240, 33, 71],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "bin_array_bitmap_extension",
+          "docs": [
+            "Initialize an account to store if a bin array is initialized."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "funder",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "rent"
         }
       ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameter"
-          }
-        }
-      ]
+      "args": []
     },
     {
-      "name": "addLiquidityByWeight",
+      "name": "initialize_customizable_permissionless_lb_pair",
+      "discriminator": [46, 39, 41, 135, 111, 183, 200, 64],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByWeight"
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategy",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_mint_x"
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "token_mint_y"
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategy"
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategyOneSide",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategyOneSide"
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSide",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityOneSideParameter"
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidity",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_x"
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "funder",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_y"
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "binLiquidityRemoval",
+          "name": "params",
           "type": {
-            "vec": {
-              "defined": "BinLiquidityReduction"
+            "defined": {
+              "name": "CustomizableParams"
             }
           }
         }
       ]
     },
     {
-      "name": "initializePosition",
+      "name": "initialize_customizable_permissionless_lb_pair2",
+      "discriminator": [243, 73, 129, 126, 51, 19, 241, 107],
       "accounts": [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          "name": "lb_pair",
+          "writable": true
         },
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_mint_x"
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "name": "token_mint_y"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_x"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "user_token_y"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CustomizableParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_lb_pair",
+      "discriminator": [45, 154, 237, 210, 221, 15, 166, 92],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "preset_parameter"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "active_id",
+          "type": "i32"
+        },
+        {
+          "name": "bin_step",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initialize_lb_pair2",
+      "discriminator": [73, 59, 36, 120, 237, 83, 108, 198],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "preset_parameter"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializeLbPair2Params"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_permission_lb_pair",
+      "discriminator": [108, 102, 213, 85, 251, 3, 53, 21],
+      "accounts": [
+        {
+          "name": "base",
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "ix_data",
+          "type": {
+            "defined": {
+              "name": "InitPermissionPairIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_position",
+      "discriminator": [219, 192, 234, 71, 190, 191, 102, 80],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair"
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1086,60 +2763,51 @@
       ]
     },
     {
-      "name": "initializePositionPda",
+      "name": "initialize_position2",
+      "discriminator": [143, 19, 242, 145, 213, 15, 104, 115],
       "accounts": [
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "base",
-          "isMut": false,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "owner"
-          ]
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1149,70 +2817,88 @@
       ]
     },
     {
-      "name": "initializePositionByOperator",
+      "name": "initialize_position_by_operator",
+      "discriminator": [251, 189, 190, 244, 117, 254, 35, 148],
       "accounts": [
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "base",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "base"
+              },
+              {
+                "kind": "arg",
+                "path": "lower_bin_id"
+              },
+              {
+                "kind": "arg",
+                "path": "width"
+              }
+            ]
+          }
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner"
         },
         {
           "name": "operator",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "operator"
-          ]
+          "docs": ["operator"],
+          "signer": true
         },
         {
-          "name": "operatorTokenX",
-          "isMut": false,
-          "isSigner": false
+          "name": "operator_token_x"
         },
         {
-          "name": "ownerTokenX",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner_token_x"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1220,5733 +2906,2316 @@
           "type": "i32"
         },
         {
-          "name": "feeOwner",
-          "type": "publicKey"
+          "name": "fee_owner",
+          "type": "pubkey"
         },
         {
-          "name": "lockReleasePoint",
+          "name": "lock_release_point",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "updatePositionOperator",
+      "name": "initialize_position_pda",
+      "discriminator": [46, 82, 125, 146, 85, 141, 228, 153],
       "accounts": [
         {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "base",
+          "signer": true
+        },
+        {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "base"
+              },
+              {
+                "kind": "arg",
+                "path": "lower_bin_id"
+              },
+              {
+                "kind": "arg",
+                "path": "width"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lb_pair"
         },
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "docs": ["owner"],
+          "signer": true
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "operator",
-          "type": "publicKey"
+          "name": "lower_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "width",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "initialize_preset_parameter",
+      "discriminator": [66, 188, 71, 211, 98, 109, 14, 186],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101,
+                  116, 101, 114, 50
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "ix.index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "ix",
+          "type": {
+            "defined": {
+              "name": "InitPresetParametersIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_reward",
+      "discriminator": [95, 135, 192, 196, 242, 129, 230, 68],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "arg",
+                "path": "reward_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "token_badge",
+          "optional": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "reward_duration",
+          "type": "u64"
+        },
+        {
+          "name": "funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "initialize_token_badge",
+      "discriminator": [253, 77, 205, 95, 27, 224, 89, 223],
+      "accounts": [
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "token_badge",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [116, 111, 107, 101, 110, 95, 98, 97, 100, 103, 101]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "place_limit_order",
+      "discriminator": [108, 176, 33, 186, 146, 229, 1, 197],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "limit_order",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "PlaceLimitOrderParams"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "rebalance_liquidity",
+      "discriminator": [92, 4, 176, 193, 119, 185, 83, 9],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "rent_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RebalanceLiquidityParams"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_all_liquidity",
+      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_liquidity",
+      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_liquidity_removal",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "BinLiquidityReduction"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity2",
+      "discriminator": [230, 215, 82, 127, 241, 101, 227, 146],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_liquidity_removal",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "BinLiquidityReduction"
+              }
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range",
+      "discriminator": [26, 82, 102, 152, 240, 74, 105, 26],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "from_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "to_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "bps_to_remove",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range2",
+      "discriminator": [204, 2, 195, 145, 53, 145, 145, 205],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "from_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "to_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "bps_to_remove",
+          "type": "u16"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_activation_point",
+      "discriminator": [91, 249, 15, 165, 26, 129, 254, 125],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "activation_point",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_pair_status",
+      "discriminator": [67, 248, 231, 137, 154, 149, 217, 174],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_pair_status_permissionless",
+      "discriminator": [78, 59, 152, 211, 70, 183, 46, 208],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_permissionless_operation_bits",
+      "discriminator": [84, 58, 203, 139, 163, 81, 190, 186],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bits",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_pre_activation_duration",
+      "discriminator": [165, 61, 201, 244, 130, 159, 22, 100],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pre_activation_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_pre_activation_swap_address",
+      "discriminator": [57, 139, 47, 123, 216, 80, 223, 10],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pre_activation_swap_address",
+          "type": "pubkey"
         }
       ]
     },
     {
       "name": "swap",
+      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "minAmountOut",
+          "name": "min_amount_out",
           "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "swapExactOut",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "user",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "maxInAmount",
-          "type": "u64"
-        },
-        {
-          "name": "outAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "swapWithPriceImpact",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "user",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amountIn",
-          "type": "u64"
-        },
-        {
-          "name": "activeId",
-          "type": {
-            "option": "i32"
-          }
-        },
-        {
-          "name": "maxPriceImpactBps",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "withdrawProtocolFee",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "receiverTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "receiverTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "claimFeeOperator",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "operator",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "operator"
-          ]
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amountX",
-          "type": "u64"
-        },
-        {
-          "name": "amountY",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "rewardDuration",
-          "type": "u64"
-        },
-        {
-          "name": "funder",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "fundReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "carryForward",
-          "type": "bool"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateRewardFunder",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "newFunder",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "updateRewardDuration",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "newDuration",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "claimReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "claimFee",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closePosition",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateBaseFeeParameters",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeParameter",
-          "type": {
-            "defined": "BaseFeeParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateDynamicFeeParameters",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeParameter",
-          "type": {
-            "defined": "DynamicFeeParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "increaseOracleLength",
-      "accounts": [
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "lengthToAdd",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "initializePresetParameter",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ix",
-          "type": {
-            "defined": "InitPresetParametersIx"
-          }
-        }
-      ]
-    },
-    {
-      "name": "closePresetParameter",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closePresetParameter2",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "removeAllLiquidity",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setPairStatus",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "status",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "migratePosition",
-      "accounts": [
-        {
-          "name": "positionV2",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionV1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "migrateBinArray",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateFeesAndRewards",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "withdrawIneligibleReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "setActivationPoint",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "activationPoint",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidityByRange",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "fromBinId",
-          "type": "i32"
-        },
-        {
-          "name": "toBinId",
-          "type": "i32"
-        },
-        {
-          "name": "bpsToRemove",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSidePrecise",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "parameter",
-          "type": {
-            "defined": "AddLiquiditySingleSidePreciseParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "goToABin",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "fromBinArray",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "toBinArray",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "binId",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "setPreActivationDuration",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "preActivationDuration",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "setPreActivationSwapAddress",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "preActivationSwapAddress",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "setPairStatusPermissionless",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "status",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "initializeTokenBadge",
-      "accounts": [
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "createClaimProtocolFeeOperator",
-      "accounts": [
-        {
-          "name": "claimFeeOperator",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "operator",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closeClaimProtocolFeeOperator",
-      "accounts": [
-        {
-          "name": "claimFeeOperator",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializePresetParameter2",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ix",
-          "type": {
-            "defined": "InitPresetParameters2Ix"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeLbPair2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "presetParameter",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "InitializeLbPair2Params"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeCustomizablePermissionlessLbPair2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CustomizableParams"
-          }
-        }
-      ]
-    },
-    {
-      "name": "claimFee2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "minBinId",
-          "type": "i32"
-        },
-        {
-          "name": "maxBinId",
-          "type": "i32"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "claimReward2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "minBinId",
-          "type": "i32"
-        },
-        {
-          "name": "maxBinId",
-          "type": "i32"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidity2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameter"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategy2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategy"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSidePrecise2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "AddLiquiditySingleSidePreciseParameter2"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidity2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "binLiquidityRemoval",
-          "type": {
-            "vec": {
-              "defined": "BinLiquidityReduction"
-            }
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidityByRange2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "fromBinId",
-          "type": "i32"
-        },
-        {
-          "name": "toBinId",
-          "type": "i32"
-        },
-        {
-          "name": "bpsToRemove",
-          "type": "u16"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
         }
       ]
     },
     {
       "name": "swap2",
+      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "minAmountOut",
+          "name": "min_amount_out",
           "type": "u64"
         },
         {
-          "name": "remainingAccountsInfo",
+          "name": "remaining_accounts_info",
           "type": {
-            "defined": "RemainingAccountsInfo"
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
           }
         }
       ]
     },
     {
-      "name": "swapExactOut2",
+      "name": "swap_exact_out",
+      "discriminator": [250, 73, 101, 33, 38, 207, 75, 184],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "maxInAmount",
+          "name": "max_in_amount",
           "type": "u64"
         },
         {
-          "name": "outAmount",
+          "name": "out_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "swap_exact_out2",
+      "discriminator": [43, 215, 247, 132, 137, 60, 243, 81],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_in",
+          "writable": true
+        },
+        {
+          "name": "user_token_out",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_in_amount",
           "type": "u64"
         },
         {
-          "name": "remainingAccountsInfo",
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
           "type": {
-            "defined": "RemainingAccountsInfo"
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
           }
         }
       ]
     },
     {
-      "name": "swapWithPriceImpact2",
+      "name": "swap_with_price_impact",
+      "discriminator": [56, 173, 230, 208, 173, 228, 156, 205],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "activeId",
+          "name": "active_id",
           "type": {
             "option": "i32"
           }
         },
         {
-          "name": "maxPriceImpactBps",
+          "name": "max_price_impact_bps",
           "type": "u16"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
         }
       ]
     },
     {
-      "name": "closePosition2",
+      "name": "swap_with_price_impact2",
+      "discriminator": [74, 98, 192, 214, 177, 51, 75, 51],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateFeesAndReward2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "minBinId",
+          "name": "amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "active_id",
+          "type": {
+            "option": "i32"
+          }
+        },
+        {
+          "name": "max_price_impact_bps",
+          "type": "u16"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_base_fee_parameters",
+      "discriminator": [75, 168, 223, 161, 16, 195, 3, 47],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_parameter",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_dynamic_fee_parameters",
+      "discriminator": [92, 161, 46, 246, 255, 189, 22, 22],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_parameter",
+          "type": {
+            "defined": {
+              "name": "DynamicFeeParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_fees_and_reward2",
+      "discriminator": [32, 142, 184, 154, 103, 65, 184, 88],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "owner",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "min_bin_id",
           "type": "i32"
         },
         {
-          "name": "maxBinId",
+          "name": "max_bin_id",
           "type": "i32"
         }
       ]
     },
     {
-      "name": "closePositionIfEmpty",
+      "name": "update_fees_and_rewards",
+      "discriminator": [154, 230, 250, 13, 236, 209, 75, 223],
       "accounts": [
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true
         },
         {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
         },
         {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
+          "name": "bin_array_lower",
+          "writable": true
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "bin_array_upper",
+          "writable": true
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner",
+          "signer": true
         }
       ],
       "args": []
+    },
+    {
+      "name": "update_position_operator",
+      "discriminator": [202, 184, 103, 143, 180, 191, 116, 217],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "operator",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_duration",
+      "discriminator": [138, 174, 196, 169, 213, 235, 254, 107],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "new_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_funder",
+      "discriminator": [211, 28, 48, 32, 215, 160, 35, 23],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "new_funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_ineligible_reward",
+      "discriminator": [148, 206, 42, 195, 247, 49, 103, 8],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fee",
+      "discriminator": [158, 201, 158, 189, 33, 93, 162, 103],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "receiver_token_x",
+          "writable": true
+        },
+        {
+          "name": "receiver_token_y",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": ["operator"],
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_x",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_y",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "discriminator": [213, 155, 187, 34, 56, 182, 91, 240],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": ["operator"],
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
     }
   ],
   "accounts": [
     {
-      "name": "BinArrayBitmapExtension",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "type": "publicKey"
-          },
-          {
-            "name": "positiveBinArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state for start_bin_index is positive"
-            ],
-            "type": {
-              "array": [
-                {
-                  "array": [
-                    "u64",
-                    8
-                  ]
-                },
-                12
-              ]
-            }
-          },
-          {
-            "name": "negativeBinArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state for start_bin_index is negative"
-            ],
-            "type": {
-              "array": [
-                {
-                  "array": [
-                    "u64",
-                    8
-                  ]
-                },
-                12
-              ]
-            }
-          }
-        ]
-      }
+      "name": "BinArray",
+      "discriminator": [92, 142, 92, 220, 5, 148, 70, 181]
     },
     {
-      "name": "BinArray",
-      "docs": [
-        "An account to contain a range of bin. For example: Bin 100 <-> 200.",
-        "For example:",
-        "BinArray index: 0 contains bin 0 <-> 599",
-        "index: 2 contains bin 600 <-> 1199, ..."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "index",
-            "type": "i64"
-          },
-          {
-            "name": "version",
-            "docs": [
-              "Version of binArray"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
-          },
-          {
-            "name": "lbPair",
-            "type": "publicKey"
-          },
-          {
-            "name": "bins",
-            "type": {
-              "array": [
-                {
-                  "defined": "Bin"
-                },
-                70
-              ]
-            }
-          }
-        ]
-      }
+      "name": "BinArrayBitmapExtension",
+      "discriminator": [80, 111, 124, 113, 55, 237, 18, 5]
     },
     {
       "name": "ClaimFeeOperator",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "operator",
-            "docs": [
-              "operator"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Reserve"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [166, 48, 134, 86, 34, 200, 188, 150]
+    },
+    {
+      "name": "DummyZcAccount",
+      "discriminator": [94, 107, 238, 80, 208, 48, 180, 8]
     },
     {
       "name": "LbPair",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "parameters",
-            "type": {
-              "defined": "StaticParameters"
-            }
-          },
-          {
-            "name": "vParameters",
-            "type": {
-              "defined": "VariableParameters"
-            }
-          },
-          {
-            "name": "bumpSeed",
-            "type": {
-              "array": [
-                "u8",
-                1
-              ]
-            }
-          },
-          {
-            "name": "binStepSeed",
-            "docs": [
-              "Bin step signer seed"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "pairType",
-            "docs": [
-              "Type of the pair"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "status",
-            "docs": [
-              "Status of the pair. Check PairStatus enum."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "requireBaseFactorSeed",
-            "docs": [
-              "Require base factor seed"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "baseFactorSeed",
-            "docs": [
-              "Base factor seed"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "creatorPoolOnOffControl",
-            "docs": [
-              "Allow pool creator to enable/disable pool with restricted validation. Only applicable for customizable permissionless pair type."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "tokenXMint",
-            "docs": [
-              "Token X mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenYMint",
-            "docs": [
-              "Token Y mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserveX",
-            "docs": [
-              "LB token X vault"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserveY",
-            "docs": [
-              "LB token Y vault"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "protocolFee",
-            "docs": [
-              "Uncollected protocol fee"
-            ],
-            "type": {
-              "defined": "ProtocolFee"
-            }
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "_padding_1, previous Fee owner, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "RewardInfo"
-                },
-                2
-              ]
-            }
-          },
-          {
-            "name": "oracle",
-            "docs": [
-              "Oracle pubkey"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "binArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                16
-              ]
-            }
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last time the pool fee parameter was updated"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "padding2",
-            "docs": [
-              "_padding_2, previous whitelisted_wallet, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "preActivationSwapAddress",
-            "docs": [
-              "Address allowed to swap when the current point is greater than or equal to the pre-activation point. The pre-activation point is calculated as `activation_point - pre_activation_duration`."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "baseKey",
-            "docs": [
-              "Base keypair. Only required for permission pair"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "activationPoint",
-            "docs": [
-              "Time point to enable the pair. Only applicable for permission pair."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "preActivationDuration",
-            "docs": [
-              "Duration before activation activation_point. Used to calculate pre-activation time point for pre_activation_swap_address"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding3",
-            "docs": [
-              "_padding 3 is reclaimed free space from swap_cap_deactivate_point and swap_cap_amount before, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          },
-          {
-            "name": "padding4",
-            "docs": [
-              "_padding_4, previous lock_duration, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "creator",
-            "docs": [
-              "Pool creator"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenMintXProgramFlag",
-            "docs": [
-              "token_mint_x_program_flag"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "tokenMintYProgramFlag",
-            "docs": [
-              "token_mint_y_program_flag"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                22
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [33, 11, 49, 98, 181, 101, 177, 13]
+    },
+    {
+      "name": "LimitOrder",
+      "discriminator": [137, 183, 212, 91, 115, 29, 141, 227]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [219, 31, 188, 145, 69, 139, 204, 117]
     },
     {
       "name": "Oracle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "idx",
-            "docs": [
-              "Index of latest observation"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeSize",
-            "docs": [
-              "Size of active sample. Active sample is initialized observation."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "length",
-            "docs": [
-              "Number of observations"
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "docs": [
-              "The LB pair of this position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner of the position. Client rely on this to to fetch their positions."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidityShares",
-            "docs": [
-              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
-            ],
-            "type": {
-              "array": [
-                "u64",
-                70
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "UserRewardInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "feeInfos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "FeeInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "lowerBinId",
-            "docs": [
-              "Lower bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "upperBinId",
-            "docs": [
-              "Upper bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last updated timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "totalClaimedFeeXAmount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedFeeYAmount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedRewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                160
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [139, 194, 131, 179, 140, 179, 229, 244]
     },
     {
       "name": "PositionV2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "docs": [
-              "The LB pair of this position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner of the position. Client rely on this to to fetch their positions."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidityShares",
-            "docs": [
-              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
-            ],
-            "type": {
-              "array": [
-                "u128",
-                70
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "UserRewardInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "feeInfos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "FeeInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "lowerBinId",
-            "docs": [
-              "Lower bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "upperBinId",
-            "docs": [
-              "Upper bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last updated timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "totalClaimedFeeXAmount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedFeeYAmount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedRewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          },
-          {
-            "name": "operator",
-            "docs": [
-              "Operator of position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "lockReleasePoint",
-            "docs": [
-              "Time point which the locked liquidity can be withdraw"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding0",
-            "docs": [
-              "_padding_0, previous subjected_to_bootstrap_liquidity_locking, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "feeOwner",
-            "docs": [
-              "Address is able to claim fee in this position, only valid for bootstrap_liquidity_position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                87
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PresetParameter2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "index",
-            "docs": [
-              "index"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding0",
-            "docs": [
-              "Padding 0 for future use"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "Padding 1 for future use"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                20
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [117, 176, 212, 199, 245, 180, 133, 182]
     },
     {
       "name": "PresetParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "minBinId",
-            "docs": [
-              "Min bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "Max bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
+      "discriminator": [242, 62, 244, 34, 181, 112, 58, 170]
+    },
+    {
+      "name": "PresetParameter2",
+      "discriminator": [171, 236, 148, 115, 162, 113, 222, 174]
     },
     {
       "name": "TokenBadge",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenMint",
-            "docs": [
-              "token mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Reserve"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "InitPresetParameters2Ix",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "index",
-            "type": "u16"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitPresetParametersIx",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BaseFeeParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Base factor for base fee rate"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "DynamicFeeParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByStrategyOneSide",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyParameters",
-            "docs": [
-              "strategy parameters"
-            ],
-            "type": {
-              "defined": "StrategyParameters"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByStrategy",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyParameters",
-            "docs": [
-              "strategy parameters"
-            ],
-            "type": {
-              "defined": "StrategyParameters"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "StrategyParameters",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "minBinId",
-            "docs": [
-              "min bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "max bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyType",
-            "docs": [
-              "strategy type"
-            ],
-            "type": {
-              "defined": "StrategyType"
-            }
-          },
-          {
-            "name": "parameteres",
-            "docs": [
-              "parameters"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityOneSideParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistributionByWeight"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityDistributionByWeight",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "weight",
-            "docs": [
-              "weight of liquidity distributed for this bin id"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByWeight",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistributionByWeight"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AddLiquiditySingleSidePreciseParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "bins",
-            "type": {
-              "vec": {
-                "defined": "CompressedBinDepositAmount"
-              }
-            }
-          },
-          {
-            "name": "decompressMultiplier",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CompressedBinDepositAmount",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "amount",
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityDistribution",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "distributionX",
-            "docs": [
-              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "distributionY",
-            "docs": [
-              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistribution"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "CustomizableParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "docs": [
-              "Pool price"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Base factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type. 0 = Slot, 1 = Time. Check ActivationType enum"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "hasAlphaVault",
-            "docs": [
-              "Whether the pool has an alpha vault"
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "activationPoint",
-            "docs": [
-              "Decide when does the pool start trade. None = Now"
-            ],
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
-            "name": "creatorPoolOnOffControl",
-            "docs": [
-              "Pool creator have permission to enable/disable pool with restricted program validation. Only applicable for customizable permissionless pool."
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                62
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitPermissionPairIx",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "type": "u8"
-          },
-          {
-            "name": "activationType",
-            "type": "u8"
-          },
-          {
-            "name": "protocolShare",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AddLiquiditySingleSidePreciseParameter2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "bins",
-            "type": {
-              "vec": {
-                "defined": "CompressedBinDepositAmount"
-              }
-            }
-          },
-          {
-            "name": "decompressMultiplier",
-            "type": "u64"
-          },
-          {
-            "name": "maxAmount",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CompressedBinDepositAmount2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "amount",
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitializeLbPair2Params",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "docs": [
-              "Pool price"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                96
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityReduction",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "bpsToRemove",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Bin",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of token X in the bin. This already excluded protocol fees."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of token Y in the bin. This already excluded protocol fees."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "price",
-            "docs": [
-              "Bin price"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "liquiditySupply",
-            "docs": [
-              "Liquidities of the bin. This is the same as LP mint supply. q-number"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "rewardPerTokenStored",
-            "docs": [
-              "reward_a_per_token_stored"
-            ],
-            "type": {
-              "array": [
-                "u128",
-                2
-              ]
-            }
-          },
-          {
-            "name": "feeAmountXPerTokenStored",
-            "docs": [
-              "Swap fee amount of token X per liquidity deposited."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "feeAmountYPerTokenStored",
-            "docs": [
-              "Swap fee amount of token Y per liquidity deposited."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "amountXIn",
-            "docs": [
-              "Total token X swap into the bin. Only used for tracking purpose."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "amountYIn",
-            "docs": [
-              "Total token Y swap into he bin. Only used for tracking purpose."
-            ],
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ProtocolFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RewardInfo",
-      "docs": [
-        "Stores the state relevant for tracking liquidity mining rewards"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mint",
-            "docs": [
-              "Reward token mint."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "vault",
-            "docs": [
-              "Reward vault token account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "funder",
-            "docs": [
-              "Authority account that allows to fund rewards"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardDuration",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "rewardDurationEnd",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "rewardRate",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "lastUpdateTime",
-            "docs": [
-              "The last time reward states were updated."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "cumulativeSecondsWithEmptyLiquidityReward",
-            "docs": [
-              "Accumulated seconds where when farm distribute rewards, but the bin is empty. The reward will be accumulated for next reward time window."
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Observation",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "cumulativeActiveBinId",
-            "docs": [
-              "Cumulative active bin ID"
-            ],
-            "type": "i128"
-          },
-          {
-            "name": "createdAt",
-            "docs": [
-              "Observation sample created timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Observation sample last updated timestamp"
-            ],
-            "type": "i64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "StaticParameters",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "minBinId",
-            "docs": [
-              "Min bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "Max bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                5
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "VariableParameters",
-      "docs": [
-        "Parameters that changes based on dynamic of the market"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "volatilityAccumulator",
-            "docs": [
-              "Volatility accumulator measure the number of bin crossed since reference bin ID. Normally (without filter period taken into consideration), reference bin ID is the active bin of last swap.",
-              "It affects the variable fee rate"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "volatilityReference",
-            "docs": [
-              "Volatility reference is decayed volatility accumulator. It is always <= volatility_accumulator"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "indexReference",
-            "docs": [
-              "Active bin id of last swap."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                4
-              ]
-            }
-          },
-          {
-            "name": "lastUpdateTimestamp",
-            "docs": [
-              "Last timestamp the variable parameters was updated"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeXPerTokenComplete",
-            "type": "u128"
-          },
-          {
-            "name": "feeYPerTokenComplete",
-            "type": "u128"
-          },
-          {
-            "name": "feeXPending",
-            "type": "u64"
-          },
-          {
-            "name": "feeYPending",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UserRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "rewardPerTokenCompletes",
-            "type": {
-              "array": [
-                "u128",
-                2
-              ]
-            }
-          },
-          {
-            "name": "rewardPendings",
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsSlice",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "accountsType",
-            "type": {
-              "defined": "AccountsType"
-            }
-          },
-          {
-            "name": "length",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slices",
-            "type": {
-              "vec": {
-                "defined": "RemainingAccountsSlice"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "StrategyType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "SpotOneSide"
-          },
-          {
-            "name": "CurveOneSide"
-          },
-          {
-            "name": "BidAskOneSide"
-          },
-          {
-            "name": "SpotBalanced"
-          },
-          {
-            "name": "CurveBalanced"
-          },
-          {
-            "name": "BidAskBalanced"
-          },
-          {
-            "name": "SpotImBalanced"
-          },
-          {
-            "name": "CurveImBalanced"
-          },
-          {
-            "name": "BidAskImBalanced"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Rounding",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Up"
-          },
-          {
-            "name": "Down"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ActivationType",
-      "docs": [
-        "Type of the activation"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Slot"
-          },
-          {
-            "name": "Timestamp"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LayoutVersion",
-      "docs": [
-        "Layout version"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V0"
-          },
-          {
-            "name": "V1"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PairType",
-      "docs": [
-        "Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permissionless"
-          },
-          {
-            "name": "Permission"
-          },
-          {
-            "name": "CustomizablePermissionless"
-          },
-          {
-            "name": "PermissionlessV2"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PairStatus",
-      "docs": [
-        "Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Enabled"
-          },
-          {
-            "name": "Disabled"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenProgramFlags",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TokenProgram"
-          },
-          {
-            "name": "TokenProgram2022"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AccountsType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TransferHookX"
-          },
-          {
-            "name": "TransferHookY"
-          },
-          {
-            "name": "TransferHookReward"
-          }
-        ]
-      }
+      "discriminator": [116, 219, 204, 229, 249, 116, 255, 150]
     }
   ],
   "events": [
     {
-      "name": "CompositionFee",
-      "fields": [
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "binId",
-          "type": "i16",
-          "index": false
-        },
-        {
-          "name": "tokenXFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenYFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTokenXFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTokenYFeeAmount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
       "name": "AddLiquidity",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amounts",
-          "type": {
-            "array": [
-              "u64",
-              2
-            ]
-          },
-          "index": false
-        },
-        {
-          "name": "activeBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
+      "discriminator": [31, 94, 125, 90, 227, 52, 61, 186]
     },
     {
-      "name": "RemoveLiquidity",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amounts",
-          "type": {
-            "array": [
-              "u64",
-              2
-            ]
-          },
-          "index": false
-        },
-        {
-          "name": "activeBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "Swap",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "startBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "endBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "amountIn",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amountOut",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "swapForY",
-          "type": "bool",
-          "index": false
-        },
-        {
-          "name": "fee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeBps",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "hostFee",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "ClaimReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "totalReward",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "FundReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "funder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "InitializeReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "funder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "rewardDuration",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdateRewardDuration",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldRewardDuration",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "newRewardDuration",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdateRewardFunder",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldFunder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newFunder",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "PositionClose",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "CancelLimitOrderEvt",
+      "discriminator": [131, 234, 194, 133, 9, 14, 189, 209]
     },
     {
       "name": "ClaimFee",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "feeX",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeY",
-          "type": "u64",
-          "index": false
-        }
-      ]
+      "discriminator": [75, 122, 154, 48, 140, 74, 123, 163]
     },
     {
-      "name": "LbPairCreate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "binStep",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "tokenX",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenY",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "ClaimFee2",
+      "discriminator": [232, 171, 242, 97, 58, 77, 35, 45]
     },
     {
-      "name": "PositionCreate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "ClaimReward",
+      "discriminator": [148, 116, 134, 204, 22, 171, 85, 95]
     },
     {
-      "name": "IncreasePositionLength",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "lengthToAdd",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "side",
-          "type": "u8",
-          "index": false
-        }
-      ]
+      "name": "ClaimReward2",
+      "discriminator": [27, 143, 244, 33, 80, 43, 110, 146]
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "discriminator": [142, 135, 8, 76, 92, 63, 118, 83]
+    },
+    {
+      "name": "CompositionFee",
+      "discriminator": [128, 151, 123, 106, 17, 102, 113, 142]
     },
     {
       "name": "DecreasePositionLength",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "lengthToRemove",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "side",
-          "type": "u8",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "FeeParameterUpdate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "protocolShare",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "baseFactor",
-          "type": "u16",
-          "index": false
-        }
-      ]
+      "discriminator": [52, 118, 235, 85, 172, 169, 15, 128]
     },
     {
       "name": "DynamicFeeParameterUpdate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "filterPeriod",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "variableFeeControl",
-          "type": "u32",
-          "index": false
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32",
-          "index": false
-        }
-      ]
+      "discriminator": [88, 88, 178, 135, 194, 146, 91, 243]
     },
     {
-      "name": "IncreaseObservation",
-      "fields": [
-        {
-          "name": "oracle",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newObservationLength",
-          "type": "u64",
-          "index": false
-        }
-      ]
+      "name": "FeeParameterUpdate",
+      "discriminator": [48, 76, 241, 117, 144, 215, 242, 44]
     },
     {
-      "name": "WithdrawIneligibleReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdatePositionOperator",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "oldOperator",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newOperator",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdatePositionLockReleasePoint",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "currentPoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "newLockReleasePoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldLockReleasePoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "sender",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "FundReward",
+      "discriminator": [246, 228, 58, 130, 145, 170, 79, 204]
     },
     {
       "name": "GoToABin",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "fromBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "toBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
+      "discriminator": [59, 138, 76, 68, 138, 131, 176, 67]
+    },
+    {
+      "name": "IncreaseObservation",
+      "discriminator": [99, 249, 17, 121, 166, 156, 207, 215]
+    },
+    {
+      "name": "IncreasePositionLength",
+      "discriminator": [157, 239, 42, 204, 30, 56, 223, 46]
+    },
+    {
+      "name": "InitializeReward",
+      "discriminator": [211, 153, 88, 62, 149, 60, 177, 70]
+    },
+    {
+      "name": "LbPairCreate",
+      "discriminator": [185, 74, 252, 125, 27, 215, 188, 111]
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "discriminator": [43, 79, 27, 169, 244, 28, 225, 63]
+    },
+    {
+      "name": "PositionClose",
+      "discriminator": [255, 196, 16, 107, 28, 202, 53, 128]
+    },
+    {
+      "name": "PositionCreate",
+      "discriminator": [144, 142, 252, 84, 157, 53, 37, 121]
+    },
+    {
+      "name": "Rebalancing",
+      "discriminator": [0, 109, 117, 179, 61, 91, 199, 200]
+    },
+    {
+      "name": "RemoveLiquidity",
+      "discriminator": [116, 244, 97, 232, 103, 31, 152, 58]
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "discriminator": [195, 229, 147, 245, 29, 125, 48, 168]
+    },
+    {
+      "name": "Swap",
+      "discriminator": [81, 108, 227, 190, 205, 208, 10, 196]
+    },
+    {
+      "name": "Swap2Evt",
+      "discriminator": [46, 116, 82, 215, 148, 27, 84, 77]
+    },
+    {
+      "name": "UpdatePositionLockReleasePoint",
+      "discriminator": [133, 214, 66, 224, 64, 12, 7, 191]
+    },
+    {
+      "name": "UpdatePositionOperator",
+      "discriminator": [39, 115, 48, 204, 246, 47, 66, 57]
+    },
+    {
+      "name": "UpdateRewardDuration",
+      "discriminator": [223, 245, 224, 153, 49, 29, 163, 172]
+    },
+    {
+      "name": "UpdateRewardFunder",
+      "discriminator": [224, 178, 174, 74, 252, 165, 85, 180]
+    },
+    {
+      "name": "WithdrawIneligibleReward",
+      "discriminator": [231, 189, 65, 149, 102, 215, 154, 244]
     }
   ],
   "errors": [
@@ -7364,6 +5633,3599 @@
       "code": 6082,
       "name": "NotSupportAtTheMoment",
       "msg": "Not support at the moment"
+    },
+    {
+      "code": 6083,
+      "name": "InvalidRebalanceParameters",
+      "msg": "Invalid rebalance parameters"
+    },
+    {
+      "code": 6084,
+      "name": "InvalidRewardAccounts",
+      "msg": "Invalid reward accounts"
+    },
+    {
+      "code": 6085,
+      "name": "UndeterminedError",
+      "msg": "Undetermined error"
+    },
+    {
+      "code": 6086,
+      "name": "ReallocExceedMaxLengthPerInstruction",
+      "msg": "Realloc exceed max length per instruction"
+    },
+    {
+      "code": 6087,
+      "name": "InvalidBaseFeeMantissa",
+      "msg": "Mantissa cannot more than two significant digits"
+    },
+    {
+      "code": 6088,
+      "name": "InvalidPositionOwner",
+      "msg": "Invalid position owner"
+    },
+    {
+      "code": 6089,
+      "name": "InvalidPoolAddress",
+      "msg": "Invalid pool address"
+    },
+    {
+      "code": 6090,
+      "name": "InvalidTokenBadgeType",
+      "msg": "Invalid token badge type"
+    },
+    {
+      "code": 6091,
+      "name": "InvalidTransferHookAuthority",
+      "msg": "Invalid transfer hook authority"
+    },
+    {
+      "code": 6092,
+      "name": "AmountXIsNegative",
+      "msg": "Amount x is negative"
+    },
+    {
+      "code": 6093,
+      "name": "AmountYIsNegative",
+      "msg": "Amount y is negative"
+    },
+    {
+      "code": 6094,
+      "name": "InvalidPoolCreator",
+      "msg": "Invalid pool creator"
+    },
+    {
+      "code": 6095,
+      "name": "InvalidFunctionType",
+      "msg": "Invalid function type"
+    },
+    {
+      "code": 6096,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6097,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6098,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6099,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6100,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6101,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6102,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6103,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6104,
+      "name": "InsufficientInAmount",
+      "msg": "Insufficient in amount"
+    },
+    {
+      "code": 6105,
+      "name": "InvalidPlaceLimitOrderParameters",
+      "msg": "Invalid place limit order parameters"
+    },
+    {
+      "code": 6106,
+      "name": "InvalidLimitOrderOwner",
+      "msg": "Invalid limit order owner"
+    },
+    {
+      "code": 6107,
+      "name": "InvalidCancelLimitOrderParameters",
+      "msg": "Invalid cancel limit order parameters"
+    },
+    {
+      "code": 6108,
+      "name": "CannotFindLimitOrderByBinId",
+      "msg": "Cannot find limit order by bin id"
+    },
+    {
+      "code": 6109,
+      "name": "CancelNonEmptyLimitOrder",
+      "msg": "Cannot cancel non-empty limit order"
+    },
+    {
+      "code": 6110,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccountsType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookX"
+          },
+          {
+            "name": "TransferHookY"
+          },
+          {
+            "name": "TransferHookReward"
+          },
+          {
+            "name": "TransferHookMultiReward",
+            "fields": ["u8"]
+          },
+          {
+            "name": "TransferHookReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ActivationType",
+      "docs": ["Type of the activation"],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Slot"
+          },
+          {
+            "name": "Timestamp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_delta_id",
+            "type": "i32"
+          },
+          {
+            "name": "max_delta_id",
+            "type": "i32"
+          },
+          {
+            "name": "x0",
+            "type": "u64"
+          },
+          {
+            "name": "y0",
+            "type": "u64"
+          },
+          {
+            "name": "delta_x",
+            "type": "u64"
+          },
+          {
+            "name": "delta_y",
+            "type": "u64"
+          },
+          {
+            "name": "bit_flag",
+            "type": "u8"
+          },
+          {
+            "name": "favor_x_in_active_id",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CompressedBinDepositAmount"
+                }
+              }
+            }
+          },
+          {
+            "name": "decompress_multiplier",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CompressedBinDepositAmount"
+                }
+              }
+            }
+          },
+          {
+            "name": "decompress_multiplier",
+            "type": "u64"
+          },
+          {
+            "name": "max_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": ["Base factor for base fee rate"],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bin",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": [
+              "Amount of token X in the bin for market making. This already excluded protocol fees."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": [
+              "Amount of token Y in the bin for market making. This already excluded protocol fees."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price",
+            "docs": ["Bin price"],
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_supply",
+            "docs": ["Bin MM liquidity supply."],
+            "type": "u128"
+          },
+          {
+            "name": "fulfilled_order_amount_x",
+            "docs": ["Total fulfilled order amount x"],
+            "type": "u64"
+          },
+          {
+            "name": "fulfilled_order_amount_y",
+            "docs": ["Total fulfilled order amount y"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_ask_side",
+            "docs": ["Limit order fee collected by ask side orders"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_bid_side",
+            "docs": ["Limit order fee collected by bid side orders"],
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount_x_per_token_stored",
+            "docs": ["Swap fee amount of token X per liquidity deposited."],
+            "type": "u128"
+          },
+          {
+            "name": "fee_amount_y_per_token_stored",
+            "docs": ["Swap fee amount of token Y per liquidity deposited."],
+            "type": "u128"
+          },
+          {
+            "name": "open_order_amount",
+            "docs": ["Pending open limit orders amount in the bin."],
+            "type": "u64"
+          },
+          {
+            "name": "total_processing_order_amount",
+            "docs": ["Total processing order amount"],
+            "type": "u64"
+          },
+          {
+            "name": "processed_order_remaining_amount",
+            "docs": [
+              "Remaining in processing open limit orders amount in the bin."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "order_age",
+            "docs": ["Age"],
+            "type": "u32"
+          },
+          {
+            "name": "limit_order_ask_side",
+            "docs": ["limit order flag"],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["padding"],
+            "type": {
+              "array": ["u8", 3]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinArray",
+      "docs": [
+        "An account to contain a range of bin. For example: Bin 100 <-> 200.",
+        "For example:",
+        "BinArray index: 0 contains bin 0 <-> 599",
+        "index: 2 contains bin 600 <-> 1199, ..."
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "i64"
+          },
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "bins",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Bin"
+                  }
+                },
+                70
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinArrayBitmapExtension",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "positive_bin_array_bitmap",
+            "docs": [
+              "Packed initialized bin array state for start_bin_index is positive"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 8]
+                },
+                12
+              ]
+            }
+          },
+          {
+            "name": "negative_bin_array_bitmap",
+            "docs": [
+              "Packed initialized bin array state for start_bin_index is negative"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 8]
+                },
+                12
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLimitOrderAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "i32"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityDistribution",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "docs": ["Define the bin ID wish to deposit to."],
+            "type": "i32"
+          },
+          {
+            "name": "distribution_x",
+            "docs": [
+              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "distribution_y",
+            "docs": [
+              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityDistributionByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "docs": ["Define the bin ID wish to deposit to."],
+            "type": "i32"
+          },
+          {
+            "name": "weight",
+            "docs": ["weight of liquidity distributed for this bin id"],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityReduction",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "bps_to_remove",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CancelLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": "i32"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_x",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_x",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y",
+            "type": "u64"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFeeOperator",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "docs": ["operator"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Reserve"],
+            "type": {
+              "array": ["u8", 128]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimReward2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CompositionFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_id",
+            "type": "i16"
+          },
+          {
+            "name": "token_x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_y_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_token_x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_token_y_fee_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CompressedBinDepositAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "amount",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Pool price"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step"],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": ["Base factor"],
+            "type": "u16"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type. 0 = Slot, 1 = Time. Check ActivationType enum"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": ["Whether the pool has an alpha vault"],
+            "type": "bool"
+          },
+          {
+            "name": "activation_point",
+            "docs": ["Decide when does the pool start trade. None = Now"],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "creator_pool_on_off_control",
+            "docs": [
+              "Pool creator have permission to enable/disable pool with restricted program validation. Only applicable for customizable permissionless pool."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": ["Concrete function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["Collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": ["Padding, for future use"],
+            "type": {
+              "array": ["u8", 60]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DecreasePositionLength",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "length_to_remove",
+            "type": "u16"
+          },
+          {
+            "name": "side",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DummyIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "_pair_status",
+            "type": {
+              "defined": {
+                "name": "PairStatus"
+              }
+            }
+          },
+          {
+            "name": "_pair_type",
+            "type": {
+              "defined": {
+                "name": "PairType"
+              }
+            }
+          },
+          {
+            "name": "_activation_type",
+            "type": {
+              "defined": {
+                "name": "ActivationType"
+              }
+            }
+          },
+          {
+            "name": "_token_program_flag",
+            "type": {
+              "defined": {
+                "name": "TokenProgramFlags"
+              }
+            }
+          },
+          {
+            "name": "_resize_side",
+            "type": {
+              "defined": {
+                "name": "ResizeSide"
+              }
+            }
+          },
+          {
+            "name": "_rounding",
+            "type": {
+              "defined": {
+                "name": "Rounding"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DummyZcAccount",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_bin_data",
+            "type": {
+              "defined": {
+                "name": "PositionBinData"
+              }
+            }
+          },
+          {
+            "name": "limit_order_bin_data",
+            "type": {
+              "defined": {
+                "name": "LimitOrderBinData"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameterUpdate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_x_per_token_complete",
+            "type": "u128"
+          },
+          {
+            "name": "fee_y_per_token_complete",
+            "type": "u128"
+          },
+          {
+            "name": "fee_x_pending",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y_pending",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeParameterUpdate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_share",
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FundReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GoToABin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "to_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreaseObservation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_observation_length",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreasePositionLength",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "length_to_add",
+            "type": "u16"
+          },
+          {
+            "name": "side",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPermissionPairIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": "u16"
+          },
+          {
+            "name": "concrete_function_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPresetParametersIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": ["function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["collect fee mode"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeLbPair2Params",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Pool price"],
+            "type": "i32"
+          },
+          {
+            "name": "padding",
+            "docs": ["Padding, for future use"],
+            "type": {
+              "array": ["u8", 96]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LbPair",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "parameters",
+            "type": {
+              "defined": {
+                "name": "StaticParameters"
+              }
+            }
+          },
+          {
+            "name": "v_parameters",
+            "type": {
+              "defined": {
+                "name": "VariableParameters"
+              }
+            }
+          },
+          {
+            "name": "bump_seed",
+            "type": {
+              "array": ["u8", 1]
+            }
+          },
+          {
+            "name": "bin_step_seed",
+            "docs": ["Bin step signer seed"],
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "pair_type",
+            "docs": ["Type of the pair"],
+            "type": "u8"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": ["Status of the pair. Check PairStatus enum."],
+            "type": "u8"
+          },
+          {
+            "name": "require_base_factor_seed",
+            "docs": ["Require base factor seed"],
+            "type": "u8"
+          },
+          {
+            "name": "base_factor_seed",
+            "docs": ["Base factor seed"],
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "activation_type",
+            "docs": ["Activation type"],
+            "type": "u8"
+          },
+          {
+            "name": "creator_pool_on_off_control",
+            "docs": [
+              "Allow pool creator to enable/disable pool with restricted validation. Only applicable for customizable permissionless pair type."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_x_mint",
+            "docs": ["Token X mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_y_mint",
+            "docs": ["Token Y mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserve_x",
+            "docs": ["LB token X vault"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserve_y",
+            "docs": ["LB token Y vault"],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee",
+            "docs": ["Uncollected protocol fee"],
+            "type": {
+              "defined": {
+                "name": "ProtocolFee"
+              }
+            }
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["padding 1"],
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "reward_infos",
+            "docs": ["Farming reward information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RewardInfo"
+                  }
+                },
+                2
+              ]
+            }
+          },
+          {
+            "name": "oracle",
+            "docs": ["Oracle pubkey"],
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_array_bitmap",
+            "docs": ["Packed initialized bin array state"],
+            "type": {
+              "array": ["u64", 16]
+            }
+          },
+          {
+            "name": "last_updated_at",
+            "docs": ["Last time the pool fee parameter was updated"],
+            "type": "i64"
+          },
+          {
+            "name": "_padding_2",
+            "docs": ["_padding_2"],
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "pre_activation_swap_address",
+            "docs": [
+              "Address allowed to swap when the current point is greater than or equal to the pre-activation point. The pre-activation point is calculated as `activation_point - pre_activation_duration`."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_key",
+            "docs": ["Base keypair. Only required for permission pair"],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "Time point to enable the pair. Only applicable for permission pair."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pre_activation_duration",
+            "docs": [
+              "Duration before activation activation_point. Used to calculate pre-activation time point for pre_activation_swap_address"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_3",
+            "docs": ["_padding 3"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "_padding_4",
+            "docs": ["_padding_4"],
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "docs": ["Pool creator"],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint_x_program_flag",
+            "docs": ["token_mint_x_program_flag"],
+            "type": "u8"
+          },
+          {
+            "name": "token_mint_y_program_flag",
+            "docs": ["token_mint_y_program_flag"],
+            "type": "u8"
+          },
+          {
+            "name": "version",
+            "docs": ["version to know whether we have reset tombstone fields"],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u8", 21]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LbPairCreate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "token_x",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_y",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrder",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "docs": ["The LB pair of this LO"],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the LO. Client rely on this to to fetch their LOs."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_count",
+            "docs": ["Bin count"],
+            "type": "u16"
+          },
+          {
+            "name": "_padding_0",
+            "docs": ["Padding"],
+            "type": {
+              "array": ["u8", 14]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u64", 4]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrderBinData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "age",
+            "type": "u32"
+          },
+          {
+            "name": "_padding_0",
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "is_ask",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": ["u8", 11]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityOneSideParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": ["Amount of X token or Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistributionByWeight"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistribution"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategy",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_parameters",
+            "docs": ["strategy parameters"],
+            "type": {
+              "defined": {
+                "name": "StrategyParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategyOneSide",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": ["Amount of X token or Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_parameters",
+            "docs": ["strategy parameters"],
+            "type": {
+              "defined": {
+                "name": "StrategyParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistributionByWeight"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signer",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Oracle",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "idx",
+            "docs": ["Index of latest observation"],
+            "type": "u64"
+          },
+          {
+            "name": "active_size",
+            "docs": [
+              "Size of active sample. Active sample is initialized observation."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "length",
+            "docs": ["Number of observations"],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairStatus",
+      "docs": [
+        "Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility."
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Enabled"
+          },
+          {
+            "name": "Disabled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairType",
+      "docs": [
+        "Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility."
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Permissionless"
+          },
+          {
+            "name": "Permission"
+          },
+          {
+            "name": "CustomizablePermissionless"
+          },
+          {
+            "name": "PermissionlessV2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "sender",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "PlaceLimitOrderParams"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceLimitOrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_ask_side",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "relative_bin",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RelativeBin"
+                }
+              }
+            }
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLimitOrderAmount"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionBinData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidity_share",
+            "type": "u128"
+          },
+          {
+            "name": "reward_info",
+            "type": {
+              "defined": {
+                "name": "UserRewardInfo"
+              }
+            }
+          },
+          {
+            "name": "fee_info",
+            "type": {
+              "defined": {
+                "name": "FeeInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionClose",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionCreate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionV2",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "docs": ["The LB pair of this position"],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the position. Client rely on this to to fetch their positions."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_shares",
+            "docs": [
+              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
+            ],
+            "type": {
+              "array": ["u128", 70]
+            }
+          },
+          {
+            "name": "reward_infos",
+            "docs": ["Farming reward information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "UserRewardInfo"
+                  }
+                },
+                70
+              ]
+            }
+          },
+          {
+            "name": "fee_infos",
+            "docs": ["Swap fee to claim information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "FeeInfo"
+                  }
+                },
+                70
+              ]
+            }
+          },
+          {
+            "name": "lower_bin_id",
+            "docs": ["Lower bin ID"],
+            "type": "i32"
+          },
+          {
+            "name": "upper_bin_id",
+            "docs": ["Upper bin ID"],
+            "type": "i32"
+          },
+          {
+            "name": "last_updated_at",
+            "docs": ["Last updated timestamp"],
+            "type": "i64"
+          },
+          {
+            "name": "total_claimed_fee_x_amount",
+            "docs": ["Total claimed token fee X"],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_fee_y_amount",
+            "docs": ["Total claimed token fee Y"],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_rewards",
+            "docs": ["Total claimed rewards"],
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "operator",
+            "docs": ["Operator of position"],
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_release_point",
+            "docs": ["Time point which the locked liquidity can be withdraw"],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "_padding_0, previous subjected_to_bootstrap_liquidity_locking, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fee_owner",
+            "docs": [
+              "Address is able to claim fee in this position, only valid for bootstrap_liquidity_position"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "version",
+            "docs": ["version to know whether we have reset tombstone fields"],
+            "type": "u8"
+          },
+          {
+            "name": "permissionless_operation_bits",
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u8", 85]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PresetParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "min_bin_id",
+            "docs": [
+              "Min bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": [
+              "Max bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PresetParameter2",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "index",
+            "docs": ["index"],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": [
+              "function type, to check whether the pool should have LM farming or other functions in the future, refer ConcreteFunctionType"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": ["Padding 1 for future use"],
+            "type": {
+              "array": ["u64", 19]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolFee",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RebalanceLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["active id"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "u16"
+          },
+          {
+            "name": "should_claim_fee",
+            "docs": ["a flag to indicate that whether fee should be harvested"],
+            "type": "bool"
+          },
+          {
+            "name": "should_claim_reward",
+            "docs": [
+              "a flag to indicate that whether rewards should be harvested"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "min_withdraw_x_amount",
+            "docs": ["threshold for withdraw token x"],
+            "type": "u64"
+          },
+          {
+            "name": "max_deposit_x_amount",
+            "docs": ["threshold for deposit token x"],
+            "type": "u64"
+          },
+          {
+            "name": "min_withdraw_y_amount",
+            "docs": ["threshold for withdraw token y"],
+            "type": "u64"
+          },
+          {
+            "name": "max_deposit_y_amount",
+            "docs": ["threshold for deposit token y"],
+            "type": "u64"
+          },
+          {
+            "name": "shrink_mode",
+            "docs": ["shrink mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": ["padding 32 bytes for future usage"],
+            "type": {
+              "array": ["u8", 31]
+            }
+          },
+          {
+            "name": "removes",
+            "docs": ["removes"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemoveLiquidityParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "adds",
+            "docs": ["adds"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "AddLiquidityParams"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rebalancing",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "x_withdrawn_amount",
+            "type": "u64"
+          },
+          {
+            "name": "x_added_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_withdrawn_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_added_amount",
+            "type": "u64"
+          },
+          {
+            "name": "x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "old_min_id",
+            "type": "i32"
+          },
+          {
+            "name": "old_max_id",
+            "type": "i32"
+          },
+          {
+            "name": "new_min_id",
+            "type": "i32"
+          },
+          {
+            "name": "new_max_id",
+            "type": "i32"
+          },
+          {
+            "name": "rewards",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RelativeBin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": {
+              "defined": {
+                "name": "AccountsType"
+              }
+            }
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_bin_id",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "max_bin_id",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "bps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ResizeSide",
+      "docs": ["Side of resize, 0 for lower and 1 for upper"],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Lower"
+          },
+          {
+            "name": "Upper"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardInfo",
+      "docs": [
+        "Stores the state relevant for tracking liquidity mining rewards"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": ["Reward token mint."],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": ["Reward vault token account."],
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "docs": ["Authority account that allows to fund rewards"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_duration",
+            "docs": ["LM reward duration in seconds."],
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration_end",
+            "docs": ["LM reward duration end time."],
+            "type": "u64"
+          },
+          {
+            "name": "reward_rate",
+            "docs": ["LM reward rate"],
+            "type": "u128"
+          },
+          {
+            "name": "last_update_time",
+            "docs": ["The last time reward states were updated."],
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_seconds_with_empty_liquidity_reward",
+            "docs": [
+              "Accumulated seconds where when farm distribute rewards, but the bin is empty. The reward will be accumulated for next reward time window."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rounding",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Up"
+          },
+          {
+            "name": "Down"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_bits",
+            "type": "u8"
+          },
+          {
+            "name": "new_bits",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StaticParameters",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "min_bin_id",
+            "docs": [
+              "Min bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": [
+              "Max bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "function_type",
+            "docs": ["function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["Collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 3]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_bin_id",
+            "docs": ["min bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": ["max bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_type",
+            "docs": ["strategy type"],
+            "type": {
+              "defined": {
+                "name": "StrategyType"
+              }
+            }
+          },
+          {
+            "name": "parameteres",
+            "docs": ["parameters"],
+            "type": {
+              "array": ["u8", 64]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SpotOneSide"
+          },
+          {
+            "name": "CurveOneSide"
+          },
+          {
+            "name": "BidAskOneSide"
+          },
+          {
+            "name": "SpotBalanced"
+          },
+          {
+            "name": "CurveBalanced"
+          },
+          {
+            "name": "BidAskBalanced"
+          },
+          {
+            "name": "SpotImBalanced"
+          },
+          {
+            "name": "CurveImBalanced"
+          },
+          {
+            "name": "BidAskImBalanced"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "end_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "swap_for_y",
+            "type": "bool"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "fee_bps",
+            "type": "u128"
+          },
+          {
+            "name": "host_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap2Evt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "end_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "swap_for_y",
+            "type": "bool"
+          },
+          {
+            "name": "fee_bps",
+            "type": "u128"
+          },
+          {
+            "name": "amount_in",
+            "docs": ["Total amount, user transfer out"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "docs": ["Leftover amount"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "docs": ["Total amount transfer to user, including transfer fee"],
+            "type": "u64"
+          },
+          {
+            "name": "mm_fee",
+            "docs": ["Market maker fee"],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "docs": ["Total protocol fee"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee",
+            "docs": ["Total limit order fee"],
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "docs": ["Total host fee"],
+            "type": "u64"
+          },
+          {
+            "name": "fees_on_input",
+            "docs": ["check if fees on input"],
+            "type": "bool"
+          },
+          {
+            "name": "fees_on_token_x",
+            "docs": ["check if fees is on token x"],
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenBadge",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint",
+            "docs": ["token mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Reserve"],
+            "type": {
+              "array": ["u8", 128]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenProgramFlags",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenProgram"
+          },
+          {
+            "name": "TokenProgram2022"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdatePositionLockReleasePoint",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_point",
+            "type": "u64"
+          },
+          {
+            "name": "new_lock_release_point",
+            "type": "u64"
+          },
+          {
+            "name": "old_lock_release_point",
+            "type": "u64"
+          },
+          {
+            "name": "sender",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdatePositionOperator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateRewardDuration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "old_reward_duration",
+            "type": "u64"
+          },
+          {
+            "name": "new_reward_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateRewardFunder",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "old_funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_funder",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserRewardInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reward_per_token_completes",
+            "type": {
+              "array": ["u128", 2]
+            }
+          },
+          {
+            "name": "reward_pendings",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VariableParameters",
+      "docs": ["Parameters that changes based on dynamic of the market"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "volatility_accumulator",
+            "docs": [
+              "Volatility accumulator measure the number of bin crossed since reference bin ID. Normally (without filter period taken into consideration), reference bin ID is the active bin of last swap.",
+              "It affects the variable fee rate"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "volatility_reference",
+            "docs": [
+              "Volatility reference is decayed volatility accumulator. It is always <= volatility_accumulator"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "index_reference",
+            "docs": ["Active bin id of last swap."],
+            "type": "i32"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "last_update_timestamp",
+            "docs": ["Last timestamp the variable parameters was updated"],
+            "type": "i64"
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawIneligibleReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "BASIS_POINT_MAX",
+      "type": "u16",
+      "value": "10000"
+    },
+    {
+      "name": "BIN_ARRAY",
+      "type": "bytes",
+      "value": "[98, 105, 110, 95, 97, 114, 114, 97, 121]"
+    },
+    {
+      "name": "BIN_ARRAY_BITMAP_SEED",
+      "type": "bytes",
+      "value": "[98, 105, 116, 109, 97, 112]"
+    },
+    {
+      "name": "BIN_ARRAY_BITMAP_SIZE",
+      "type": "i32",
+      "value": "512"
+    },
+    {
+      "name": "CLAIM_PROTOCOL_FEE_OPERATOR",
+      "type": "bytes",
+      "value": "[99, 102, 95, 111, 112, 101, 114, 97, 116, 111, 114]"
+    },
+    {
+      "name": "DEFAULT_BIN_PER_POSITION",
+      "type": "u64",
+      "value": "70"
+    },
+    {
+      "name": "EXTENSION_BINARRAY_BITMAP_SIZE",
+      "type": "u64",
+      "value": "12"
+    },
+    {
+      "name": "FEE_DENOMINATOR",
+      "type": "u64",
+      "value": "1000000000"
+    },
+    {
+      "name": "HOST_FEE_BPS",
+      "docs": ["Host fee. 20%"],
+      "type": "u16",
+      "value": "2000"
+    },
+    {
+      "name": "ILM_PROTOCOL_SHARE",
+      "type": "u16",
+      "value": "2000"
+    },
+    {
+      "name": "LIMIT_ORDER_FEE_SHARE",
+      "type": "u16",
+      "value": "5000"
+    },
+    {
+      "name": "MAX_BASE_FEE",
+      "docs": ["Maximum base fee, base_fee / 10^9 = fee_in_percentage"],
+      "type": "u128",
+      "value": "100000000"
+    },
+    {
+      "name": "MAX_BIN_ID_PER_BIN_STEP",
+      "docs": [
+        "Maximum bin ID per bin step. Computed based on 1 bps. Used for bin id bound estimation."
+      ],
+      "type": "i32",
+      "value": "351639"
+    },
+    {
+      "name": "MAX_BIN_PER_ARRAY",
+      "type": "u64",
+      "value": "70"
+    },
+    {
+      "name": "MAX_BIN_PER_LIMIT_ORDER",
+      "type": "u64",
+      "value": "50"
+    },
+    {
+      "name": "MAX_BIN_STEP",
+      "docs": ["Maximum bin step"],
+      "type": "u16",
+      "value": "400"
+    },
+    {
+      "name": "MAX_FEE_RATE",
+      "docs": ["Maximum fee rate. 10%"],
+      "type": "u64",
+      "value": "100000000"
+    },
+    {
+      "name": "MAX_PROTOCOL_SHARE",
+      "docs": ["Maximum protocol share of the fee. 25%"],
+      "type": "u16",
+      "value": "2500"
+    },
+    {
+      "name": "MAX_RESIZE_LENGTH",
+      "type": "u64",
+      "value": "91"
+    },
+    {
+      "name": "MAX_REWARD_BIN_SPLIT",
+      "type": "u64",
+      "value": "15"
+    },
+    {
+      "name": "MAX_REWARD_DURATION",
+      "type": "u64",
+      "value": "31536000"
+    },
+    {
+      "name": "MINIMUM_LIQUIDITY",
+      "type": "u128",
+      "value": "1000000"
+    },
+    {
+      "name": "MIN_BASE_FEE",
+      "docs": ["Minimum base fee"],
+      "type": "u128",
+      "value": "100000"
+    },
+    {
+      "name": "MIN_REWARD_DURATION",
+      "type": "u64",
+      "value": "1"
+    },
+    {
+      "name": "NUM_REWARDS",
+      "type": "u64",
+      "value": "2"
+    },
+    {
+      "name": "OPERATOR_PREFIX",
+      "type": "bytes",
+      "value": "[111, 112, 101, 114, 97, 116, 111, 114]"
+    },
+    {
+      "name": "ORACLE",
+      "type": "bytes",
+      "value": "[111, 114, 97, 99, 108, 101]"
+    },
+    {
+      "name": "POSITION",
+      "type": "bytes",
+      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
+    },
+    {
+      "name": "POSITION_MAX_LENGTH",
+      "type": "u64",
+      "value": "1400"
+    },
+    {
+      "name": "PRESET_PARAMETER",
+      "type": "bytes",
+      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114]"
+    },
+    {
+      "name": "PRESET_PARAMETER2",
+      "type": "bytes",
+      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 50]"
+    },
+    {
+      "name": "PROTOCOL_SHARE",
+      "type": "u16",
+      "value": "500"
     }
   ]
 }

--- a/idls/meteora_dynamic_bonding_curve.json
+++ b/idls/meteora_dynamic_bonding_curve.json
@@ -1,0 +1,6964 @@
+{
+  "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN",
+  "metadata": {
+    "name": "dynamic_bonding_curve",
+    "version": "0.2.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "claim_creator_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        82,
+        220,
+        250,
+        189,
+        3,
+        85,
+        107,
+        45
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_creator_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        238,
+        247,
+        213,
+        94,
+        110,
+        145,
+        88,
+        142
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_partner_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        250,
+        238,
+        26,
+        4,
+        139,
+        10,
+        101,
+        248
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "fee_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        165,
+        228,
+        133,
+        48,
+        99,
+        249,
+        255,
+        33
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "token_base_account",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint"
+        },
+        {
+          "name": "quote_mint"
+        },
+        {
+          "name": "token_base_program"
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        114,
+        205,
+        83,
+        188,
+        240,
+        153,
+        25,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "treasury",
+          "writable": true,
+          "address": "6aYhxiNGmG8AyU25rh2R7iFu4pBrqnQHpNUGhmsEXRcm"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        8,
+        236,
+        89,
+        49,
+        152,
+        125,
+        177,
+        81
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        84,
+        191,
+        71,
+        50,
+        9,
+        162,
+        55,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_claim_protocol_fee_operator",
+      "discriminator": [
+        8,
+        41,
+        87,
+        35,
+        80,
+        48,
+        121,
+        26
+      ],
+      "accounts": [
+        {
+          "name": "claim_fee_operator",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_operator_account",
+      "discriminator": [
+        171,
+        9,
+        213,
+        74,
+        120,
+        23,
+        3,
+        29
+      ],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_config",
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer"
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "quote mint"
+          ]
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_config_with_transfer_hook",
+      "discriminator": [
+        216,
+        37,
+        1,
+        57,
+        88,
+        226,
+        25,
+        41
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer"
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "quote mint"
+          ]
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_locker",
+      "docs": [
+        "PERMISSIONLESS FUNCTIONS ///",
+        "create locker",
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        167,
+        90,
+        137,
+        154,
+        75,
+        47,
+        17,
+        84
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "writable": true
+        },
+        {
+          "name": "base",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  97,
+                  115,
+                  101,
+                  95,
+                  108,
+                  111,
+                  99,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "escrow",
+          "writable": true
+        },
+        {
+          "name": "escrow_token",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "locker_program",
+          "address": "LocpQgucEQHbqNABEYvBvwoxCPsSbG91A1QaQhQQqjn"
+        },
+        {
+          "name": "locker_event_authority"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_operator_account",
+      "discriminator": [
+        221,
+        64,
+        246,
+        149,
+        240,
+        153,
+        229,
+        163
+      ],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_address"
+              }
+            ]
+          }
+        },
+        {
+          "name": "whitelisted_address"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "create_partner_metadata",
+      "docs": [
+        "PARTNER FUNCTIONS ///"
+      ],
+      "discriminator": [
+        192,
+        168,
+        234,
+        191,
+        188,
+        226,
+        227,
+        255
+      ],
+      "accounts": [
+        {
+          "name": "partner_metadata",
+          "docs": [
+            "Partner metadata"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  97,
+                  114,
+                  116,
+                  110,
+                  101,
+                  114,
+                  95,
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "fee_claimer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Payer of the partner metadata."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer",
+          "docs": [
+            "Fee claimer for partner"
+          ],
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata",
+          "type": {
+            "defined": {
+              "name": "CreatePartnerMetadataParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_virtual_pool_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        45,
+        97,
+        187,
+        103,
+        254,
+        109,
+        124,
+        134
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "virtual_pool_metadata",
+          "docs": [
+            "Virtual pool metadata"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  105,
+                  114,
+                  116,
+                  117,
+                  97,
+                  108,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Payer of the virtual pool metadata."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata",
+          "type": {
+            "defined": {
+              "name": "CreateVirtualPoolMetadataParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "creator_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        165,
+        3,
+        137,
+        7,
+        28,
+        134,
+        76,
+        80
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_virtual_pool_with_spl_token",
+      "docs": [
+        "POOL CREATOR FUNCTIONS ////",
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        140,
+        85,
+        215,
+        176,
+        102,
+        54,
+        104,
+        79
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "Token a vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_virtual_pool_with_token2022",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        169,
+        118,
+        51,
+        78,
+        145,
+        110,
+        220,
+        155
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "Token quote vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token program for base mint"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_virtual_pool_with_token2022_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        182,
+        13,
+        233,
+        177,
+        42,
+        145,
+        135,
+        2
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Transfer hook config — contains the transfer hook program set by partner"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "migrate_meteora_damm",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        27,
+        1,
+        48,
+        22,
+        180,
+        63,
+        118,
+        217
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "docs": [
+            "virtual pool"
+          ],
+          "writable": true,
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "writable": true
+        },
+        {
+          "name": "config",
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "damm_config",
+          "docs": [
+            "pool config"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "writable": true
+        },
+        {
+          "name": "token_b_mint"
+        },
+        {
+          "name": "a_vault",
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "quote_vault",
+          "writable": true,
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "virtual_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "amm_program",
+          "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB"
+        },
+        {
+          "name": "vault_program"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_meteora_damm_claim_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        139,
+        133,
+        2,
+        30,
+        91,
+        145,
+        127,
+        154
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "docs": [
+            "migration metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "lp_mint",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "source_token",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pool_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "destination_token",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_meteora_damm_lock_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        177,
+        55,
+        238,
+        157,
+        251,
+        88,
+        165,
+        42
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "docs": [
+            "migration_metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "lock_escrow"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "lock_escrow",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "relations": [
+            "lock_escrow"
+          ]
+        },
+        {
+          "name": "source_tokens",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pool_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "escrow_vault",
+          "writable": true
+        },
+        {
+          "name": "amm_program",
+          "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB"
+        },
+        {
+          "name": "a_vault"
+        },
+        {
+          "name": "b_vault"
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "b_vault_lp"
+        },
+        {
+          "name": "a_vault_lp_mint"
+        },
+        {
+          "name": "b_vault_lp_mint"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_damm_v2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        156,
+        169,
+        230,
+        103,
+        53,
+        228,
+        80,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "migration_metadata"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "first_position_nft_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "first_position_nft_account",
+          "writable": true
+        },
+        {
+          "name": "first_position",
+          "writable": true
+        },
+        {
+          "name": "second_position_nft_mint",
+          "writable": true,
+          "signer": true,
+          "optional": true
+        },
+        {
+          "name": "second_position_nft_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "second_position",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "damm_pool_authority"
+        },
+        {
+          "name": "amm_program",
+          "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG"
+        },
+        {
+          "name": "base_mint",
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "writable": true
+        },
+        {
+          "name": "token_a_vault",
+          "writable": true
+        },
+        {
+          "name": "token_b_vault",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_base_program"
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "damm_event_authority"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_damm_v2_create_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        109,
+        189,
+        19,
+        36,
+        195,
+        183,
+        222,
+        82
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "migration_metadata"
+        },
+        {
+          "name": "payer"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_meteora_damm_create_metadata",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        47,
+        94,
+        126,
+        115,
+        221,
+        226,
+        194,
+        133
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  101,
+                  111,
+                  114,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "partner_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        168,
+        173,
+        72,
+        100,
+        201,
+        98,
+        38,
+        92
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "swap",
+      "docs": [
+        "TRADING BOTS FUNCTIONS ////",
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "swap2",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        65,
+        75,
+        63,
+        76,
+        235,
+        91,
+        91,
+        136
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "swap2_with_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        183,
+        93,
+        153,
+        40,
+        24,
+        230,
+        194,
+        151
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token",
+            "must be mutable so we can revoke the transfer hook after the last swap is performed"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "transfer_pool_creator",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        20,
+        7,
+        169,
+        33,
+        58,
+        147,
+        166,
+        33
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "new_creator"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdraw_leftover",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        20,
+        198,
+        202,
+        237,
+        235,
+        243,
+        183,
+        66
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_base_account",
+          "docs": [
+            "The receiver token account, withdraw to ATA"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "leftover_receiver"
+              },
+              {
+                "kind": "account",
+                "path": "token_base_program"
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdraw_migration_fee",
+      "docs": [
+        "BOTH partner and creator FUNCTIONS ///",
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        237,
+        142,
+        45,
+        23,
+        129,
+        6,
+        222,
+        162
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "flag",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        213,
+        155,
+        187,
+        34,
+        56,
+        182,
+        91,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_vault",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "zap claim fee operator"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ]
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ClaimFeeOperator",
+      "discriminator": [
+        166,
+        48,
+        134,
+        86,
+        34,
+        200,
+        188,
+        150
+      ]
+    },
+    {
+      "name": "ConfigWithTransferHook",
+      "discriminator": [
+        40,
+        220,
+        194,
+        251,
+        41,
+        199,
+        123,
+        253
+      ]
+    },
+    {
+      "name": "MeteoraDammMigrationMetadata",
+      "discriminator": [
+        17,
+        155,
+        141,
+        215,
+        207,
+        4,
+        133,
+        156
+      ]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [
+        219,
+        31,
+        188,
+        145,
+        69,
+        139,
+        204,
+        117
+      ]
+    },
+    {
+      "name": "PartnerMetadata",
+      "discriminator": [
+        68,
+        68,
+        130,
+        19,
+        16,
+        209,
+        98,
+        156
+      ]
+    },
+    {
+      "name": "PoolConfig",
+      "discriminator": [
+        26,
+        108,
+        14,
+        123,
+        116,
+        230,
+        129,
+        43
+      ]
+    },
+    {
+      "name": "TransferHookPool",
+      "discriminator": [
+        237,
+        219,
+        184,
+        23,
+        42,
+        189,
+        169,
+        35
+      ]
+    },
+    {
+      "name": "VirtualPool",
+      "discriminator": [
+        213,
+        224,
+        5,
+        209,
+        98,
+        69,
+        119,
+        92
+      ]
+    },
+    {
+      "name": "VirtualPoolMetadata",
+      "discriminator": [
+        217,
+        37,
+        82,
+        250,
+        43,
+        47,
+        228,
+        254
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "EvtClaimCreatorTradingFee",
+      "discriminator": [
+        154,
+        228,
+        215,
+        202,
+        133,
+        155,
+        214,
+        138
+      ]
+    },
+    {
+      "name": "EvtClaimPoolCreationFee",
+      "discriminator": [
+        149,
+        111,
+        149,
+        44,
+        136,
+        64,
+        175,
+        62
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "discriminator": [
+        186,
+        244,
+        75,
+        251,
+        188,
+        13,
+        25,
+        33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
+      ]
+    },
+    {
+      "name": "EvtClaimTradingFee",
+      "discriminator": [
+        26,
+        83,
+        117,
+        240,
+        92,
+        202,
+        112,
+        254
+      ]
+    },
+    {
+      "name": "EvtCloseClaimFeeOperator",
+      "discriminator": [
+        111,
+        39,
+        37,
+        55,
+        110,
+        216,
+        194,
+        23
+      ]
+    },
+    {
+      "name": "EvtCreateClaimFeeOperator",
+      "discriminator": [
+        21,
+        6,
+        153,
+        120,
+        68,
+        116,
+        28,
+        177
+      ]
+    },
+    {
+      "name": "EvtCreateConfig",
+      "discriminator": [
+        131,
+        207,
+        180,
+        174,
+        180,
+        73,
+        165,
+        54
+      ]
+    },
+    {
+      "name": "EvtCreateConfigV2",
+      "discriminator": [
+        163,
+        74,
+        66,
+        187,
+        119,
+        195,
+        26,
+        144
+      ]
+    },
+    {
+      "name": "EvtCreateConfigV2WithTransferHook",
+      "discriminator": [
+        182,
+        81,
+        135,
+        4,
+        39,
+        46,
+        132,
+        253
+      ]
+    },
+    {
+      "name": "EvtCreateMeteoraMigrationMetadata",
+      "discriminator": [
+        99,
+        167,
+        133,
+        63,
+        214,
+        143,
+        175,
+        139
+      ]
+    },
+    {
+      "name": "EvtCreatorWithdrawSurplus",
+      "discriminator": [
+        152,
+        73,
+        21,
+        15,
+        66,
+        87,
+        53,
+        157
+      ]
+    },
+    {
+      "name": "EvtCurveComplete",
+      "discriminator": [
+        229,
+        231,
+        86,
+        84,
+        156,
+        134,
+        75,
+        24
+      ]
+    },
+    {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "discriminator": [
+        59,
+        47,
+        109,
+        205,
+        13,
+        31,
+        44,
+        159
+      ]
+    },
+    {
+      "name": "EvtInitializePool",
+      "discriminator": [
+        228,
+        50,
+        246,
+        85,
+        203,
+        66,
+        134,
+        37
+      ]
+    },
+    {
+      "name": "EvtInitializePoolWithTransferHook",
+      "discriminator": [
+        213,
+        137,
+        164,
+        53,
+        193,
+        74,
+        15,
+        110
+      ]
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "discriminator": [
+        174,
+        223,
+        44,
+        150,
+        145,
+        98,
+        89,
+        195
+      ]
+    },
+    {
+      "name": "EvtPartnerMetadata",
+      "discriminator": [
+        200,
+        127,
+        6,
+        55,
+        13,
+        32,
+        8,
+        150
+      ]
+    },
+    {
+      "name": "EvtPartnerWithdrawSurplus",
+      "discriminator": [
+        195,
+        56,
+        152,
+        9,
+        232,
+        72,
+        35,
+        22
+      ]
+    },
+    {
+      "name": "EvtSwap",
+      "discriminator": [
+        27,
+        60,
+        21,
+        213,
+        138,
+        170,
+        187,
+        147
+      ]
+    },
+    {
+      "name": "EvtSwap2",
+      "discriminator": [
+        189,
+        66,
+        51,
+        168,
+        38,
+        80,
+        117,
+        153
+      ]
+    },
+    {
+      "name": "EvtSwap2WithTransferHook",
+      "discriminator": [
+        134,
+        59,
+        168,
+        120,
+        94,
+        51,
+        114,
+        231
+      ]
+    },
+    {
+      "name": "EvtUpdatePoolCreator",
+      "discriminator": [
+        107,
+        225,
+        165,
+        237,
+        91,
+        158,
+        213,
+        220
+      ]
+    },
+    {
+      "name": "EvtVirtualPoolMetadata",
+      "discriminator": [
+        188,
+        18,
+        72,
+        76,
+        195,
+        91,
+        38,
+        74
+      ]
+    },
+    {
+      "name": "EvtWithdrawLeftover",
+      "discriminator": [
+        191,
+        189,
+        104,
+        143,
+        111,
+        156,
+        94,
+        229
+      ]
+    },
+    {
+      "name": "EvtWithdrawMigrationFee",
+      "discriminator": [
+        26,
+        203,
+        84,
+        85,
+        161,
+        23,
+        100,
+        214
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "ExceededSlippage",
+      "msg": "Exceeded slippage tolerance"
+    },
+    {
+      "code": 6003,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
+    },
+    {
+      "code": 6005,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6006,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidQuoteMint",
+      "msg": "Invalid quote mint"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidMigrationFeeOption",
+      "msg": "Invalid migration fee option"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidInput",
+      "msg": "Invalid input"
+    },
+    {
+      "code": 6012,
+      "name": "NotEnoughLiquidity",
+      "msg": "Not enough liquidity"
+    },
+    {
+      "code": 6013,
+      "name": "PoolIsCompleted",
+      "msg": "Pool is completed"
+    },
+    {
+      "code": 6014,
+      "name": "PoolIsIncompleted",
+      "msg": "Pool is incompleted"
+    },
+    {
+      "code": 6015,
+      "name": "InvalidMigrationOption",
+      "msg": "Invalid migration option"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidTokenDecimals",
+      "msg": "Invalid token decimals"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidTokenType",
+      "msg": "Invalid token type"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidFeePercentage",
+      "msg": "Invalid fee percentage"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidQuoteThreshold",
+      "msg": "Invalid quote threshold"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidTokenSupply",
+      "msg": "Invalid token supply"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidCurve",
+      "msg": "Invalid curve"
+    },
+    {
+      "code": 6022,
+      "name": "NotPermitToDoThisAction",
+      "msg": "Not permit to do this action"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidOwnerAccount",
+      "msg": "Invalid owner account"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidConfigAccount",
+      "msg": "Invalid config account"
+    },
+    {
+      "code": 6025,
+      "name": "SurplusHasBeenWithdraw",
+      "msg": "Surplus has been withdraw"
+    },
+    {
+      "code": 6026,
+      "name": "LeftoverHasBeenWithdraw",
+      "msg": "Leftover has been withdraw"
+    },
+    {
+      "code": 6027,
+      "name": "TotalBaseTokenExceedMaxSupply",
+      "msg": "Total base token is exceeded max supply"
+    },
+    {
+      "code": 6028,
+      "name": "UnsupportNativeMintToken2022",
+      "msg": "Unsupport native mint token 2022"
+    },
+    {
+      "code": 6029,
+      "name": "InsufficientLiquidityForMigration",
+      "msg": "Insufficient liquidity for migration"
+    },
+    {
+      "code": 6030,
+      "name": "MissingPoolConfigInRemainingAccount",
+      "msg": "Missing pool config in remaining account"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidVestingParameters",
+      "msg": "Invalid vesting parameters"
+    },
+    {
+      "code": 6032,
+      "name": "InvalidLeftoverAddress",
+      "msg": "Invalid leftover address"
+    },
+    {
+      "code": 6033,
+      "name": "InsufficientLiquidity",
+      "msg": "Liquidity in bonding curve is insufficient"
+    },
+    {
+      "code": 6034,
+      "name": "InvalidFeeScheduler",
+      "msg": "Invalid fee scheduler"
+    },
+    {
+      "code": 6035,
+      "name": "InvalidCreatorTradingFeePercentage",
+      "msg": "Invalid creator trading fee percentage"
+    },
+    {
+      "code": 6036,
+      "name": "InvalidNewCreator",
+      "msg": "Invalid new creator"
+    },
+    {
+      "code": 6037,
+      "name": "InvalidTokenAuthorityOption",
+      "msg": "Invalid token authority option"
+    },
+    {
+      "code": 6038,
+      "name": "InvalidAccount",
+      "msg": "Invalid account for the instruction"
+    },
+    {
+      "code": 6039,
+      "name": "InvalidMigratorFeePercentage",
+      "msg": "Invalid migrator fee percentage"
+    },
+    {
+      "code": 6040,
+      "name": "MigrationFeeHasBeenWithdraw",
+      "msg": "Migration fee has been withdraw"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidBaseFeeMode",
+      "msg": "Invalid base fee mode"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidFeeRateLimiter",
+      "msg": "Invalid fee rate limiter"
+    },
+    {
+      "code": 6043,
+      "name": "FailToValidateSingleSwapInstruction",
+      "msg": "Fail to validate single swap instruction in rate limiter"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidMigratedPoolFee",
+      "msg": "Invalid migrated pool fee params"
+    },
+    {
+      "code": 6045,
+      "name": "UndeterminedError",
+      "msg": "Undertermined error"
+    },
+    {
+      "code": 6046,
+      "name": "RateLimiterNotSupported",
+      "msg": "Rate limiter not supported"
+    },
+    {
+      "code": 6047,
+      "name": "AmountLeftIsNotZero",
+      "msg": "Amount left is not zero"
+    },
+    {
+      "code": 6048,
+      "name": "NextSqrtPriceIsSmallerThanStartSqrtPrice",
+      "msg": "Next sqrt price is smaller than start sqrt price"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidMinBaseFee",
+      "msg": "Invalid min base fee"
+    },
+    {
+      "code": 6050,
+      "name": "AccountInvariantViolation",
+      "msg": "Account invariant violation"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidPoolCreationFee",
+      "msg": "Invalid pool creation fee"
+    },
+    {
+      "code": 6052,
+      "name": "PoolCreationFeeHasBeenClaimed",
+      "msg": "Pool creation fee has been claimed"
+    },
+    {
+      "code": 6053,
+      "name": "Unauthorized",
+      "msg": "Not permit to do this action"
+    },
+    {
+      "code": 6054,
+      "name": "ZeroPoolCreationFee",
+      "msg": "Pool creation fee is zero"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidMigrationLockedLiquidity",
+      "msg": "Invalid migration locked liquidity"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidFeeMarketCapScheduler",
+      "msg": "Invalid fee market cap scheduler"
+    },
+    {
+      "code": 6057,
+      "name": "FirstSwapValidationFailed",
+      "msg": "Fail to validate first swap with minimum fee"
+    },
+    {
+      "code": 6058,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6059,
+      "name": "InsufficientPoolLamports",
+      "msg": "Pool has insufficient lamports to perform the operation"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6062,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6063,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6064,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6065,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6066,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingParameters",
+      "msg": "Invalid compounding parameters"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidInstructionsSysvar",
+      "msg": "Invalid instructions sysvar account"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidRemainingAccountsLength",
+      "msg": "Invalid remaining accounts length"
+    },
+    {
+      "code": 6071,
+      "name": "MissingRemainingAccountForTransferHook",
+      "msg": "Missing remaining account for transfer hook"
+    },
+    {
+      "code": 6072,
+      "name": "NoTransferHookProgram",
+      "msg": "No transfer hook program"
+    },
+    {
+      "code": 6073,
+      "name": "DuplicatedRemainingAccountTypes",
+      "msg": "Duplicated remaining account types"
+    },
+    {
+      "code": 6074,
+      "name": "InvalidTransferHookProgram",
+      "msg": "Invalid transfer hook program"
+    },
+    {
+      "code": 6075,
+      "name": "InvalidPoolAccount",
+      "msg": "Invalid pool account"
+    },
+    {
+      "code": 6076,
+      "name": "PoolTypeMismatch",
+      "msg": "Pool type does not match instruction"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccountsType",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookBase"
+          },
+          {
+            "name": "TransferHookBaseReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "second_factor",
+            "type": "u64"
+          },
+          {
+            "name": "third_factor",
+            "type": "u64"
+          },
+          {
+            "name": "first_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "first_factor",
+            "type": "u16"
+          },
+          {
+            "name": "second_factor",
+            "type": "u64"
+          },
+          {
+            "name": "third_factor",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFeeOperator",
+      "docs": [
+        "Parameter that set by the protocol"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "docs": [
+              "operator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                219
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_start_price",
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting",
+            "type": {
+              "defined": {
+                "name": "LockedVestingParams"
+              }
+            }
+          },
+          {
+            "name": "migration_fee_option",
+            "type": "u8"
+          },
+          {
+            "name": "token_supply",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "TokenSupplyParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "creator_trading_fee_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "token_update_authority",
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee",
+            "type": {
+              "defined": {
+                "name": "MigrationFee"
+              }
+            }
+          },
+          {
+            "name": "migrated_pool_fee",
+            "type": {
+              "defined": {
+                "name": "MigratedPoolFee"
+              }
+            }
+          },
+          {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in SOL lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_pool_market_cap_fee_scheduler_params",
+            "type": {
+              "defined": {
+                "name": "MigratedPoolMarketCapFeeSchedulerParams"
+              }
+            }
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "bool"
+          },
+          {
+            "name": "compounding_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "curve",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "LiquidityDistributionParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigWithTransferHook",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "PoolConfig"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreatePartnerMetadataParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateVirtualPoolMetadataParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "initialized",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimCreatorTradingFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimTradingFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCloseClaimFeeOperator",
+      "docs": [
+        "Close claim fee operator"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "claim_fee_operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateClaimFeeOperator",
+      "docs": [
+        "Create claim fee operator"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfig",
+      "docs": [
+        "Create config"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "swap_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "migration_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_start_price",
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting",
+            "type": {
+              "defined": {
+                "name": "LockedVestingParams"
+              }
+            }
+          },
+          {
+            "name": "migration_fee_option",
+            "type": "u8"
+          },
+          {
+            "name": "fixed_token_supply_flag",
+            "type": "u8"
+          },
+          {
+            "name": "pre_migration_token_supply",
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "type": "u64"
+          },
+          {
+            "name": "curve",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "LiquidityDistributionParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfigV2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_parameters",
+            "type": {
+              "defined": {
+                "name": "ConfigParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfigV2WithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_parameters",
+            "type": {
+              "defined": {
+                "name": "ConfigParameters"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateMeteoraMigrationMetadata",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreatorWithdrawSurplus",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "surplus_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCurveComplete",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtInitializePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtInitializePoolWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          },
+          {
+            "name": "fee_receiver",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerMetadata",
+      "docs": [
+        "Create partner metadata"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "partner_metadata",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerWithdrawSurplus",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "surplus_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "SwapParameters"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult"
+              }
+            }
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "swap_parameters",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "quote_reserve_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap2WithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "swap_parameters",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "quote_reserve_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtUpdatePoolCreator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_creator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtVirtualPoolMetadata",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool_metadata",
+            "type": "pubkey"
+          },
+          {
+            "name": "virtual_pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawLeftover",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawMigrationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "flag",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializePoolParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "name": "uri",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityDistributionConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityDistributionParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_initialized",
+            "type": "u8"
+          },
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfoParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockEscrow",
+      "docs": [
+        "State of lock escrow account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "escrow_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "total_locked_amount",
+            "type": "u64"
+          },
+          {
+            "name": "lp_per_token",
+            "type": "u128"
+          },
+          {
+            "name": "unclaimed_fee_pending",
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockedVestingConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_per_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u64"
+          },
+          {
+            "name": "frequency",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_amount",
+            "type": "u64"
+          },
+          {
+            "name": "_padding",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockedVestingParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_per_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u64"
+          },
+          {
+            "name": "frequency",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MeteoraDammMigrationMetadata",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "docs": [
+              "pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "!!! BE CAREFUL to use tombstone field, previous is pool creator"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "partner",
+            "docs": [
+              "partner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_mint",
+            "docs": [
+              "lp mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "partner_locked_liquidity",
+            "docs": [
+              "partner locked liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_liquidity",
+            "docs": [
+              "partner liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_locked_liquidity",
+            "docs": [
+              "creator locked liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_liquidity",
+            "docs": [
+              "creator liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "padding"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_locked_status",
+            "docs": [
+              "flag to check whether liquidity token is locked for creator"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_locked_status",
+            "docs": [
+              "flag to check whether liquidity token is locked for partner"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_claim_status",
+            "docs": [
+              "flag to check whether creator has claimed liquidity token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_claim_status",
+            "docs": [
+              "flag to check whether partner has claimed liquidity token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                107
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigratedPoolFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "dynamic_fee",
+            "type": "u8"
+          },
+          {
+            "name": "pool_fee_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigratedPoolMarketCapFeeSchedulerParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u16"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_fee_percentage",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whitelisted_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerMetadata",
+      "docs": [
+        "Metadata for a partner."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_claimer",
+            "docs": [
+              "fee claimer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Name of partner."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "docs": [
+              "Website of partner."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "docs": [
+              "Logo of partner"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "quote_mint",
+            "docs": [
+              "quote mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "docs": [
+              "Address to get the fee"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "docs": [
+              "Address to receive extra base token after migration, in case token is fixed supply"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "docs": [
+              "Pool fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeesConfig"
+              }
+            }
+          },
+          {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "Padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": [
+              "Previously was protocol and referral fee percent. Beware of tombstone."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "Collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "docs": [
+              "migration option"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "whether mode slot or timestamp"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "docs": [
+              "token decimals"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "version",
+            "docs": [
+              "version"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "docs": [
+              "token type of base token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "quote_token_flag",
+            "docs": [
+              "quote token flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "docs": [
+              "partner locked liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "docs": [
+              "partner liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "docs": [
+              "creator post migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "docs": [
+              "creator liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_option",
+            "docs": [
+              "migration fee option"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fixed_token_supply_flag",
+            "docs": [
+              "flag to indicate whether token is dynamic supply (0) or fixed supply (1)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_trading_fee_percentage",
+            "docs": [
+              "creator trading fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_update_authority",
+            "docs": [
+              "token update authority"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_percentage",
+            "docs": [
+              "migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_migration_fee_percentage",
+            "docs": [
+              "creator migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_2",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "swap_base_amount",
+            "docs": [
+              "swap base amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "docs": [
+              "migration quote threshold (in quote token)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_base_threshold",
+            "docs": [
+              "migration base threshold (in base token)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_sqrt_price",
+            "docs": [
+              "migration sqrt price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting_config",
+            "docs": [
+              "locked vesting config"
+            ],
+            "type": {
+              "defined": {
+                "name": "LockedVestingConfig"
+              }
+            }
+          },
+          {
+            "name": "pre_migration_token_supply",
+            "docs": [
+              "pre migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "docs": [
+              "post migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migrated_collect_fee_mode",
+            "docs": [
+              "migrated pool collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migrated_dynamic_fee",
+            "docs": [
+              "migrated dynamic fee option."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migrated_pool_fee_bps",
+            "docs": [
+              "migrated pool fee in bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_compounding_fee_bps",
+            "docs": [
+              "compounding fee bps for migrated DAMM v2 pool, should only be non-zero if migrated_collect_fee_mode is 2 (Compounding)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migrated_pool_base_fee_bytes",
+            "docs": [
+              "serialized MigratedPoolMarketCapFeeSchedulerParams, only used when migrated_pool_base_fee_mode is market cap scheduler"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "sqrt_start_price",
+            "docs": [
+              "minimum price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "curve",
+            "docs": [
+              "curve, only use 20 point firstly, we can extend that latter"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "LiquidityDistributionConfig"
+                  }
+                },
+                20
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFeeParameters",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_fee",
+            "docs": [
+              "Base fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "BaseFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "docs": [
+              "dynamic fee"
+            ],
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "DynamicFeeParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFees",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFeesConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_fee",
+            "type": {
+              "defined": {
+                "name": "BaseFeeConfig"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "type": {
+              "defined": {
+                "name": "DynamicFeeConfig"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolMetrics",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "total_protocol_base_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_protocol_quote_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_trading_base_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_trading_quote_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolState",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "volatility_tracker",
+            "docs": [
+              "volatility tracker"
+            ],
+            "type": {
+              "defined": {
+                "name": "VolatilityTracker"
+              }
+            }
+          },
+          {
+            "name": "config",
+            "docs": [
+              "config key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "docs": [
+              "base mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_vault",
+            "docs": [
+              "base vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_vault",
+            "docs": [
+              "quote vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "docs": [
+              "base reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "docs": [
+              "quote reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_base_fee",
+            "docs": [
+              "protocol base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_quote_fee",
+            "docs": [
+              "protocol quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_base_fee",
+            "docs": [
+              "partner base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_quote_fee",
+            "docs": [
+              "trading quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_price",
+            "docs": [
+              "current price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "Activation point"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pool_type",
+            "docs": [
+              "pool type, spl token or token2022"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_migrated",
+            "docs": [
+              "is migrated"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_partner_withdraw_surplus",
+            "docs": [
+              "is partner withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_protocol_withdraw_surplus",
+            "docs": [
+              "is protocol withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_progress",
+            "docs": [
+              "migration progress"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_withdraw_leftover",
+            "docs": [
+              "is withdraw leftover"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_creator_withdraw_surplus",
+            "docs": [
+              "is creator withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_withdraw_status",
+            "docs": [
+              "migration fee withdraw status",
+              "bit 1 (0b010) creator",
+              "bit 2 (0b100) partner"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "metrics",
+            "docs": [
+              "pool metrics"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolMetrics"
+              }
+            }
+          },
+          {
+            "name": "finish_curve_timestamp",
+            "docs": [
+              "The time curve is finished"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_base_fee",
+            "docs": [
+              "creator base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_quote_fee",
+            "docs": [
+              "creator quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "legacy_creation_fee_bits",
+            "docs": [
+              "legacy creation fee bits, we dont use this now"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creation_fee_bits",
+            "docs": [
+              "pool creation fee claim status"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_swap",
+            "docs": [
+              "Cached flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "protocol_liquidity_migration_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "protocol_migration_base_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_migration_quote_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "_padding_2",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": {
+              "defined": {
+                "name": "AccountsType"
+              }
+            }
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "minimum_amount_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_0",
+            "docs": [
+              "When it's exact in, partial fill, this will be amount_in. When it's exact out, this will be amount_out"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "When it's exact in, partial fill, this will be minimum_amount_out. When it's exact out, this will be maximum_amount_in"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "swap_mode",
+            "docs": [
+              "Swap mode, refer [SwapMode]"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult",
+      "docs": [
+        "Encodes all results of swapping"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "actual_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "included_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenSupplyParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pre_migration_token_supply",
+            "docs": [
+              "pre migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "docs": [
+              "post migration token supply",
+              "because DBC allow user to swap over the migration quote threshold, so in extreme case user may swap more than allowed buffer on curve",
+              "that result the total supply in post migration may be increased a bit (between pre_migration_token_supply and post_migration_token_supply)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualPoolMetadata",
+      "docs": [
+        "Metadata for a virtual pool."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "docs": [
+              "virtual pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Name of project."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "docs": [
+              "Website of project."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "docs": [
+              "Logo of project"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VolatilityTracker",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_update_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "sqrt_price_reference",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_accumulator",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_reference",
+            "type": "u128"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/idls/orca_whirlpool.json
+++ b/idls/orca_whirlpool.json
@@ -1,4326 +1,7608 @@
 {
-  "version": "0.3.6",
-  "name": "whirlpool",
-  "instructions": [
-    {
-      "name": "initializeConfig",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
+    "address": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+    "metadata": {
+        "name": "whirlpool",
+        "version": "0.9.0",
+        "spec": "0.1.0"
     },
-    {
-      "name": "initializePool",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "WhirlpoolBumps"
-          }
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeTickArray",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tickArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "startTickIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "initializeFeeTier",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissions",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "openPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithMetadata",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionMetadataAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionWithMetadataBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "updateFeesAndRewards",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectFees",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectReward",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFees",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "swap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setDefaultFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "protocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setCollectProtocolFeesAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newCollectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setRewardAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardAuthorityBySuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsSuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "twoHopSwap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializePositionBundleWithMetadata",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleMetadata",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deletePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "openBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "closeBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        },
-        {
-          "name": "withTokenMetadataExtension",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "lockPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "lockType",
-          "type": {
-            "defined": "LockType"
-          }
-        }
-      ]
-    },
-    {
-      "name": "resetPositionRange",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "newTickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "newTickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "transferLockedPosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "destinationTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeAdaptiveFeeTier",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeTierIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initializePoolAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        },
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultBaseFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newDelegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setInitializePoolAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newInitializePoolAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setPresetAdaptiveFeeConstants",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializePoolWithAdaptiveFee",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "initializePoolAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        },
-        {
-          "name": "tradeEnableTimestamp",
-          "type": {
-            "option": "u64"
-          }
-        }
-      ]
-    },
-    {
-      "name": "setFeeRateByDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "collectFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectRewardV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializePoolV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeRewardV2",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenBadge",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "swapV2",
-      "accounts": [
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "twoHopSwapV2",
-      "accounts": [
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeConfigExtension",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "configExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setConfigExtensionAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newConfigExtensionAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setTokenBadgeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newTokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deleteTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    }
-  ],
-  "accounts": [
-    {
-      "name": "AdaptiveFeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeTierIndex",
-            "type": "u16"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "initializePoolAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "delegatedFeeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultBaseFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "collectProtocolFeesAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardEmissionsSuperAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultProtocolFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfigExtension",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "configExtensionAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBadgeAuthority",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "defaultFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "position",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionOwner",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "lockedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lockType",
-            "type": {
-              "defined": "LockTypeLabel"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Oracle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "tradeEnableTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "adaptiveFeeConstants",
-            "type": {
-              "defined": "AdaptiveFeeConstants"
-            }
-          },
-          {
-            "name": "adaptiveFeeVariables",
-            "type": {
-              "defined": "AdaptiveFeeVariables"
-            }
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "tickLowerIndex",
-            "type": "i32"
-          },
-          {
-            "name": "tickUpperIndex",
-            "type": "i32"
-          },
-          {
-            "name": "feeGrowthCheckpointA",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "feeGrowthCheckpointB",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+    "instructions": [
+        {
+            "name": "close_bundled_position",
+            "docs": [
+                "Close a bundled position in a Whirlpool.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to close.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                41,
+                36,
+                216,
+                245,
+                27,
+                85,
+                103,
+                67
+            ],
+            "accounts": [
                 {
-                  "defined": "PositionRewardInfo"
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionBundle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBundleMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionBitmap",
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "TickArray",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "startTickIndex",
-            "type": "i32"
-          },
-          {
-            "name": "ticks",
-            "type": {
-              "array": [
                 {
-                  "defined": "Tick"
+                    "name": "position_bundle",
+                    "writable": true
                 },
-                88
-              ]
-            }
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenBadge",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenMint",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Whirlpool",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpoolBump",
-            "type": {
-              "array": [
-                "u8",
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "close_position",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                123,
+                134,
+                81,
+                0,
+                49,
+                68,
+                98,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "close_position_with_token_extensions",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "Mint and TokenAccount are based on Token-2022. And Mint accout will be also closed.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                1,
+                182,
+                135,
+                59,
+                155,
+                25,
+                99,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                164,
+                152,
+                207,
+                99,
+                30,
+                186,
+                19,
+                182
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees_v2",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                207,
+                117,
+                95,
+                191,
+                229,
+                180,
+                226,
+                15
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_protocol_fees",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                22,
+                67,
+                23,
+                98,
+                150,
+                178,
+                70,
+                220
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_protocol_fees_v2",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                103,
+                128,
+                222,
+                134,
+                114,
+                200,
+                22,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_reward",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                70,
+                5,
+                132,
+                87,
+                86,
+                235,
+                177,
+                34
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "collect_reward_v2",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                177,
+                107,
+                37,
+                180,
+                160,
+                19,
+                49,
+                209
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                160,
+                38,
+                208,
+                111,
+                104,
+                91,
+                44,
                 1
-              ]
-            }
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "feeTierIndexSeed",
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "feeRate",
-            "type": "u16"
-          },
-          {
-            "name": "protocolFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "sqrtPrice",
-            "type": "u128"
-          },
-          {
-            "name": "tickCurrentIndex",
-            "type": "i32"
-          },
-          {
-            "name": "protocolFeeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "protocolFeeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "tokenMintA",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultA",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalA",
-            "type": "u128"
-          },
-          {
-            "name": "tokenMintB",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultB",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardLastUpdatedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+            ],
+            "accounts": [
                 {
-                  "defined": "WhirlpoolRewardInfo"
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "LockType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockTypeLabel",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeConstants",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeVariables",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lastReferenceUpdateTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lastMajorSwapTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "volatilityReference",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupIndexReference",
-            "type": "i32"
-          },
-          {
-            "name": "volatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionWithMetadataBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          },
-          {
-            "name": "metadataBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "growthInsideCheckpoint",
-            "type": "u128"
-          },
-          {
-            "name": "amountOwed",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Tick",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "initialized",
-            "type": "bool"
-          },
-          {
-            "name": "liquidityNet",
-            "type": "i128"
-          },
-          {
-            "name": "liquidityGross",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideA",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardGrowthsOutside",
-            "type": {
-              "array": [
-                "u128",
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mint",
-            "type": "publicKey"
-          },
-          {
-            "name": "vault",
-            "type": "publicKey"
-          },
-          {
-            "name": "authority",
-            "type": "publicKey"
-          },
-          {
-            "name": "emissionsPerSecondX64",
-            "type": "u128"
-          },
-          {
-            "name": "growthGlobalX64",
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AccountsType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TransferHookA"
-          },
-          {
-            "name": "TransferHookB"
-          },
-          {
-            "name": "TransferHookReward"
-          },
-          {
-            "name": "TransferHookInput"
-          },
-          {
-            "name": "TransferHookIntermediate"
-          },
-          {
-            "name": "TransferHookOutput"
-          },
-          {
-            "name": "SupplementalTickArrays"
-          },
-          {
-            "name": "SupplementalTickArraysOne"
-          },
-          {
-            "name": "SupplementalTickArraysTwo"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slices",
-            "type": {
-              "vec": {
-                "defined": "RemainingAccountsSlice"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsSlice",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "accountsType",
-            "type": {
-              "defined": "AccountsType"
-            }
-          },
-          {
-            "name": "length",
-            "type": "u8"
-          }
-        ]
-      }
-    }
-  ],
-  "events": [
-    {
-      "name": "LiquidityDecreased",
-      "fields": [
-        {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "decrease_liquidity_v2",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                58,
+                127,
+                188,
+                62,
+                79,
+                82,
+                196,
+                96
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_position_bundle",
+            "docs": [
+                "Delete a PositionBundle account. Burns the position bundle token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- `position_bundle_owner` - The owner that owns the position bundle token.",
+                "",
+                "### Special Errors",
+                "- `PositionBundleNotDeletable` - The provided position bundle has open positions."
+            ],
+            "discriminator": [
+                100,
+                25,
+                99,
+                2,
+                217,
+                239,
+                124,
+                173
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_owner",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_token_badge",
+            "docs": [
+                "Delete a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                53,
+                146,
+                68,
+                8,
+                18,
+                117,
+                17,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": []
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "idl_include",
+            "discriminator": [
+                223,
+                253,
+                121,
+                121,
+                60,
+                193,
+                129,
+                31
+            ],
+            "accounts": [
+                {
+                    "name": "tick_array"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                46,
+                156,
+                243,
+                118,
+                13,
+                205,
+                251,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_by_token_amounts_v2",
+            "docs": [
+                "Add liquidity to a position by specifying token maxima, not liquidity.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "NOTE: This instruction is only implemented in Pinocchio, not Anchor.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "- `min_sqrt_price` - The minimum sqrt price allowed.",
+                "- `max_sqrt_price` - The maximum sqrt price allowed.",
+                "",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Computed liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Computed liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                239,
+                251,
+                9,
+                124,
+                210,
+                198,
+                53,
+                43
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "IncreaseLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_v2",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                133,
+                29,
+                89,
+                223,
+                69,
+                238,
+                176,
+                10
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "initialize_adaptive_fee_tier",
+            "docs": [
+                "Initializes an adaptive_fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_tier_index` - The index of the fee-tier that this adaptive fee tier will be initialized.",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `initialize_pool_authority` - The authority that can initialize pools with this adaptive fee-tier.",
+                "- `delegated_fee_authority` - The authority that can set the base fee rate for pools using this adaptive fee-tier.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `InvalidFeeTierIndex` - If the provided fee_tier_index is same to tick_spacing.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE.",
+                "- `InvalidAdaptiveFeeConstants` - If the provided adaptive fee constants are invalid."
+            ],
+            "discriminator": [
+                77,
+                99,
+                208,
+                200,
+                141,
+                123,
+                117,
+                48
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config"
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "fee_tier_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_tier_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                },
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config",
+            "docs": [
+                "Initializes a WhirlpoolsConfig account that hosts info & authorities",
+                "required to govern a set of Whirlpools.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `fee_authority` - Authority authorized to initialize fee-tiers and set customs fees.",
+                "- `collect_protocol_fees_authority` - Authority authorized to collect protocol fees.",
+                "- `reward_emissions_super_authority` - Authority authorized to set reward authorities in pools."
+            ],
+            "discriminator": [
+                208,
+                127,
+                21,
+                1,
+                194,
+                190,
+                196,
+                70
+            ],
+            "accounts": [
+                {
+                    "name": "config",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config_extension",
+            "docs": [
+                "Initializes a WhirlpoolConfigExtension account that hosts info & authorities.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                55,
+                9,
+                53,
+                9,
+                114,
+                57,
+                209,
+                52
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "config_extension",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103,
+                                    95,
+                                    101,
+                                    120,
+                                    116,
+                                    101,
+                                    110,
+                                    115,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_dynamic_tick_array",
+            "docs": [
+                "Initialize a variable-length tick array for a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "- `idempotent` - If true, the instruction will not fail if the tick array already exists.",
+                "Note: The idempotent option exits successfully if a FixedTickArray is present as well as a DynamicTickArray.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                41,
+                33,
+                165,
+                200,
+                120,
+                231,
+                142,
+                50
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "idempotent",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "initialize_fee_tier",
+            "docs": [
+                "Initializes a fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                183,
+                74,
+                156,
+                160,
+                112,
+                2,
+                42,
+                30
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                95,
+                180,
+                10,
+                172,
+                84,
+                174,
+                232,
+                40
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "WhirlpoolBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_v2",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "This instruction works with both Token and Token-2022.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                207,
+                45,
+                87,
+                242,
+                27,
+                63,
+                204,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_with_adaptive_fee",
+            "docs": [
+                "Initializes a Whirlpool account and Oracle account with adaptive fee.",
+                "",
+                "### Parameters",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "- `trade_enable_timestamp` - The timestamp when trading is enabled for this pool (within 72 hours)",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                "`InvalidTradeEnableTimestamp` - provided trade_enable_timestamp is not within 72 hours or the adaptive fee-tier is permission-less",
+                "`UnsupportedTokenMint` - The provided token mint is not supported by the program (e.g. it has risky token extensions)",
+                ""
+            ],
+            "discriminator": [
+                143,
+                94,
+                96,
+                76,
+                172,
+                124,
+                119,
+                199
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "adaptive_fee_tier.fee_tier_index",
+                                "account": "AdaptiveFeeTier"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                },
+                {
+                    "name": "trade_enable_timestamp",
+                    "type": {
+                        "option": "u64"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_position_bundle",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet."
+            ],
+            "discriminator": [
+                117,
+                45,
+                241,
+                149,
+                24,
+                18,
+                194,
+                65
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_position_bundle_with_metadata",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet.",
+                "Additional Metaplex metadata is appended to identify the token."
+            ],
+            "discriminator": [
+                93,
+                124,
+                16,
+                179,
+                249,
+                131,
+                115,
+                245
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_metadata",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/metaplex-program-library/blob/773a574c4b34e5b9f248a81306ec24db064e255f/token-metadata/program/src/utils/metadata.rs#L100"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_reward",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                95,
+                135,
+                192,
+                196,
+                242,
+                129,
+                230,
+                68
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_reward_v2",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                91,
+                1,
+                77,
+                50,
+                235,
+                229,
+                133,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_token_badge",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool.whirlpools_config",
+                                "account": "Whirlpool"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "reward_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_tick_array",
+            "docs": [
+                "Initializes a fixed-length tick_array account to represent a tick-range in a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                11,
+                188,
+                193,
+                214,
+                141,
+                91,
+                149,
+                184
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "initialize_token_badge",
+            "docs": [
+                "Initialize a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                253,
+                77,
+                205,
+                95,
+                27,
+                224,
+                89,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "lock_position",
+            "docs": [
+                "Lock the position to prevent any liquidity changes.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `PositionAlreadyLocked` - The provided position is already locked.",
+                "- `PositionNotLockable` - The provided position is not lockable (e.g. An empty position)."
+            ],
+            "discriminator": [
+                227,
+                62,
+                2,
+                252,
+                247,
+                10,
+                171,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    108,
+                                    111,
+                                    99,
+                                    107,
+                                    95,
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "lock_type",
+                    "type": {
+                        "defined": {
+                            "name": "LockType"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "migrate_repurpose_reward_authority_space",
+            "docs": [
+                "Migration instruction to repurpose the reward authority space in the Whirlpool.",
+                "TODO: This instruction should be removed once all pools have been migrated."
+            ],
+            "discriminator": [
+                214,
+                161,
+                248,
+                79,
+                152,
+                98,
+                172,
+                231
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "open_bundled_position",
+            "docs": [
+                "Open a bundled position in a Whirlpool. No new tokens are issued",
+                "because the owner of the position bundle becomes the owner of the position.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to open.",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                169,
+                113,
+                126,
+                171,
+                213,
+                172,
+                212,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                135,
+                128,
+                47,
+                77,
+                15,
+                152,
+                240,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_metadata",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional Metaplex metadata is appended to identify the token.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                242,
+                29,
+                134,
+                48,
+                58,
+                110,
+                14,
+                60
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_metadata_account",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/mpl-token-metadata/blob/master/programs/token-metadata/program/src/utils/metadata.rs#L78"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionWithMetadataBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_token_extensions",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional TokenMetadata extension is initialized to identify the token.",
+                "Mint and TokenAccount are based on Token-2022.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "- `with_token_metadata_extension` - If true, the token metadata extension will be initialized.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                212,
+                47,
+                95,
+                92,
+                114,
+                102,
+                131,
+                250
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "with_token_metadata_extension",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "reposition_liquidity_v2",
+            "docs": [
+                "An atomic instruction that repositions liquidity for a position through the following steps:",
+                "- Withdraws liquidity from the current position range",
+                "- Resets the position to a new tick range",
+                "- Adds liquidity to the new position range",
+                "- Restores fees and rewards",
+                "",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick index for the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick index for the upper end of the position range.",
+                "- `new_liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `existing_range_token_min_a` - The minimum amount of tokenA the user is willing to withdraw from the existing range.",
+                "- `existing_range_token_min_b` - The minimum amount of tokenB the user is willing to withdraw from the existing range.",
+                "- `new_range_token_max_a` - The maximum amount of tokenA the user is willing to deposit into the new range.",
+                "- `new_range_token_max_b` - The maximum amount of tokenB the user is willing to deposit into the new range.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                191,
+                169,
+                224,
+                11,
+                131,
+                19,
+                158,
+                253
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "RepositionLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "reset_position_range",
+            "docs": [
+                "Reset the position range to a new range.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick specifying the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                164,
+                123,
+                180,
+                141,
+                194,
+                100,
+                160,
+                175
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "set_adaptive_fee_constants",
+            "docs": [
+                "Sets specific adaptive fee constants for a pool. Only the provided constants will be updated,",
+                "others remain unchanged. Caller should avoid invoking this instruction when a pool's adaptive",
+                "fee is high to prevent LP revenue loss",
+                "",
+                "### Authority",
+                "- `fee_authority` - Set authority in the WhirlpoolsConfig",
+                "",
+                "### Parameters",
+                "All parameters are optional. Only provided values will be updated.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidAdaptiveFeeConstants` - If the resulting constants are invalid for the pool's tick_spacing.",
+                "- `AdaptiveFeeConstantsUnchanged` - If the provided adaptive fee constants are unchanged from the existing constants."
+            ],
+            "discriminator": [
+                133,
+                158,
+                212,
+                189,
+                237,
+                12,
+                73,
+                39
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "oracle"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "oracle",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "decay_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": {
+                        "option": "u16"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_collect_protocol_fees_authority",
+            "docs": [
+                "Sets the fee authority to collect protocol fees for a WhirlpoolConfig.",
+                "Only the current collect protocol fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can collect protocol fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                34,
+                150,
+                93,
+                244,
+                139,
+                225,
+                233,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_collect_protocol_fees_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_extension_authority",
+            "docs": [
+                "Sets the config extension authority for a WhirlpoolsConfigExtension.",
+                "Only the current config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                44,
+                94,
+                241,
+                116,
+                24,
+                188,
+                60,
+                143
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_config_extension_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_feature_flag",
+            "docs": [
+                "Sets the feature flag for a WhirlpoolConfig.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `feature_flag` - The feature flag that the WhirlpoolConfig will use."
+            ],
+            "discriminator": [
+                71,
+                173,
+                228,
+                18,
+                67,
+                247,
+                210,
+                57
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "feature_flag",
+                    "type": {
+                        "defined": {
+                            "name": "ConfigFeatureFlag"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_default_base_fee_rate",
+            "docs": [
+                "Set the default_base_fee_rate for an AdaptiveFeeTier",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_base_fee_rate` - The default base fee rate that a pool will use if the pool uses this",
+                "adaptive fee-tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                229,
+                66,
+                84,
+                251,
+                164,
+                134,
+                183,
+                7
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_fee_rate",
+            "docs": [
+                "Set the default_fee_rate for a FeeTier",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                118,
+                215,
+                214,
+                157,
+                182,
+                229,
+                208,
+                228
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_protocol_fee_rate",
+            "docs": [
+                "Sets the default protocol fee rate for a WhirlpoolConfig",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_protocol_fee_rate` - Rate that is referenced during the initialization of a Whirlpool using this config.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                107,
+                205,
+                249,
+                226,
+                151,
+                35,
+                86,
+                0
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_delegated_fee_authority",
+            "docs": [
+                "Sets the delegated fee authority for an AdaptiveFeeTier.",
+                "The delegated fee authority can set the fee rate for individual pools initialized with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                193,
+                234,
+                231,
+                147,
+                138,
+                57,
+                3,
+                122
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_delegated_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_authority",
+            "docs": [
+                "Sets the fee authority for a WhirlpoolConfig.",
+                "The fee authority can set the fee & protocol fee rate for individual pools or",
+                "set the default fee rate for newly minted pools.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                31,
+                1,
+                50,
+                87,
+                237,
+                101,
+                97,
+                132
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_rate",
+            "docs": [
+                "Sets the fee rate for a Whirlpool.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                53,
+                243,
+                137,
+                65,
+                8,
+                140,
+                158,
+                6
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_fee_rate_by_delegated_fee_authority",
+            "docs": [
+                "Sets the fee rate for a Whirlpool by the delegated fee authority in AdaptiveFeeTier.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "",
+                "### Authority",
+                "- \"delegated_fee_authority\" - Set authority that can modify pool fees in the AdaptiveFeeTier",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                121,
+                121,
+                54,
+                114,
+                131,
+                230,
+                162,
+                104
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_initialize_pool_authority",
+            "docs": [
+                "Sets the initialize pool authority for an AdaptiveFeeTier.",
+                "Only the initialize pool authority can initialize pools with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                125,
+                43,
+                127,
+                235,
+                149,
+                26,
+                106,
+                236
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_initialize_pool_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_preset_adaptive_fee_constants",
+            "docs": [
+                "Sets the adaptive fee constants for an AdaptiveFeeTier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap."
+            ],
+            "discriminator": [
+                132,
+                185,
+                66,
+                148,
+                83,
+                88,
+                134,
+                198
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_protocol_fee_rate",
+            "docs": [
+                "Sets the protocol fee rate for a Whirlpool.",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `protocol_fee_rate` - The rate that the pool will use to calculate protocol fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                95,
+                7,
+                4,
+                50,
+                154,
+                79,
+                156,
+                131
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward authority for this reward index has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                34,
+                39,
+                183,
+                252,
+                83,
+                28,
+                85,
+                127
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority_by_super_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                240,
+                154,
+                201,
+                198,
+                148,
+                93,
+                56,
+                25
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                13,
+                197,
+                86,
+                168,
+                109,
+                176,
+                27,
+                244
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions_super_authority",
+            "docs": [
+                "Set the whirlpool reward super authority for a WhirlpoolConfig",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "This instruction will not change the authority on any `WhirlpoolRewardInfo` whirlpool rewards.",
+                "",
+                "### Authority",
+                "- \"reward_emissions_super_authority\" - Set authority that can control reward authorities for all pools in this config space."
+            ],
+            "discriminator": [
+                207,
+                5,
+                200,
+                209,
+                122,
+                56,
+                82,
+                183
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_emissions_super_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_reward_emissions_v2",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                114,
+                228,
+                72,
+                32,
+                193,
+                48,
+                160,
+                102
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_attribute",
+            "docs": [
+                "Set an attribute on a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Parameters",
+                "- `attribute` - The attribute to set on the TokenBadge account.",
+                "",
+                "#### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                224,
+                88,
+                65,
+                33,
+                138,
+                147,
+                246,
+                137
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint",
+                    "relations": [
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "attribute",
+                    "type": {
+                        "defined": {
+                            "name": "TokenBadgeAttribute"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_authority",
+            "docs": [
+                "Sets the token badge authority for a WhirlpoolsConfigExtension.",
+                "Only the config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                207,
+                202,
+                4,
+                32,
+                205,
+                79,
+                13,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_token_badge_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "swap",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                248,
+                198,
+                158,
+                145,
+                225,
+                117,
+                135,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "swap_v2",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                43,
+                4,
+                237,
+                11,
+                26,
+                201,
+                30,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "transfer_locked_position",
+            "docs": [
+                "Transfer a locked position to a different token account.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token."
+            ],
+            "discriminator": [
+                179,
+                121,
+                229,
+                46,
+                67,
+                138,
+                194,
+                138
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    },
+                    "relations": [
+                        "lock_config"
+                    ]
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "destination_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "two_hop_swap",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                195,
+                96,
+                237,
+                108,
+                68,
+                162,
+                219,
+                230
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "two_hop_swap_v2",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                186,
+                143,
+                209,
+                29,
+                254,
+                2,
+                194,
+                117
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_input"
+                },
+                {
+                    "name": "token_mint_intermediate"
+                },
+                {
+                    "name": "token_mint_output"
+                },
+                {
+                    "name": "token_program_input"
+                },
+                {
+                    "name": "token_program_intermediate"
+                },
+                {
+                    "name": "token_program_output"
+                },
+                {
+                    "name": "token_owner_account_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "update_fees_and_rewards",
+            "docs": [
+                "Update the accrued fees and rewards for a position.",
+                "",
+                "#### Special Errors",
+                "- `TickNotFound` - Provided tick array account does not contain the tick for this position.",
+                "- `LiquidityZero` - Position has zero liquidity and therefore already has the most updated fees and reward values."
+            ],
+            "discriminator": [
+                154,
+                230,
+                250,
+                13,
+                236,
+                209,
+                75,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower"
+                },
+                {
+                    "name": "tick_array_upper"
+                }
+            ],
+            "args": []
         }
-      ]
-    },
-    {
-      "name": "LiquidityIncreased",
-      "fields": [
+    ],
+    "accounts": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "AdaptiveFeeTier",
+            "discriminator": [
+                147,
+                16,
+                144,
+                116,
+                47,
+                146,
+                149,
+                46
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "DynamicTickArray",
+            "discriminator": [
+                17,
+                216,
+                246,
+                142,
+                225,
+                199,
+                218,
+                56
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "FeeTier",
+            "discriminator": [
+                56,
+                75,
+                159,
+                76,
+                142,
+                68,
+                190,
+                105
+            ]
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "LockConfig",
+            "discriminator": [
+                106,
+                47,
+                238,
+                159,
+                124,
+                12,
+                160,
+                192
+            ]
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "Oracle",
+            "discriminator": [
+                139,
+                194,
+                131,
+                179,
+                140,
+                179,
+                229,
+                244
+            ]
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "Position",
+            "discriminator": [
+                170,
+                188,
+                143,
+                228,
+                122,
+                64,
+                247,
+                208
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "PositionBundle",
+            "discriminator": [
+                129,
+                169,
+                175,
+                65,
+                185,
+                95,
+                32,
+                100
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TickArray",
+            "discriminator": [
+                69,
+                97,
+                189,
+                190,
+                110,
+                7,
+                66,
+                187
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TokenBadge",
+            "discriminator": [
+                116,
+                219,
+                204,
+                229,
+                249,
+                116,
+                255,
+                150
+            ]
+        },
+        {
+            "name": "Whirlpool",
+            "discriminator": [
+                63,
+                149,
+                209,
+                12,
+                225,
+                128,
+                99,
+                9
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "discriminator": [
+                157,
+                20,
+                49,
+                224,
+                217,
+                87,
+                193,
+                254
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "discriminator": [
+                2,
+                99,
+                215,
+                163,
+                240,
+                26,
+                153,
+                58
+            ]
         }
-      ]
-    },
-    {
-      "name": "PoolInitialized",
-      "fields": [
+    ],
+    "events": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityDecreased",
+            "discriminator": [
+                166,
+                1,
+                36,
+                71,
+                112,
+                202,
+                181,
+                171
+            ]
         },
         {
-          "name": "whirlpoolsConfig",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityIncreased",
+            "discriminator": [
+                30,
+                7,
+                144,
+                181,
+                102,
+                254,
+                155,
+                161
+            ]
         },
         {
-          "name": "tokenMintA",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityRepositioned",
+            "discriminator": [
+                95,
+                130,
+                181,
+                132,
+                251,
+                50,
+                195,
+                38
+            ]
         },
         {
-          "name": "tokenMintB",
-          "type": "publicKey",
-          "index": false
+            "name": "PoolInitialized",
+            "discriminator": [
+                100,
+                118,
+                173,
+                87,
+                12,
+                198,
+                254,
+                229
+            ]
         },
         {
-          "name": "tickSpacing",
-          "type": "u16",
-          "index": false
+            "name": "PositionOpened",
+            "discriminator": [
+                237,
+                175,
+                243,
+                230,
+                147,
+                117,
+                101,
+                121
+            ]
         },
         {
-          "name": "tokenProgramA",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenProgramB",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "decimalsA",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "decimalsB",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128",
-          "index": false
+            "name": "Traded",
+            "discriminator": [
+                225,
+                202,
+                73,
+                175,
+                147,
+                43,
+                160,
+                150
+            ]
         }
-      ]
-    },
-    {
-      "name": "Traded",
-      "fields": [
+    ],
+    "errors": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "code": 6000,
+            "name": "InvalidEnum",
+            "msg": "Enum value could not be converted"
         },
         {
-          "name": "aToB",
-          "type": "bool",
-          "index": false
+            "code": 6001,
+            "name": "InvalidStartTick",
+            "msg": "Invalid start tick index provided."
         },
         {
-          "name": "preSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6002,
+            "name": "TickArrayExistInPool",
+            "msg": "Tick-array already exists in this whirlpool"
         },
         {
-          "name": "postSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6003,
+            "name": "TickArrayIndexOutofBounds",
+            "msg": "Attempt to search for a tick-array failed"
         },
         {
-          "name": "inputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6004,
+            "name": "InvalidTickSpacing",
+            "msg": "Tick-spacing is not supported"
         },
         {
-          "name": "outputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6005,
+            "name": "ClosePositionNotEmpty",
+            "msg": "Position is not empty It cannot be closed"
         },
         {
-          "name": "inputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6006,
+            "name": "DivideByZero",
+            "msg": "Unable to divide by zero"
         },
         {
-          "name": "outputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6007,
+            "name": "NumberCastError",
+            "msg": "Unable to cast number into BigInt"
         },
         {
-          "name": "lpFee",
-          "type": "u64",
-          "index": false
+            "code": 6008,
+            "name": "NumberDownCastError",
+            "msg": "Unable to down cast number"
         },
         {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
+            "code": 6009,
+            "name": "TickNotFound",
+            "msg": "Tick not found within tick array"
+        },
+        {
+            "code": 6010,
+            "name": "InvalidTickIndex",
+            "msg": "Provided tick index is either out of bounds or uninitializable"
+        },
+        {
+            "code": 6011,
+            "name": "SqrtPriceOutOfBounds",
+            "msg": "Provided sqrt price out of bounds"
+        },
+        {
+            "code": 6012,
+            "name": "LiquidityZero",
+            "msg": "Liquidity amount must be greater than zero"
+        },
+        {
+            "code": 6013,
+            "name": "LiquidityTooHigh",
+            "msg": "Liquidity amount must be less than i64::MAX"
+        },
+        {
+            "code": 6014,
+            "name": "LiquidityOverflow",
+            "msg": "Liquidity overflow"
+        },
+        {
+            "code": 6015,
+            "name": "LiquidityUnderflow",
+            "msg": "Liquidity underflow"
+        },
+        {
+            "code": 6016,
+            "name": "LiquidityNetError",
+            "msg": "Tick liquidity net underflowed or overflowed"
+        },
+        {
+            "code": 6017,
+            "name": "TokenMaxExceeded",
+            "msg": "Exceeded token max"
+        },
+        {
+            "code": 6018,
+            "name": "TokenMinSubceeded",
+            "msg": "Did not meet token min"
+        },
+        {
+            "code": 6019,
+            "name": "MissingOrInvalidDelegate",
+            "msg": "Position token account has a missing or invalid delegate"
+        },
+        {
+            "code": 6020,
+            "name": "InvalidPositionTokenAmount",
+            "msg": "Position token amount must be 1"
+        },
+        {
+            "code": 6021,
+            "name": "InvalidTimestampConversion",
+            "msg": "Timestamp should be convertible from i64 to u64"
+        },
+        {
+            "code": 6022,
+            "name": "InvalidTimestamp",
+            "msg": "Timestamp should be greater than the last updated timestamp"
+        },
+        {
+            "code": 6023,
+            "name": "InvalidTickArraySequence",
+            "msg": "Invalid tick array sequence provided for instruction."
+        },
+        {
+            "code": 6024,
+            "name": "InvalidTokenMintOrder",
+            "msg": "Token Mint in wrong order"
+        },
+        {
+            "code": 6025,
+            "name": "RewardNotInitialized",
+            "msg": "Reward not initialized"
+        },
+        {
+            "code": 6026,
+            "name": "InvalidRewardIndex",
+            "msg": "Invalid reward index"
+        },
+        {
+            "code": 6027,
+            "name": "RewardVaultAmountInsufficient",
+            "msg": "Reward vault requires amount to support emissions for at least one day"
+        },
+        {
+            "code": 6028,
+            "name": "FeeRateMaxExceeded",
+            "msg": "Exceeded max fee rate"
+        },
+        {
+            "code": 6029,
+            "name": "ProtocolFeeRateMaxExceeded",
+            "msg": "Exceeded max protocol fee rate"
+        },
+        {
+            "code": 6030,
+            "name": "MultiplicationShiftRightOverflow",
+            "msg": "Multiplication with shift right overflow"
+        },
+        {
+            "code": 6031,
+            "name": "MulDivOverflow",
+            "msg": "Muldiv overflow"
+        },
+        {
+            "code": 6032,
+            "name": "MulDivInvalidInput",
+            "msg": "Invalid div_u256 input"
+        },
+        {
+            "code": 6033,
+            "name": "MultiplicationOverflow",
+            "msg": "Multiplication overflow"
+        },
+        {
+            "code": 6034,
+            "name": "InvalidSqrtPriceLimitDirection",
+            "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
+        },
+        {
+            "code": 6035,
+            "name": "ZeroTradableAmount",
+            "msg": "There are no tradable amount to swap."
+        },
+        {
+            "code": 6036,
+            "name": "AmountOutBelowMinimum",
+            "msg": "Amount out below minimum threshold"
+        },
+        {
+            "code": 6037,
+            "name": "AmountInAboveMaximum",
+            "msg": "Amount in above maximum threshold"
+        },
+        {
+            "code": 6038,
+            "name": "TickArraySequenceInvalidIndex",
+            "msg": "Invalid index for tick array sequence"
+        },
+        {
+            "code": 6039,
+            "name": "AmountCalcOverflow",
+            "msg": "Amount calculated overflows"
+        },
+        {
+            "code": 6040,
+            "name": "AmountRemainingOverflow",
+            "msg": "Amount remaining overflows"
+        },
+        {
+            "code": 6041,
+            "name": "InvalidIntermediaryMint",
+            "msg": "Invalid intermediary mint"
+        },
+        {
+            "code": 6042,
+            "name": "DuplicateTwoHopPool",
+            "msg": "Duplicate two hop pool"
+        },
+        {
+            "code": 6043,
+            "name": "InvalidBundleIndex",
+            "msg": "Bundle index is out of bounds"
+        },
+        {
+            "code": 6044,
+            "name": "BundledPositionAlreadyOpened",
+            "msg": "Position has already been opened"
+        },
+        {
+            "code": 6045,
+            "name": "BundledPositionAlreadyClosed",
+            "msg": "Position has already been closed"
+        },
+        {
+            "code": 6046,
+            "name": "PositionBundleNotDeletable",
+            "msg": "Unable to delete PositionBundle with open positions"
+        },
+        {
+            "code": 6047,
+            "name": "UnsupportedTokenMint",
+            "msg": "Token mint has unsupported attributes"
+        },
+        {
+            "code": 6048,
+            "name": "RemainingAccountsInvalidSlice",
+            "msg": "Invalid remaining accounts"
+        },
+        {
+            "code": 6049,
+            "name": "RemainingAccountsInsufficient",
+            "msg": "Insufficient remaining accounts"
+        },
+        {
+            "code": 6050,
+            "name": "NoExtraAccountsForTransferHook",
+            "msg": "Unable to call transfer hook without extra accounts"
+        },
+        {
+            "code": 6051,
+            "name": "IntermediateTokenAmountMismatch",
+            "msg": "Output and input amount mismatch"
+        },
+        {
+            "code": 6052,
+            "name": "TransferFeeCalculationError",
+            "msg": "Transfer fee calculation failed"
+        },
+        {
+            "code": 6053,
+            "name": "RemainingAccountsDuplicatedAccountsType",
+            "msg": "Same accounts type is provided more than once"
+        },
+        {
+            "code": 6054,
+            "name": "FullRangeOnlyPool",
+            "msg": "This whirlpool only supports full-range positions"
+        },
+        {
+            "code": 6055,
+            "name": "TooManySupplementalTickArrays",
+            "msg": "Too many supplemental tick arrays provided"
+        },
+        {
+            "code": 6056,
+            "name": "DifferentWhirlpoolTickArrayAccount",
+            "msg": "TickArray account for different whirlpool provided"
+        },
+        {
+            "code": 6057,
+            "name": "PartialFillError",
+            "msg": "Trade resulted in partial fill"
+        },
+        {
+            "code": 6058,
+            "name": "PositionNotLockable",
+            "msg": "Position is not lockable"
+        },
+        {
+            "code": 6059,
+            "name": "OperationNotAllowedOnLockedPosition",
+            "msg": "Operation not allowed on locked position"
+        },
+        {
+            "code": 6060,
+            "name": "SameTickRangeNotAllowed",
+            "msg": "Cannot reset position range with same tick range"
+        },
+        {
+            "code": 6061,
+            "name": "InvalidAdaptiveFeeConstants",
+            "msg": "Invalid adaptive fee constants"
+        },
+        {
+            "code": 6062,
+            "name": "InvalidFeeTierIndex",
+            "msg": "Invalid fee tier index"
+        },
+        {
+            "code": 6063,
+            "name": "InvalidTradeEnableTimestamp",
+            "msg": "Invalid trade enable timestamp"
+        },
+        {
+            "code": 6064,
+            "name": "TradeIsNotEnabled",
+            "msg": "Trade is not enabled yet"
+        },
+        {
+            "code": 6065,
+            "name": "RentCalculationError",
+            "msg": "Rent calculation error"
+        },
+        {
+            "code": 6066,
+            "name": "FeatureIsNotEnabled",
+            "msg": "Feature is not enabled"
+        },
+        {
+            "code": 6067,
+            "name": "PositionWithTokenExtensionsRequired",
+            "msg": "This whirlpool only supports open_position_with_token_extensions instruction"
+        },
+        {
+            "code": 6068,
+            "name": "AdaptiveFeeConstantsUnchanged",
+            "msg": "Provided adaptive fee constants are unchanged"
+        },
+        {
+            "code": 6069,
+            "name": "PriceSlippageOutOfBounds",
+            "msg": "Price outside slippage bounds"
         }
-      ]
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "InvalidEnum",
-      "msg": "Enum value could not be converted"
-    },
-    {
-      "code": 6001,
-      "name": "InvalidStartTick",
-      "msg": "Invalid start tick index provided."
-    },
-    {
-      "code": 6002,
-      "name": "TickArrayExistInPool",
-      "msg": "Tick-array already exists in this whirlpool"
-    },
-    {
-      "code": 6003,
-      "name": "TickArrayIndexOutofBounds",
-      "msg": "Attempt to search for a tick-array failed"
-    },
-    {
-      "code": 6004,
-      "name": "InvalidTickSpacing",
-      "msg": "Tick-spacing is not supported"
-    },
-    {
-      "code": 6005,
-      "name": "ClosePositionNotEmpty",
-      "msg": "Position is not empty It cannot be closed"
-    },
-    {
-      "code": 6006,
-      "name": "DivideByZero",
-      "msg": "Unable to divide by zero"
-    },
-    {
-      "code": 6007,
-      "name": "NumberCastError",
-      "msg": "Unable to cast number into BigInt"
-    },
-    {
-      "code": 6008,
-      "name": "NumberDownCastError",
-      "msg": "Unable to down cast number"
-    },
-    {
-      "code": 6009,
-      "name": "TickNotFound",
-      "msg": "Tick not found within tick array"
-    },
-    {
-      "code": 6010,
-      "name": "InvalidTickIndex",
-      "msg": "Provided tick index is either out of bounds or uninitializable"
-    },
-    {
-      "code": 6011,
-      "name": "SqrtPriceOutOfBounds",
-      "msg": "Provided sqrt price out of bounds"
-    },
-    {
-      "code": 6012,
-      "name": "LiquidityZero",
-      "msg": "Liquidity amount must be greater than zero"
-    },
-    {
-      "code": 6013,
-      "name": "LiquidityTooHigh",
-      "msg": "Liquidity amount must be less than i64::MAX"
-    },
-    {
-      "code": 6014,
-      "name": "LiquidityOverflow",
-      "msg": "Liquidity overflow"
-    },
-    {
-      "code": 6015,
-      "name": "LiquidityUnderflow",
-      "msg": "Liquidity underflow"
-    },
-    {
-      "code": 6016,
-      "name": "LiquidityNetError",
-      "msg": "Tick liquidity net underflowed or overflowed"
-    },
-    {
-      "code": 6017,
-      "name": "TokenMaxExceeded",
-      "msg": "Exceeded token max"
-    },
-    {
-      "code": 6018,
-      "name": "TokenMinSubceeded",
-      "msg": "Did not meet token min"
-    },
-    {
-      "code": 6019,
-      "name": "MissingOrInvalidDelegate",
-      "msg": "Position token account has a missing or invalid delegate"
-    },
-    {
-      "code": 6020,
-      "name": "InvalidPositionTokenAmount",
-      "msg": "Position token amount must be 1"
-    },
-    {
-      "code": 6021,
-      "name": "InvalidTimestampConversion",
-      "msg": "Timestamp should be convertible from i64 to u64"
-    },
-    {
-      "code": 6022,
-      "name": "InvalidTimestamp",
-      "msg": "Timestamp should be greater than the last updated timestamp"
-    },
-    {
-      "code": 6023,
-      "name": "InvalidTickArraySequence",
-      "msg": "Invalid tick array sequence provided for instruction."
-    },
-    {
-      "code": 6024,
-      "name": "InvalidTokenMintOrder",
-      "msg": "Token Mint in wrong order"
-    },
-    {
-      "code": 6025,
-      "name": "RewardNotInitialized",
-      "msg": "Reward not initialized"
-    },
-    {
-      "code": 6026,
-      "name": "InvalidRewardIndex",
-      "msg": "Invalid reward index"
-    },
-    {
-      "code": 6027,
-      "name": "RewardVaultAmountInsufficient",
-      "msg": "Reward vault requires amount to support emissions for at least one day"
-    },
-    {
-      "code": 6028,
-      "name": "FeeRateMaxExceeded",
-      "msg": "Exceeded max fee rate"
-    },
-    {
-      "code": 6029,
-      "name": "ProtocolFeeRateMaxExceeded",
-      "msg": "Exceeded max protocol fee rate"
-    },
-    {
-      "code": 6030,
-      "name": "MultiplicationShiftRightOverflow",
-      "msg": "Multiplication with shift right overflow"
-    },
-    {
-      "code": 6031,
-      "name": "MulDivOverflow",
-      "msg": "Muldiv overflow"
-    },
-    {
-      "code": 6032,
-      "name": "MulDivInvalidInput",
-      "msg": "Invalid div_u256 input"
-    },
-    {
-      "code": 6033,
-      "name": "MultiplicationOverflow",
-      "msg": "Multiplication overflow"
-    },
-    {
-      "code": 6034,
-      "name": "InvalidSqrtPriceLimitDirection",
-      "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
-    },
-    {
-      "code": 6035,
-      "name": "ZeroTradableAmount",
-      "msg": "There are no tradable amount to swap."
-    },
-    {
-      "code": 6036,
-      "name": "AmountOutBelowMinimum",
-      "msg": "Amount out below minimum threshold"
-    },
-    {
-      "code": 6037,
-      "name": "AmountInAboveMaximum",
-      "msg": "Amount in above maximum threshold"
-    },
-    {
-      "code": 6038,
-      "name": "TickArraySequenceInvalidIndex",
-      "msg": "Invalid index for tick array sequence"
-    },
-    {
-      "code": 6039,
-      "name": "AmountCalcOverflow",
-      "msg": "Amount calculated overflows"
-    },
-    {
-      "code": 6040,
-      "name": "AmountRemainingOverflow",
-      "msg": "Amount remaining overflows"
-    },
-    {
-      "code": 6041,
-      "name": "InvalidIntermediaryMint",
-      "msg": "Invalid intermediary mint"
-    },
-    {
-      "code": 6042,
-      "name": "DuplicateTwoHopPool",
-      "msg": "Duplicate two hop pool"
-    },
-    {
-      "code": 6043,
-      "name": "InvalidBundleIndex",
-      "msg": "Bundle index is out of bounds"
-    },
-    {
-      "code": 6044,
-      "name": "BundledPositionAlreadyOpened",
-      "msg": "Position has already been opened"
-    },
-    {
-      "code": 6045,
-      "name": "BundledPositionAlreadyClosed",
-      "msg": "Position has already been closed"
-    },
-    {
-      "code": 6046,
-      "name": "PositionBundleNotDeletable",
-      "msg": "Unable to delete PositionBundle with open positions"
-    },
-    {
-      "code": 6047,
-      "name": "UnsupportedTokenMint",
-      "msg": "Token mint has unsupported attributes"
-    },
-    {
-      "code": 6048,
-      "name": "RemainingAccountsInvalidSlice",
-      "msg": "Invalid remaining accounts"
-    },
-    {
-      "code": 6049,
-      "name": "RemainingAccountsInsufficient",
-      "msg": "Insufficient remaining accounts"
-    },
-    {
-      "code": 6050,
-      "name": "NoExtraAccountsForTransferHook",
-      "msg": "Unable to call transfer hook without extra accounts"
-    },
-    {
-      "code": 6051,
-      "name": "IntermediateTokenAmountMismatch",
-      "msg": "Output and input amount mismatch"
-    },
-    {
-      "code": 6052,
-      "name": "TransferFeeCalculationError",
-      "msg": "Transfer fee calculation failed"
-    },
-    {
-      "code": 6053,
-      "name": "RemainingAccountsDuplicatedAccountsType",
-      "msg": "Same accounts type is provided more than once"
-    },
-    {
-      "code": 6054,
-      "name": "FullRangeOnlyPool",
-      "msg": "This whirlpool only supports full-range positions"
-    },
-    {
-      "code": 6055,
-      "name": "TooManySupplementalTickArrays",
-      "msg": "Too many supplemental tick arrays provided"
-    },
-    {
-      "code": 6056,
-      "name": "DifferentWhirlpoolTickArrayAccount",
-      "msg": "TickArray account for different whirlpool provided"
-    },
-    {
-      "code": 6057,
-      "name": "PartialFillError",
-      "msg": "Trade resulted in partial fill"
-    },
-    {
-      "code": 6058,
-      "name": "PositionNotLockable",
-      "msg": "Position is not lockable"
-    },
-    {
-      "code": 6059,
-      "name": "OperationNotAllowedOnLockedPosition",
-      "msg": "Operation not allowed on locked position"
-    },
-    {
-      "code": 6060,
-      "name": "SameTickRangeNotAllowed",
-      "msg": "Cannot reset position range with same tick range"
-    },
-    {
-      "code": 6061,
-      "name": "InvalidAdaptiveFeeConstants",
-      "msg": "Invalid adaptive fee constants"
-    },
-    {
-      "code": 6062,
-      "name": "InvalidFeeTierIndex",
-      "msg": "Invalid fee tier index"
-    },
-    {
-      "code": 6063,
-      "name": "InvalidTradeEnableTimestamp",
-      "msg": "Invalid trade enable timestamp"
-    },
-    {
-      "code": 6064,
-      "name": "TradeIsNotEnabled",
-      "msg": "Trade is not enabled yet"
-    }
-  ]
+    ],
+    "types": [
+        {
+            "name": "AccountsType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TransferHookA"
+                    },
+                    {
+                        "name": "TransferHookB"
+                    },
+                    {
+                        "name": "TransferHookReward"
+                    },
+                    {
+                        "name": "TransferHookInput"
+                    },
+                    {
+                        "name": "TransferHookIntermediate"
+                    },
+                    {
+                        "name": "TransferHookOutput"
+                    },
+                    {
+                        "name": "SupplementalTickArrays"
+                    },
+                    {
+                        "name": "SupplementalTickArraysOne"
+                    },
+                    {
+                        "name": "SupplementalTickArraysTwo"
+                    },
+                    {
+                        "name": "TransferHookDepositA"
+                    },
+                    {
+                        "name": "TransferHookDepositB"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalA"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalB"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeConstants",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_tier_index",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "initialize_pool_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "delegated_fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_base_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeVariables",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "last_reference_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "last_major_swap_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_index_reference",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "ConfigFeatureFlag",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TokenBadge",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTick",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Uninitialized"
+                    },
+                    {
+                        "name": "Initialized",
+                        "fields": [
+                            {
+                                "defined": {
+                                    "name": "DynamicTickData"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickArray",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_bitmap",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "DynamicTick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickData",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "FeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "default_fee_rate",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "IncreaseLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByTokenAmounts",
+                        "fields": [
+                            {
+                                "name": "token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "token_max_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "min_sqrt_price",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "max_sqrt_price",
+                                "type": "u128"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityDecreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityIncreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityRepositioned",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "existing_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "new_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "existing_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "existing_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_a_transfer_from_owner",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "token_b_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_b_transfer_from_owner",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_owner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "locked_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lock_type",
+                        "type": {
+                            "defined": {
+                                "name": "LockTypeLabel"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockTypeLabel",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionWithMetadataBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "metadata_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Oracle",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "trade_enable_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "adaptive_fee_constants",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeConstants"
+                            }
+                        }
+                    },
+                    {
+                        "name": "adaptive_fee_variables",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeVariables"
+                            }
+                        }
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                128
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolInitialized",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "token_program_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_program_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "decimals_a",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "decimals_b",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "initial_sqrt_price",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Position",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "PositionRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionBundle",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bundle_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_bitmap",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionOpened",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionRewardInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "growth_inside_checkpoint",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "amount_owed",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "slices",
+                        "type": {
+                            "vec": {
+                                "defined": {
+                                    "name": "RemainingAccountsSlice"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsSlice",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "accounts_type",
+                        "type": {
+                            "defined": {
+                                "name": "AccountsType"
+                            }
+                        }
+                    },
+                    {
+                        "name": "length",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RepositionLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByLiquidity",
+                        "fields": [
+                            {
+                                "name": "new_liquidity_amount",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "existing_range_token_min_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "existing_range_token_min_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_b",
+                                "type": "u64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Tick",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TickArray",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "Tick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadge",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "attribute_require_non_transferable_position",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadgeAttribute",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "RequireNonTransferablePosition",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Traded",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "a_to_b",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "pre_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "post_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "input_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "input_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lp_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Whirlpool",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool_bump",
+                        "type": {
+                            "array": [
+                                "u8",
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "fee_tier_index_seed",
+                        "type": {
+                            "array": [
+                                "u8",
+                                2
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_current_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "protocol_fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_last_updated_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "WhirlpoolRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolRewardInfo",
+            "docs": [
+                "Stores the state relevant for tracking liquidity mining rewards at the `Whirlpool` level.",
+                "These values are used in conjunction with `PositionRewardInfo`, `Tick.reward_growths_outside`,",
+                "and `Whirlpool.reward_last_updated_timestamp` to determine how many rewards are earned by open",
+                "positions."
+            ],
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "mint",
+                        "docs": [
+                            "Reward token mint."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "vault",
+                        "docs": [
+                            "Reward vault token account."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "extension",
+                        "docs": [
+                            "reward_infos[0]: Authority account that has permission to initialize the reward and set emissions.",
+                            "reward_infos[1]: used for a struct that contains fields for extending the functionality of Whirlpool.",
+                            "reward_infos[2]: reserved for future use.",
+                            "",
+                            "Historical notes:",
+                            "Originally, this was a field named \"authority\", but it was found that there was no opportunity",
+                            "to set different authorities for the three rewards. Therefore, the use of this field was changed for Whirlpool's future extensibility."
+                        ],
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "emissions_per_second_x64",
+                        "docs": [
+                            "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+                        ],
+                        "type": "u128"
+                    },
+                    {
+                        "name": "growth_global_x64",
+                        "docs": [
+                            "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+                            "emissions were turned on."
+                        ],
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "collect_protocol_fees_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "reward_emissions_super_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "feature_flags",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "config_extension_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_badge_authority",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        }
+    ]
 }

--- a/idls/raydium_cpmm.json
+++ b/idls/raydium_cpmm.json
@@ -2762,6 +2762,13 @@
             }
           },
           {
+            "name": "last_update_timestamp",
+            "docs": [
+              "the last update timestamp"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for feature update"
@@ -2769,7 +2776,7 @@
             "type": {
               "array": [
                 "u64",
-                4
+                3
               ]
             }
           }

--- a/idls/raydium_launchpad.json
+++ b/idls/raydium_launchpad.json
@@ -1109,6 +1109,79 @@
       "args": []
     },
     {
+      "name": "close_platform_global_access",
+      "docs": [
+        "Close a platform's permission to use a global config."
+      ],
+      "discriminator": [
+        123,
+        180,
+        184,
+        129,
+        111,
+        185,
+        187,
+        59
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "collect_fee",
       "docs": [
         "Collects accumulated fees from the pool",
@@ -1538,6 +1611,84 @@
           }
         }
       ]
+    },
+    {
+      "name": "create_platform_global_access",
+      "docs": [
+        "Create a platform permission to use a global config when authorization is enabled."
+      ],
+      "discriminator": [
+        162,
+        91,
+        146,
+        199,
+        93,
+        133,
+        234,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     },
     {
       "name": "create_platform_vesting_account",
@@ -4116,6 +4267,7 @@
         "* `param` - Parameter to update:",
         "- 0: Update trade_fee_rate",
         "- 1: Update fee owner",
+        "- 12: Toggle whether explicit platform authorization is required",
         "* `value` - New value for the selected parameter",
         ""
       ],
@@ -4355,6 +4507,19 @@
       ]
     },
     {
+      "name": "PlatformGlobalAccess",
+      "discriminator": [
+        174,
+        147,
+        132,
+        240,
+        137,
+        219,
+        243,
+        16
+      ]
+    },
+    {
       "name": "PoolState",
       "discriminator": [
         247,
@@ -4545,6 +4710,16 @@
       "code": 6021,
       "name": "InvalidTotalLockedAmount",
       "msg": "Total locked amount must great or equal to the platform vesting share amount"
+    },
+    {
+      "code": 6022,
+      "name": "PlatformGlobalAccessDenied",
+      "msg": "Platform is not authorized to use this global config"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidPlatformGlobalAccess",
+      "msg": "Invalid platform-global access account"
     }
   ],
   "types": [
@@ -4897,6 +5072,25 @@
             "type": "pubkey"
           },
           {
+            "name": "requires_platform_auth",
+            "docs": [
+              "Whether a platform must be explicitly authorized before using this global config"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_alignment",
+            "docs": [
+              "padding alignment"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -4904,7 +5098,7 @@
             "type": {
               "array": [
                 "u64",
-                16
+                15
               ]
             }
           }
@@ -5336,6 +5530,38 @@
               "array": [
                 "u64",
                 50
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlatformGlobalAccess",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "global_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future updates"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                8
               ]
             }
           }

--- a/src/core/account_fillers/raydium.rs
+++ b/src/core/account_fillers/raydium.rs
@@ -205,9 +205,10 @@ pub fn fill_clmm_decrease_liquidity_accounts(
 /// 10: inputTokenMint
 /// 11: outputTokenMint
 /// 12: observationState
-pub fn fill_cpmm_swap_accounts(_e: &mut RaydiumCpmmSwapEvent, _get: &AccountGetter<'_>) {
-    // pool_id, input_amount, output_amount 已从事件数据解析
-    // 其他字段不需要填充
+pub fn fill_cpmm_swap_accounts(e: &mut RaydiumCpmmSwapEvent, get: &AccountGetter<'_>) {
+    if e.pool_id == Pubkey::default() {
+        e.pool_id = get(3);
+    }
 }
 
 /// Raydium CPMM Deposit 账户填充

--- a/src/core/merger.rs
+++ b/src/core/merger.rs
@@ -26,6 +26,14 @@ use crate::core::events::*;
 /// - 预期开销 < 10ns
 #[inline(always)]
 pub fn merge_events(base: &mut DexEvent, inner: DexEvent) {
+    let _ = try_merge_events(base, inner);
+}
+
+/// Try to merge `inner` into `base`, returning the untouched event when the
+/// variants are not compatible. Instruction parsers use this to avoid
+/// silently dropping unrelated inner events that share an outer index.
+#[inline(always)]
+pub fn try_merge_events(base: &mut DexEvent, inner: DexEvent) -> Result<(), DexEvent> {
     use DexEvent::*;
 
     match (base, inner) {
@@ -141,10 +149,16 @@ pub fn merge_events(base: &mut DexEvent, inner: DexEvent) {
         (MeteoraDlmmSwap(b), MeteoraDlmmSwap(i)) => merge_generic(b, i),
         (MeteoraDlmmAddLiquidity(b), MeteoraDlmmAddLiquidity(i)) => merge_generic(b, i),
         (MeteoraDlmmRemoveLiquidity(b), MeteoraDlmmRemoveLiquidity(i)) => merge_generic(b, i),
-        (MeteoraDlmmInitializePool(b), MeteoraDlmmInitializePool(i)) => merge_generic(b, i),
+        (MeteoraDlmmInitializePool(b), MeteoraDlmmInitializePool(i)) => {
+            merge_dlmm_initialize_pool(b, i)
+        }
         (MeteoraDlmmInitializeBinArray(b), MeteoraDlmmInitializeBinArray(i)) => merge_generic(b, i),
-        (MeteoraDlmmCreatePosition(b), MeteoraDlmmCreatePosition(i)) => merge_generic(b, i),
-        (MeteoraDlmmClosePosition(b), MeteoraDlmmClosePosition(i)) => merge_generic(b, i),
+        (MeteoraDlmmCreatePosition(b), MeteoraDlmmCreatePosition(i)) => {
+            merge_dlmm_create_position(b, i)
+        }
+        (MeteoraDlmmClosePosition(b), MeteoraDlmmClosePosition(i)) => {
+            merge_dlmm_close_position(b, i)
+        }
         (MeteoraDlmmClaimFee(b), MeteoraDlmmClaimFee(i)) => merge_generic(b, i),
 
         // ========== RaydiumLaunchlab 系列 ==========
@@ -153,8 +167,10 @@ pub fn merge_events(base: &mut DexEvent, inner: DexEvent) {
         (RaydiumLaunchlabMigrateAmm(b), RaydiumLaunchlabMigrateAmm(i)) => merge_generic(b, i),
 
         // 其他组合不需要合并（类型不匹配）
-        _ => {}
+        (_, inner) => return Err(inner),
     }
+
+    Ok(())
 }
 
 /// 通用合并函数 - 对于大多数事件，inner instruction 包含完整数据
@@ -166,6 +182,40 @@ pub fn merge_events(base: &mut DexEvent, inner: DexEvent) {
 #[inline(always)]
 fn merge_generic<T>(base: &mut T, inner: T) {
     *base = inner;
+}
+
+#[inline(always)]
+fn merge_dlmm_initialize_pool(
+    base: &mut MeteoraDlmmInitializePoolEvent,
+    inner: MeteoraDlmmInitializePoolEvent,
+) {
+    let creator = base.creator;
+    let active_bin_id = base.active_bin_id;
+    *base = inner;
+    base.creator = creator;
+    base.active_bin_id = active_bin_id;
+}
+
+#[inline(always)]
+fn merge_dlmm_create_position(
+    base: &mut MeteoraDlmmCreatePositionEvent,
+    inner: MeteoraDlmmCreatePositionEvent,
+) {
+    let lower_bin_id = base.lower_bin_id;
+    let width = base.width;
+    *base = inner;
+    base.lower_bin_id = lower_bin_id;
+    base.width = width;
+}
+
+#[inline(always)]
+fn merge_dlmm_close_position(
+    base: &mut MeteoraDlmmClosePositionEvent,
+    inner: MeteoraDlmmClosePositionEvent,
+) {
+    let pool = base.pool;
+    *base = inner;
+    base.pool = pool;
 }
 
 // ============================================================================
@@ -756,6 +806,8 @@ fn merge_raydium_amm_v4_swap_log_preferred(
     fill_pk(&mut log.serum_vault_signer, ix.serum_vault_signer);
     fill_pk(&mut log.user_source_token_account, ix.user_source_token_account);
     fill_pk(&mut log.user_destination_token_account, ix.user_destination_token_account);
+    fill_pk(&mut log.user_source_owner, ix.user_source_owner);
+    fill_pk(&mut log.amm, ix.amm);
 }
 
 #[inline]
@@ -1115,6 +1167,34 @@ mod tests {
         });
 
         assert!(!can_merge(&base, &different_sig));
+    }
+
+    #[test]
+    fn dlmm_position_event_keeps_instruction_only_fields() {
+        let pool = Pubkey::new_unique();
+        let position = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mut base = DexEvent::MeteoraDlmmCreatePosition(MeteoraDlmmCreatePositionEvent {
+            metadata: EventMetadata::default(),
+            pool,
+            position,
+            owner,
+            lower_bin_id: -42,
+            width: 70,
+        });
+        let inner = DexEvent::MeteoraDlmmCreatePosition(MeteoraDlmmCreatePositionEvent {
+            metadata: EventMetadata::default(),
+            pool,
+            position,
+            owner,
+            lower_bin_id: 0,
+            width: 0,
+        });
+
+        assert!(try_merge_events(&mut base, inner).is_ok());
+        let DexEvent::MeteoraDlmmCreatePosition(event) = base else { panic!("position") };
+        assert_eq!(event.lower_bin_id, -42);
+        assert_eq!(event.width, 70);
     }
 
     #[test]

--- a/src/grpc/instruction_parser.rs
+++ b/src/grpc/instruction_parser.rs
@@ -6,7 +6,7 @@
 //! - 可读性：每个步骤都有明确的注释
 
 use crate::core::{
-    events::*, merger::merge_events, pumpfun_fee_enrich::enrich_pumpfun_same_tx_post_merge,
+    events::*, merger::try_merge_events, pumpfun_fee_enrich::enrich_pumpfun_same_tx_post_merge,
 };
 use crate::grpc::types::EventTypeFilter;
 use crate::instr::read_pubkey_fast;
@@ -14,6 +14,30 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use std::collections::HashMap;
 use yellowstone_grpc_proto::prelude::{Transaction, TransactionStatusMeta};
+
+#[derive(Debug)]
+struct IndexedInstructionEvent {
+    outer_idx: usize,
+    inner_idx: Option<usize>,
+    stack_height: Option<u32>,
+    is_dlmm_event_cpi: bool,
+    event: DexEvent,
+}
+
+#[inline(always)]
+fn is_dlmm_event(event: &DexEvent) -> bool {
+    matches!(
+        event,
+        DexEvent::MeteoraDlmmSwap(_)
+            | DexEvent::MeteoraDlmmAddLiquidity(_)
+            | DexEvent::MeteoraDlmmRemoveLiquidity(_)
+            | DexEvent::MeteoraDlmmInitializePool(_)
+            | DexEvent::MeteoraDlmmInitializeBinArray(_)
+            | DexEvent::MeteoraDlmmCreatePosition(_)
+            | DexEvent::MeteoraDlmmClosePosition(_)
+            | DexEvent::MeteoraDlmmClaimFee(_)
+    )
+}
 
 /// 解析交易中的所有指令事件（instruction + inner instruction）
 ///
@@ -93,7 +117,13 @@ pub fn parse_instructions_enhanced(
             filter,
             is_created_buy,
         ) {
-            result.push((i, None, event)); // (outer_idx, inner_idx, event)
+            result.push(IndexedInstructionEvent {
+                outer_idx: i,
+                inner_idx: None,
+                stack_height: Some(1),
+                is_dlmm_event_cpi: false,
+                event,
+            });
         }
     }
 
@@ -134,7 +164,14 @@ pub fn parse_instructions_enhanced(
             });
 
             if let Some(event) = event {
-                result.push((outer_idx, Some(j), event)); // (outer_idx, Some(inner_idx), event)
+                result.push(IndexedInstructionEvent {
+                    outer_idx,
+                    inner_idx: Some(j),
+                    stack_height: inner_ix.stack_height,
+                    is_dlmm_event_cpi: pid == crate::instr::program_ids::METEORA_DLMM_PROGRAM_ID
+                        && crate::instr::all_inner::meteora_dlmm::is_event_cpi(&inner_ix.data),
+                    event,
+                });
             }
         }
     }
@@ -428,7 +465,7 @@ fn parse_inner_instruction(
 /// 3. 同一 outer 下若有多个 inner，依次链式合并进同一条事件，再输出
 /// 4. 合并后返回更完整的事件
 #[inline(always)]
-fn merge_instruction_events(events: Vec<(usize, Option<usize>, DexEvent)>) -> Vec<DexEvent> {
+fn merge_instruction_events(events: Vec<IndexedInstructionEvent>) -> Vec<DexEvent> {
     if events.is_empty() {
         return Vec::new();
     }
@@ -436,45 +473,110 @@ fn merge_instruction_events(events: Vec<(usize, Option<usize>, DexEvent)>) -> Ve
     // 按 (outer_idx, inner_idx) 排序，确保顺序：同一 outer 下 **主指令在前、inner 在后**
     // （`None` 若用 MAX 会把 outer 排到 inner 后面，导致无法 merge）
     let mut events = events;
-    events.sort_by_key(|(outer, inner, _)| (*outer, inner.map_or(0, |i| i + 1)));
+    events.sort_unstable_by_key(|event| {
+        (event.outer_idx, event.inner_idx.map_or(0, |inner_idx| inner_idx + 1))
+    });
 
     let mut result = Vec::with_capacity(events.len());
-    let mut pending_outer: Option<(usize, DexEvent)> = None;
+    let mut outer_target: Option<(usize, usize)> = None;
+    // Solana's instruction stack is shallow; keep DLMM parent candidates on
+    // the stack so nested DLMM CPIs do not require a hot-path heap allocation.
+    let mut dlmm_targets: [Option<(usize, Option<u32>, usize)>; 8] = [None; 8];
+    let mut dlmm_targets_len = 0usize;
 
-    for (outer_idx, inner_idx, event) in events {
+    for indexed in events {
+        let IndexedInstructionEvent {
+            outer_idx,
+            inner_idx,
+            stack_height,
+            is_dlmm_event_cpi,
+            event,
+        } = indexed;
         match inner_idx {
             None => {
-                // 这是一个 outer instruction
-                // 先处理之前的 pending_outer
-                if let Some((_, outer_event)) = pending_outer.take() {
-                    result.push(outer_event);
+                let is_dlmm = is_dlmm_event(&event);
+                let target_idx = result.len();
+                result.push(event);
+                outer_target = Some((outer_idx, target_idx));
+                dlmm_targets_len = 0;
+                if is_dlmm {
+                    dlmm_targets[0] = Some((outer_idx, stack_height, target_idx));
+                    dlmm_targets_len = 1;
                 }
-                // 保存当前的 outer instruction，等待可能的 inner instruction
-                pending_outer = Some((outer_idx, event));
             }
             Some(_) => {
-                // 这是一个 inner instruction
-                if let Some((pending_outer_idx, mut outer_event)) = pending_outer.take() {
-                    if pending_outer_idx == outer_idx {
-                        // 合并进当前 outer（可多次：多段 inner 链式叠在同一条事件上）
-                        merge_events(&mut outer_event, event);
-                        pending_outer = Some((outer_idx, outer_event));
+                if is_dlmm_event_cpi {
+                    let target = (0..dlmm_targets_len).rev().find_map(|idx| {
+                        let (target_outer, target_height, target_idx) = dlmm_targets[idx]?;
+                        let is_direct_child = match (target_height, stack_height) {
+                            (Some(parent), Some(child)) => child == parent + 1,
+                            _ => true,
+                        };
+                        (target_outer == outer_idx && is_direct_child).then_some((idx, target_idx))
+                    });
+                    if let Some((candidate_idx, target_idx)) = target {
+                        dlmm_targets_len = candidate_idx + 1;
+                        if target_idx < result.len() {
+                            match try_merge_events(&mut result[target_idx], event) {
+                                Ok(()) => continue,
+                                Err(event) => result.push(event),
+                            }
+                            continue;
+                        }
+                    }
+                    result.push(event);
+                    continue;
+                }
+
+                let is_dlmm = is_dlmm_event(&event);
+                let target_idx = if let Some((target_outer, target_idx)) = outer_target {
+                    if target_outer == outer_idx {
+                        match try_merge_events(&mut result[target_idx], event) {
+                            Ok(()) => target_idx,
+                            Err(event) => {
+                                let target_idx = result.len();
+                                result.push(event);
+                                target_idx
+                            }
+                        }
                     } else {
-                        // 不匹配，分别保留
-                        result.push(outer_event);
+                        let target_idx = result.len();
                         result.push(event);
+                        target_idx
                     }
                 } else {
-                    // 没有 pending outer，直接添加 inner event
+                    let target_idx = result.len();
                     result.push(event);
+                    target_idx
+                };
+
+                if is_dlmm {
+                    if let Some(height) = stack_height {
+                        while dlmm_targets_len > 0 {
+                            let Some((candidate_outer, candidate_height, _)) =
+                                dlmm_targets[dlmm_targets_len - 1]
+                            else {
+                                break;
+                            };
+                            if candidate_outer != outer_idx
+                                || candidate_height.is_some_and(|candidate| candidate >= height)
+                            {
+                                dlmm_targets_len -= 1;
+                            } else {
+                                break;
+                            }
+                        }
+                    } else {
+                        dlmm_targets_len = 0;
+                    }
+                    if dlmm_targets_len < dlmm_targets.len() {
+                        dlmm_targets[dlmm_targets_len] =
+                            Some((outer_idx, stack_height, target_idx));
+                        dlmm_targets_len += 1;
+                    }
                 }
             }
         }
-    }
-
-    // 处理最后一个 pending_outer
-    if let Some((_, outer_event)) = pending_outer {
-        result.push(outer_event);
     }
 
     result
@@ -783,8 +885,20 @@ mod tests {
         });
 
         let events = vec![
-            (0, None, outer_event),    // outer instruction at index 0
-            (0, Some(0), inner_event), // inner instruction at index 0
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: None,
+                stack_height: Some(1),
+                is_dlmm_event_cpi: false,
+                event: outer_event,
+            },
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(0),
+                stack_height: Some(2),
+                is_dlmm_event_cpi: false,
+                event: inner_event,
+            },
         ];
 
         let result = merge_instruction_events(events);
@@ -839,8 +953,29 @@ mod tests {
             ..Default::default()
         });
 
-        let events =
-            vec![(0, None, outer_event), (0, Some(0), inner_trade), (0, Some(1), inner_fee_only)];
+        let events = vec![
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: None,
+                stack_height: Some(1),
+                is_dlmm_event_cpi: false,
+                event: outer_event,
+            },
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(0),
+                stack_height: Some(2),
+                is_dlmm_event_cpi: false,
+                event: inner_trade,
+            },
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(1),
+                stack_height: Some(2),
+                is_dlmm_event_cpi: false,
+                event: inner_fee_only,
+            },
+        ];
 
         let result = merge_instruction_events(events);
         assert_eq!(result.len(), 1);
@@ -852,6 +987,102 @@ mod tests {
         } else {
             panic!("Expected PumpFunTrade event");
         }
+    }
+
+    fn dlmm_swap(pool: Pubkey, amount_in: u64, amount_out: u64) -> DexEvent {
+        DexEvent::MeteoraDlmmSwap(MeteoraDlmmSwapEvent {
+            metadata: EventMetadata::default(),
+            pool,
+            from: Pubkey::default(),
+            start_bin_id: 0,
+            end_bin_id: 0,
+            amount_in,
+            amount_out,
+            swap_for_y: false,
+            fee: 0,
+            protocol_fee: 0,
+            fee_bps: 0,
+            host_fee: 0,
+        })
+    }
+
+    fn dlmm_add_liquidity() -> DexEvent {
+        DexEvent::MeteoraDlmmAddLiquidity(MeteoraDlmmAddLiquidityEvent {
+            metadata: EventMetadata::default(),
+            pool: Pubkey::default(),
+            from: Pubkey::default(),
+            position: Pubkey::default(),
+            amounts: [0; 2],
+            active_bin_id: 0,
+        })
+    }
+
+    #[test]
+    fn merge_preserves_unrelated_inner_events() {
+        let events = vec![
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: None,
+                stack_height: Some(1),
+                is_dlmm_event_cpi: false,
+                event: dlmm_swap(Pubkey::default(), 0, 0),
+            },
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(0),
+                stack_height: Some(2),
+                is_dlmm_event_cpi: false,
+                event: dlmm_add_liquidity(),
+            },
+        ];
+
+        let result = merge_instruction_events(events);
+        assert_eq!(result.len(), 2);
+        assert!(matches!(result[0], DexEvent::MeteoraDlmmSwap(_)));
+        assert!(matches!(result[1], DexEvent::MeteoraDlmmAddLiquidity(_)));
+    }
+
+    #[test]
+    fn merge_dlmm_inner_instruction_with_direct_event_cpi() {
+        let first_pool = Pubkey::new_unique();
+        let second_pool = Pubkey::new_unique();
+        let events = vec![
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(0),
+                stack_height: Some(2),
+                is_dlmm_event_cpi: false,
+                event: dlmm_swap(first_pool, 1, 0),
+            },
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(1),
+                stack_height: Some(3),
+                is_dlmm_event_cpi: true,
+                event: dlmm_swap(first_pool, 10, 9),
+            },
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(2),
+                stack_height: Some(2),
+                is_dlmm_event_cpi: false,
+                event: dlmm_swap(second_pool, 2, 0),
+            },
+            IndexedInstructionEvent {
+                outer_idx: 0,
+                inner_idx: Some(3),
+                stack_height: Some(3),
+                is_dlmm_event_cpi: true,
+                event: dlmm_swap(second_pool, 20, 18),
+            },
+        ];
+
+        let result = merge_instruction_events(events);
+        assert_eq!(result.len(), 2);
+        let DexEvent::MeteoraDlmmSwap(first) = &result[0] else { panic!("swap") };
+        let DexEvent::MeteoraDlmmSwap(second) = &result[1] else { panic!("swap") };
+        assert_eq!((first.pool, first.amount_in, first.amount_out), (first_pool, 10, 9));
+        assert_eq!((second.pool, second.amount_in, second.amount_out), (second_pool, 20, 18));
     }
 
     #[test]

--- a/src/grpc/log_instr_dedup.rs
+++ b/src/grpc/log_instr_dedup.rs
@@ -81,16 +81,26 @@ enum LogInstrDedupKey {
     /// `sender` 可能仅 ix 填全，不参与键以免与 log 配对失败。
     RaydiumClmmSwap {
         pool: Pubkey,
-        zero_for_one: bool,
+        occurrence: u16,
     },
-    /// 仅 `amm`：用户 ATA 常仅一路有，用 amm+ATA 会导致无法去重。
+    RaydiumCpmmSwap {
+        pool: Pubkey,
+        occurrence: u16,
+    },
     RaydiumAmmV4Swap {
-        amm: Pubkey,
+        base_out: bool,
+        instruction_amount: u64,
+        occurrence: u16,
+    },
+    OrcaWhirlpoolSwap {
+        whirlpool: Pubkey,
+        occurrence: u16,
     },
     MeteoraDlmmSwap {
         pool: Pubkey,
         from: Pubkey,
         swap_for_y: bool,
+        occurrence: u16,
     },
 }
 
@@ -108,7 +118,23 @@ fn pumpswap_ix_lane(ix_name: &str) -> u8 {
     pumpfun_ix_lane(ix_name)
 }
 
-type PumpFunLaneBase = (Pubkey, Pubkey, bool, u8);
+#[derive(Clone, Hash, PartialEq, Eq)]
+enum OccurrenceBase {
+    PumpFun { mint: Pubkey, user: Pubkey, is_buy: bool, lane: u8 },
+    RaydiumClmm(Pubkey),
+    RaydiumCpmm(Pubkey),
+    RaydiumAmmV4 { base_out: bool, amount: u64 },
+    OrcaWhirlpool(Pubkey),
+    MeteoraDlmm { pool: Pubkey, from: Pubkey, swap_for_y: bool },
+}
+
+#[inline]
+fn next_occurrence(base: OccurrenceBase, counts: &mut HashMap<OccurrenceBase, u16>) -> u16 {
+    let entry = counts.entry(base).or_insert(0);
+    let occurrence = *entry;
+    *entry = occurrence.saturating_add(1);
+    occurrence
+}
 
 #[inline]
 fn pumpfun_trade_key_with_occ(
@@ -166,40 +192,74 @@ fn log_instr_dedup_key(ev: &DexEvent) -> Option<LogInstrDedupKey> {
         PumpSwapLiquidityRemoved(r) => {
             Some(LogInstrDedupKey::PumpSwapLiquidityRemoved { pool: r.pool, user: r.user })
         }
-        RaydiumClmmSwap(s) => Some(LogInstrDedupKey::RaydiumClmmSwap {
-            pool: s.pool_state,
-            zero_for_one: s.zero_for_one,
-        }),
-        // CPMM swap 事件体无用户/ATA，仅用池+金额去重会误伤多用户同额；不参与 log/ix 折叠。
-        RaydiumCpmmSwap(_) => None,
-        RaydiumAmmV4Swap(s) => Some(LogInstrDedupKey::RaydiumAmmV4Swap { amm: s.amm }),
-        // Orca swap 事件体当前无 token authority / 用户 ATA 字段，无法安全区分用户。
+        RaydiumClmmSwap(_) => None,
+        RaydiumCpmmSwap(_) | RaydiumAmmV4Swap(_) => None,
         OrcaWhirlpoolSwap(_) => None,
         MeteoraDammV2Swap(_) => None,
-        MeteoraDlmmSwap(s) => Some(LogInstrDedupKey::MeteoraDlmmSwap {
-            pool: s.pool,
-            from: s.from,
-            swap_for_y: s.swap_for_y,
-        }),
+        MeteoraDlmmSwap(_) => None,
         // 无稳定链上指纹或其它路径：不去重
         _ => None,
     }
 }
 
 #[inline]
-fn next_pumpfun_dedup_key(
+fn next_dedup_key(
     ev: &DexEvent,
-    lane_count: &mut HashMap<PumpFunLaneBase, u16>,
+    occurrence_counts: &mut HashMap<OccurrenceBase, u16>,
 ) -> Option<LogInstrDedupKey> {
     use DexEvent::*;
     match ev {
         PumpFunTrade(t) | PumpFunBuy(t) | PumpFunSell(t) | PumpFunBuyExactSolIn(t) => {
             let lane = pumpfun_ix_lane(t.ix_name.as_str());
-            let base = (t.mint, t.user, t.is_buy, lane);
-            let entry = lane_count.entry(base).or_insert(0);
-            let occ = *entry;
-            *entry = occ.saturating_add(1);
+            let occ = next_occurrence(
+                OccurrenceBase::PumpFun { mint: t.mint, user: t.user, is_buy: t.is_buy, lane },
+                occurrence_counts,
+            );
             Some(pumpfun_trade_key_with_occ(t, occ))
+        }
+        RaydiumClmmSwap(s) => {
+            let occurrence =
+                next_occurrence(OccurrenceBase::RaydiumClmm(s.pool_state), occurrence_counts);
+            Some(LogInstrDedupKey::RaydiumClmmSwap { pool: s.pool_state, occurrence })
+        }
+        RaydiumCpmmSwap(s) => {
+            let occurrence =
+                next_occurrence(OccurrenceBase::RaydiumCpmm(s.pool_id), occurrence_counts);
+            Some(LogInstrDedupKey::RaydiumCpmmSwap { pool: s.pool_id, occurrence })
+        }
+        RaydiumAmmV4Swap(s) => {
+            let base_out = s.max_amount_in != 0;
+            let amount = if base_out { s.amount_out } else { s.amount_in };
+            let occurrence = next_occurrence(
+                OccurrenceBase::RaydiumAmmV4 { base_out, amount },
+                occurrence_counts,
+            );
+            Some(LogInstrDedupKey::RaydiumAmmV4Swap {
+                base_out,
+                instruction_amount: amount,
+                occurrence,
+            })
+        }
+        OrcaWhirlpoolSwap(s) => {
+            let occurrence =
+                next_occurrence(OccurrenceBase::OrcaWhirlpool(s.whirlpool), occurrence_counts);
+            Some(LogInstrDedupKey::OrcaWhirlpoolSwap { whirlpool: s.whirlpool, occurrence })
+        }
+        MeteoraDlmmSwap(s) => {
+            let occurrence = next_occurrence(
+                OccurrenceBase::MeteoraDlmm {
+                    pool: s.pool,
+                    from: s.from,
+                    swap_for_y: s.swap_for_y,
+                },
+                occurrence_counts,
+            );
+            Some(LogInstrDedupKey::MeteoraDlmmSwap {
+                pool: s.pool,
+                from: s.from,
+                swap_for_y: s.swap_for_y,
+                occurrence,
+            })
         }
         _ => log_instr_dedup_key(ev),
     }
@@ -213,10 +273,10 @@ pub(crate) fn dedupe_log_instruction_events(
     let cap = log_events.len().saturating_add(instr_events.len());
     let mut out: Vec<DexEvent> = Vec::with_capacity(cap);
     let mut idx_by_key: HashMap<LogInstrDedupKey, usize> = HashMap::new();
-    let mut pump_lane_log: HashMap<PumpFunLaneBase, u16> = HashMap::new();
+    let mut log_occurrences: HashMap<OccurrenceBase, u16> = HashMap::new();
 
     for e in log_events {
-        if let Some(k) = next_pumpfun_dedup_key(&e, &mut pump_lane_log) {
+        if let Some(k) = next_dedup_key(&e, &mut log_occurrences) {
             idx_by_key.insert(k, out.len());
             out.push(e);
         } else {
@@ -224,9 +284,9 @@ pub(crate) fn dedupe_log_instruction_events(
         }
     }
 
-    let mut pump_lane_ix: HashMap<PumpFunLaneBase, u16> = HashMap::new();
+    let mut ix_occurrences: HashMap<OccurrenceBase, u16> = HashMap::new();
     for e in instr_events {
-        if let Some(k) = next_pumpfun_dedup_key(&e, &mut pump_lane_ix) {
+        if let Some(k) = next_dedup_key(&e, &mut ix_occurrences) {
             if let Some(&idx) = idx_by_key.get(&k) {
                 crate::core::merger::merge_grpc_instruction_into_log(&mut out[idx], e);
             } else {
@@ -306,6 +366,51 @@ mod tests {
             }
             e => panic!("expected PumpFunTrade (保留 log 变体), got {:?}", e),
         }
+    }
+
+    fn clmm_swap(pool: Pubkey, zero_for_one: bool, amount_0: u64) -> DexEvent {
+        DexEvent::RaydiumClmmSwap(crate::core::events::RaydiumClmmSwapEvent {
+            metadata: dummy_meta(),
+            pool_state: pool,
+            sender: Pubkey::default(),
+            token_account_0: Pubkey::default(),
+            token_account_1: Pubkey::default(),
+            amount_0,
+            transfer_fee_0: 0,
+            amount_1: 0,
+            transfer_fee_1: 0,
+            zero_for_one,
+            sqrt_price_x64: 0,
+            liquidity: 0,
+            tick: 0,
+        })
+    }
+
+    #[test]
+    fn clmm_log_ix_dedup_ignores_instruction_placeholder_direction() {
+        let pool = Pubkey::new_unique();
+        let merged = dedupe_log_instruction_events(
+            vec![clmm_swap(pool, false, 123)],
+            vec![clmm_swap(pool, true, 0)],
+        );
+        assert_eq!(merged.len(), 1);
+        match &merged[0] {
+            DexEvent::RaydiumClmmSwap(s) => {
+                assert_eq!(s.amount_0, 123);
+                assert!(!s.zero_for_one);
+            }
+            other => panic!("expected RaydiumClmmSwap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clmm_same_pool_occurrences_are_retained() {
+        let pool = Pubkey::new_unique();
+        let merged = dedupe_log_instruction_events(
+            vec![clmm_swap(pool, false, 1), clmm_swap(pool, true, 2)],
+            vec![clmm_swap(pool, true, 0), clmm_swap(pool, false, 0)],
+        );
+        assert_eq!(merged.len(), 2);
     }
 
     #[test]

--- a/src/instr/all_inner/meteora_dlmm.rs
+++ b/src/instr/all_inner/meteora_dlmm.rs
@@ -16,38 +16,154 @@ use solana_sdk::pubkey::Pubkey;
 // - **启用**: `cargo build --features parse-zero-copy --no-default-features`
 // - 特点：最高性能、零内存分配、直接读取内存
 pub mod discriminators {
-    // 16-byte discriminators: 8-byte event hash + 8-byte magic
-    pub const SWAP: [u8; 16] =
-        [143, 190, 90, 218, 196, 30, 51, 222, 155, 167, 108, 32, 122, 76, 173, 64];
-    pub const ADD_LIQUIDITY: [u8; 16] =
-        [181, 157, 89, 67, 143, 182, 52, 72, 155, 167, 108, 32, 122, 76, 173, 64];
-    pub const REMOVE_LIQUIDITY: [u8; 16] =
-        [80, 85, 209, 72, 24, 206, 35, 178, 155, 167, 108, 32, 122, 76, 173, 64];
-    pub const INITIALIZE_POOL: [u8; 16] =
-        [95, 180, 10, 172, 84, 174, 232, 40, 155, 167, 108, 32, 122, 76, 173, 64];
-    pub const INITIALIZE_BIN_ARRAY: [u8; 16] =
-        [11, 18, 155, 194, 33, 115, 238, 119, 155, 167, 108, 32, 122, 76, 173, 64];
-    pub const CREATE_POSITION: [u8; 16] =
-        [123, 233, 11, 43, 146, 180, 97, 119, 155, 167, 108, 32, 122, 76, 173, 64];
-    pub const CLOSE_POSITION: [u8; 16] =
-        [94, 168, 102, 45, 59, 122, 137, 54, 155, 167, 108, 32, 122, 76, 173, 64];
-    pub const CLAIM_FEE: [u8; 16] =
-        [152, 70, 208, 111, 104, 91, 44, 1, 155, 167, 108, 32, 122, 76, 173, 64];
+    pub const SWAP: [u8; 8] = [81, 108, 227, 190, 205, 208, 10, 196];
+    pub const SWAP2: [u8; 8] = [46, 116, 82, 215, 148, 27, 84, 77];
+    pub const ADD_LIQUIDITY: [u8; 8] = [31, 94, 125, 90, 227, 52, 61, 186];
+    pub const REMOVE_LIQUIDITY: [u8; 8] = [116, 244, 97, 232, 103, 31, 152, 58];
+    pub const INITIALIZE_POOL: [u8; 8] = [185, 74, 252, 125, 27, 215, 188, 111];
+    pub const INITIALIZE_BIN_ARRAY: [u8; 8] = [11, 18, 155, 194, 33, 115, 238, 119];
+    pub const CREATE_POSITION: [u8; 8] = [144, 142, 252, 84, 157, 53, 37, 121];
+    pub const CLOSE_POSITION: [u8; 8] = [255, 196, 16, 107, 28, 202, 53, 128];
+    pub const CLAIM_FEE: [u8; 8] = [75, 122, 154, 48, 140, 74, 123, 163];
+    pub const CLAIM_FEE2: [u8; 8] = [232, 171, 242, 97, 58, 77, 35, 45];
+}
+
+const EVENT_CPI_PREFIX: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+const LEGACY_EVENT_CPI_SUFFIX: [u8; 8] = [155, 167, 108, 32, 122, 76, 173, 64];
+
+#[inline(always)]
+pub(crate) fn is_event_cpi(data: &[u8]) -> bool {
+    data.len() >= 16 && (data[..8] == EVENT_CPI_PREFIX || data[8..16] == LEGACY_EVENT_CPI_SUFFIX)
+}
+
+#[inline(always)]
+fn event_discriminator(disc: &[u8; 16]) -> Option<[u8; 8]> {
+    if disc[..8] == EVENT_CPI_PREFIX {
+        return disc[8..].try_into().ok();
+    }
+    if disc[8..] == LEGACY_EVENT_CPI_SUFFIX {
+        return disc[..8].try_into().ok();
+    }
+    None
 }
 
 /// 主入口：根据 discriminator 解析事件
 #[inline]
 pub fn parse(disc: &[u8; 16], data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    match *disc {
+    match event_discriminator(disc)? {
         discriminators::SWAP => parse_swap(data, metadata),
+        discriminators::SWAP2 => parse_swap2(data, metadata),
         discriminators::ADD_LIQUIDITY => parse_add_liquidity(data, metadata),
         discriminators::REMOVE_LIQUIDITY => parse_remove_liquidity(data, metadata),
-        discriminators::INITIALIZE_POOL => parse_initialize_pool(data, metadata),
+        discriminators::INITIALIZE_POOL => parse_lb_pair_create(data, metadata),
         discriminators::INITIALIZE_BIN_ARRAY => parse_initialize_bin_array(data, metadata),
-        discriminators::CREATE_POSITION => parse_create_position(data, metadata),
-        discriminators::CLOSE_POSITION => parse_close_position(data, metadata),
+        discriminators::CREATE_POSITION => parse_position_create(data, metadata),
+        discriminators::CLOSE_POSITION => parse_position_close(data, metadata),
         discriminators::CLAIM_FEE => parse_claim_fee(data, metadata),
+        discriminators::CLAIM_FEE2 => parse_claim_fee2(data, metadata),
         _ => None,
+    }
+}
+
+#[inline(always)]
+fn parse_lb_pair_create(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    unsafe {
+        if !check_length(data, 32 + 2 + 32 + 32) {
+            return None;
+        }
+        let pool = read_pubkey_unchecked(data, 0);
+        Some(DexEvent::MeteoraDlmmInitializePool(MeteoraDlmmInitializePoolEvent {
+            metadata,
+            pool,
+            creator: Pubkey::default(),
+            active_bin_id: 0,
+            bin_step: read_u16_unchecked(data, 32),
+        }))
+    }
+}
+
+#[inline(always)]
+fn parse_position_create(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    unsafe {
+        if !check_length(data, 32 + 32 + 32) {
+            return None;
+        }
+        Some(DexEvent::MeteoraDlmmCreatePosition(MeteoraDlmmCreatePositionEvent {
+            metadata,
+            pool: read_pubkey_unchecked(data, 0),
+            position: read_pubkey_unchecked(data, 32),
+            owner: read_pubkey_unchecked(data, 64),
+            lower_bin_id: 0,
+            width: 0,
+        }))
+    }
+}
+
+#[inline(always)]
+fn parse_position_close(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    unsafe {
+        if !check_length(data, 32 + 32) {
+            return None;
+        }
+        Some(DexEvent::MeteoraDlmmClosePosition(MeteoraDlmmClosePositionEvent {
+            metadata,
+            pool: Pubkey::default(),
+            position: read_pubkey_unchecked(data, 0),
+            owner: read_pubkey_unchecked(data, 32),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn swap2_payload() -> Vec<u8> {
+        let mut data = vec![0u8; 147];
+        data[72] = 1;
+        data[73..89].copy_from_slice(&25u128.to_le_bytes());
+        data[89..97].copy_from_slice(&100u64.to_le_bytes());
+        data[105..113].copy_from_slice(&90u64.to_le_bytes());
+        data[113..121].copy_from_slice(&3u64.to_le_bytes());
+        data[121..129].copy_from_slice(&2u64.to_le_bytes());
+        data[137..145].copy_from_slice(&1u64.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn parses_current_anchor_event_cpi_prefix_layout() {
+        let mut disc = [0u8; 16];
+        disc[..8].copy_from_slice(&EVENT_CPI_PREFIX);
+        disc[8..].copy_from_slice(&discriminators::SWAP2);
+
+        let event = parse(&disc, &swap2_payload(), EventMetadata::default()).expect("swap2");
+        let DexEvent::MeteoraDlmmSwap(event) = event else {
+            panic!("unexpected event");
+        };
+        assert_eq!(event.amount_in, 100);
+        assert_eq!(event.amount_out, 90);
+        assert_eq!(event.fee, 3);
+    }
+
+    #[test]
+    fn keeps_legacy_event_cpi_suffix_layout() {
+        let mut disc = [0u8; 16];
+        disc[..8].copy_from_slice(&discriminators::SWAP2);
+        disc[8..].copy_from_slice(&LEGACY_EVENT_CPI_SUFFIX);
+        assert!(parse(&disc, &swap2_payload(), EventMetadata::default()).is_some());
+    }
+
+    #[test]
+    fn current_position_events_use_current_idl_lengths() {
+        let mut create_disc = [0u8; 16];
+        create_disc[..8].copy_from_slice(&EVENT_CPI_PREFIX);
+        create_disc[8..].copy_from_slice(&discriminators::CREATE_POSITION);
+        assert!(parse(&create_disc, &[0u8; 96], EventMetadata::default()).is_some());
+
+        let mut close_disc = [0u8; 16];
+        close_disc[..8].copy_from_slice(&EVENT_CPI_PREFIX);
+        close_disc[8..].copy_from_slice(&discriminators::CLOSE_POSITION);
+        assert!(parse(&close_disc, &[0u8; 64], EventMetadata::default()).is_some());
     }
 }
 
@@ -67,6 +183,48 @@ fn parse_swap(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
     {
         parse_swap_zero_copy(data, metadata)
     }
+}
+
+#[inline(always)]
+fn parse_swap2(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    unsafe {
+        if !check_length(data, 32 + 32 + 4 + 4 + 1 + 16 + 8 + 8 + 8 + 8 + 8 + 8 + 8 + 1 + 1) {
+            return None;
+        }
+        let pool = read_pubkey_unchecked(data, 0);
+        let from = read_pubkey_unchecked(data, 32);
+        let start_bin_id = read_i32_unchecked(data, 64);
+        let end_bin_id = read_i32_unchecked(data, 68);
+        let swap_for_y = read_bool_unchecked(data, 72);
+        let fee_bps = read_u128_unchecked(data, 73);
+        let amount_in = read_u64_unchecked(data, 89);
+        let amount_out = read_u64_unchecked(data, 105);
+        let fee = read_u64_unchecked(data, 113);
+        let protocol_fee = read_u64_unchecked(data, 121);
+        let host_fee = read_u64_unchecked(data, 137);
+        Some(DexEvent::MeteoraDlmmSwap(MeteoraDlmmSwapEvent {
+            metadata,
+            pool,
+            from,
+            start_bin_id,
+            end_bin_id,
+            amount_in,
+            amount_out,
+            swap_for_y,
+            fee,
+            protocol_fee,
+            fee_bps,
+            host_fee,
+        }))
+    }
+}
+
+#[inline(always)]
+fn parse_claim_fee2(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    if data.len() < 116 {
+        return None;
+    }
+    parse_claim_fee(data, metadata)
 }
 
 /// Borsh 解析器 - Swap
@@ -241,63 +399,6 @@ fn parse_remove_liquidity_zero_copy(data: &[u8], metadata: EventMetadata) -> Opt
 }
 
 // ============================================================================
-// Initialize Pool Event
-// ============================================================================
-
-/// 解析 Initialize Pool 事件（统一入口）
-#[inline(always)]
-fn parse_initialize_pool(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    #[cfg(all(feature = "parse-borsh", not(feature = "parse-zero-copy")))]
-    {
-        parse_initialize_pool_borsh(data, metadata)
-    }
-
-    #[cfg(feature = "parse-zero-copy")]
-    {
-        parse_initialize_pool_zero_copy(data, metadata)
-    }
-}
-
-/// Borsh 解析器 - Initialize Pool
-#[cfg(all(feature = "parse-borsh", not(feature = "parse-zero-copy")))]
-#[inline(always)]
-fn parse_initialize_pool_borsh(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    // pool(32) + creator(32) + active_bin_id(4) + bin_step(2) = 70 bytes
-    const INITIALIZE_POOL_EVENT_SIZE: usize = 32 + 32 + 4 + 2;
-    if data.len() < INITIALIZE_POOL_EVENT_SIZE {
-        return None;
-    }
-
-    let mut event =
-        borsh::from_slice::<MeteoraDlmmInitializePoolEvent>(&data[..INITIALIZE_POOL_EVENT_SIZE])
-            .ok()?;
-    event.metadata = metadata;
-    Some(DexEvent::MeteoraDlmmInitializePool(event))
-}
-
-/// 零拷贝解析器 - Initialize Pool
-#[cfg(feature = "parse-zero-copy")]
-#[inline(always)]
-fn parse_initialize_pool_zero_copy(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    unsafe {
-        if !check_length(data, 32 + 32 + 4 + 2) {
-            return None;
-        }
-        let pool = read_pubkey_unchecked(data, 0);
-        let creator = read_pubkey_unchecked(data, 32);
-        let active_bin_id = read_i32_unchecked(data, 64);
-        let bin_step = read_u16_unchecked(data, 68);
-        Some(DexEvent::MeteoraDlmmInitializePool(MeteoraDlmmInitializePoolEvent {
-            metadata,
-            pool,
-            creator,
-            active_bin_id,
-            bin_step,
-        }))
-    }
-}
-
-// ============================================================================
 // Initialize Bin Array Event
 // ============================================================================
 
@@ -349,120 +450,6 @@ fn parse_initialize_bin_array_zero_copy(data: &[u8], metadata: EventMetadata) ->
             pool,
             bin_array,
             index,
-        }))
-    }
-}
-
-// ============================================================================
-// Create Position Event
-// ============================================================================
-
-/// 解析 Create Position 事件（统一入口）
-#[inline(always)]
-fn parse_create_position(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    #[cfg(all(feature = "parse-borsh", not(feature = "parse-zero-copy")))]
-    {
-        parse_create_position_borsh(data, metadata)
-    }
-
-    #[cfg(feature = "parse-zero-copy")]
-    {
-        parse_create_position_zero_copy(data, metadata)
-    }
-}
-
-/// Borsh 解析器 - Create Position
-#[cfg(all(feature = "parse-borsh", not(feature = "parse-zero-copy")))]
-#[inline(always)]
-fn parse_create_position_borsh(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    // pool(32) + position(32) + owner(32) + lower_bin_id(4) + width(4) = 104 bytes
-    const CREATE_POSITION_EVENT_SIZE: usize = 32 + 32 + 32 + 4 + 4;
-    if data.len() < CREATE_POSITION_EVENT_SIZE {
-        return None;
-    }
-
-    let mut event =
-        borsh::from_slice::<MeteoraDlmmCreatePositionEvent>(&data[..CREATE_POSITION_EVENT_SIZE])
-            .ok()?;
-    event.metadata = metadata;
-    Some(DexEvent::MeteoraDlmmCreatePosition(event))
-}
-
-/// 零拷贝解析器 - Create Position
-#[cfg(feature = "parse-zero-copy")]
-#[inline(always)]
-fn parse_create_position_zero_copy(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    unsafe {
-        if !check_length(data, 32 + 32 + 32 + 4 + 4) {
-            return None;
-        }
-        let pool = read_pubkey_unchecked(data, 0);
-        let position = read_pubkey_unchecked(data, 32);
-        let owner = read_pubkey_unchecked(data, 64);
-        let lower_bin_id = read_i32_unchecked(data, 96);
-        let width = read_u32_unchecked(data, 100);
-        Some(DexEvent::MeteoraDlmmCreatePosition(MeteoraDlmmCreatePositionEvent {
-            metadata,
-            pool,
-            position,
-            owner,
-            lower_bin_id,
-            width,
-        }))
-    }
-}
-
-// ============================================================================
-// Close Position Event
-// ============================================================================
-
-/// 解析 Close Position 事件（统一入口）
-#[inline(always)]
-fn parse_close_position(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    #[cfg(all(feature = "parse-borsh", not(feature = "parse-zero-copy")))]
-    {
-        parse_close_position_borsh(data, metadata)
-    }
-
-    #[cfg(feature = "parse-zero-copy")]
-    {
-        parse_close_position_zero_copy(data, metadata)
-    }
-}
-
-/// Borsh 解析器 - Close Position
-#[cfg(all(feature = "parse-borsh", not(feature = "parse-zero-copy")))]
-#[inline(always)]
-fn parse_close_position_borsh(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    // pool(32) + position(32) + owner(32) = 96 bytes
-    const CLOSE_POSITION_EVENT_SIZE: usize = 32 + 32 + 32;
-    if data.len() < CLOSE_POSITION_EVENT_SIZE {
-        return None;
-    }
-
-    let mut event =
-        borsh::from_slice::<MeteoraDlmmClosePositionEvent>(&data[..CLOSE_POSITION_EVENT_SIZE])
-            .ok()?;
-    event.metadata = metadata;
-    Some(DexEvent::MeteoraDlmmClosePosition(event))
-}
-
-/// 零拷贝解析器 - Close Position
-#[cfg(feature = "parse-zero-copy")]
-#[inline(always)]
-fn parse_close_position_zero_copy(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
-    unsafe {
-        if !check_length(data, 32 + 32 + 32) {
-            return None;
-        }
-        let pool = read_pubkey_unchecked(data, 0);
-        let position = read_pubkey_unchecked(data, 32);
-        let owner = read_pubkey_unchecked(data, 64);
-        Some(DexEvent::MeteoraDlmmClosePosition(MeteoraDlmmClosePositionEvent {
-            metadata,
-            pool,
-            position,
-            owner,
         }))
     }
 }

--- a/src/instr/meteora_dlmm.rs
+++ b/src/instr/meteora_dlmm.rs
@@ -7,51 +7,27 @@ use super::utils::*;
 use crate::core::events::*;
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 
-/// Meteora DLMM 指令类型枚举
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MeteoraDlmmInstruction {
-    InitializeLbPair = 0,
-    InitializeBinArray = 1,
-    AddLiquidity = 2,
-    AddLiquidityByWeight = 3,
-    AddLiquidityByStrategy = 4,
-    AddLiquidityByStrategyOneSide = 5,
-    AddLiquidityOneSide = 6,
-    RemoveLiquidity = 7,
-    InitializePosition = 8,
-    UpdatePosition = 9,
-    WithdrawIneligibleReward = 10,
-    Swap = 11,
-    ClaimReward = 12,
-    ClaimFee = 13,
-    ClosePosition = 14,
-    UpdateRewardFunder = 15,
-    UpdateRewardDuration = 16,
-    FundReward = 17,
-    InitializeReward = 18,
-    SetActivationSlot = 19,
-    UpdateWhitelistedWallet = 20,
-    MigratePosition = 21,
-    MigrateBinArray = 22,
-    UpdateFeesAndRewards = 23,
-    SwapWithPriceImpact = 24,
-    GoToABin = 25,
-    SetPreActivationSwapAddress = 26,
-    SetLockReleaseSlot = 27,
-    RemoveAllLiquidity = 28,
-    TogglePairStatus = 29,
-    UpdateSwapCapDeactivateSlot = 30,
-    CreateConfig = 31,
-    CreateClaimFeeOperator = 32,
-    CloseClaimFeeOperator = 33,
-    ClaimPartnerFee = 34,
-    ClaimProtocolFee = 35,
-    CloseConfig = 36,
-    SetPoolStatus = 37,
-    UpdateLockDuration = 38,
-    CreatePool = 39,
-    SetPresetParameter = 40,
-    RemovePresetParameter = 41,
+pub mod discriminators {
+    pub const ADD_LIQUIDITY: [u8; 8] = [181, 157, 89, 67, 143, 182, 52, 72];
+    pub const ADD_LIQUIDITY2: [u8; 8] = [228, 162, 78, 28, 70, 219, 116, 115];
+    pub const CLAIM_FEE: [u8; 8] = [169, 32, 79, 137, 136, 232, 70, 137];
+    pub const CLAIM_FEE2: [u8; 8] = [112, 191, 101, 171, 28, 144, 127, 187];
+    pub const CLOSE_POSITION: [u8; 8] = [123, 134, 81, 0, 49, 68, 98, 98];
+    pub const CLOSE_POSITION2: [u8; 8] = [174, 90, 35, 115, 186, 40, 147, 226];
+    pub const INITIALIZE_BIN_ARRAY: [u8; 8] = [35, 86, 19, 185, 78, 212, 75, 211];
+    pub const INITIALIZE_LB_PAIR: [u8; 8] = [45, 154, 237, 210, 221, 15, 166, 92];
+    pub const INITIALIZE_LB_PAIR2: [u8; 8] = [73, 59, 36, 120, 237, 83, 108, 198];
+    pub const INITIALIZE_POSITION: [u8; 8] = [219, 192, 234, 71, 190, 191, 102, 80];
+    pub const INITIALIZE_POSITION2: [u8; 8] = [143, 19, 242, 145, 213, 15, 104, 115];
+    pub const INITIALIZE_POSITION_PDA: [u8; 8] = [46, 82, 125, 146, 85, 141, 228, 153];
+    pub const REMOVE_LIQUIDITY: [u8; 8] = [80, 85, 209, 72, 24, 206, 177, 108];
+    pub const REMOVE_LIQUIDITY2: [u8; 8] = [230, 215, 82, 127, 241, 101, 227, 146];
+    pub const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+    pub const SWAP2: [u8; 8] = [65, 75, 63, 76, 235, 91, 91, 136];
+    pub const SWAP_EXACT_OUT: [u8; 8] = [250, 73, 101, 33, 38, 207, 75, 184];
+    pub const SWAP_EXACT_OUT2: [u8; 8] = [43, 215, 247, 132, 137, 60, 243, 81];
+    pub const SWAP_WITH_PRICE_IMPACT: [u8; 8] = [56, 173, 230, 208, 173, 228, 156, 205];
+    pub const SWAP_WITH_PRICE_IMPACT2: [u8; 8] = [74, 98, 192, 214, 177, 51, 75, 51];
 }
 
 /// Meteora DLMM 程序 ID (使用常量)
@@ -66,15 +42,15 @@ pub fn parse_instruction(
     tx_index: u64,
     block_time_us: Option<i64>,
 ) -> Option<DexEvent> {
-    if instruction_data.is_empty() {
+    if instruction_data.len() < 8 {
         return None;
     }
 
-    let instruction_type = instruction_data[0];
-    let data = &instruction_data[1..];
+    let discriminator: [u8; 8] = instruction_data[..8].try_into().ok()?;
+    let data = &instruction_data[8..];
 
-    match instruction_type {
-        0 => parse_initialize_lb_pair_instruction(
+    match discriminator {
+        discriminators::INITIALIZE_LB_PAIR => parse_initialize_lb_pair_instruction(
             data,
             accounts,
             signature,
@@ -82,7 +58,7 @@ pub fn parse_instruction(
             tx_index,
             block_time_us,
         ),
-        1 => parse_initialize_bin_array_instruction(
+        discriminators::INITIALIZE_LB_PAIR2 => parse_initialize_lb_pair2_instruction(
             data,
             accounts,
             signature,
@@ -90,7 +66,7 @@ pub fn parse_instruction(
             tx_index,
             block_time_us,
         ),
-        2 => parse_add_liquidity_instruction(
+        discriminators::INITIALIZE_BIN_ARRAY => parse_initialize_bin_array_instruction(
             data,
             accounts,
             signature,
@@ -98,27 +74,94 @@ pub fn parse_instruction(
             tx_index,
             block_time_us,
         ),
-        7 => parse_remove_liquidity_instruction(
-            data,
+        discriminators::ADD_LIQUIDITY => {
+            parse_add_liquidity_instruction(accounts, 11, signature, slot, tx_index, block_time_us)
+        }
+        discriminators::ADD_LIQUIDITY2 => {
+            parse_add_liquidity_instruction(accounts, 9, signature, slot, tx_index, block_time_us)
+        }
+        discriminators::REMOVE_LIQUIDITY => parse_remove_liquidity_instruction(
             accounts,
+            11,
             signature,
             slot,
             tx_index,
             block_time_us,
         ),
-        8 => parse_initialize_position_instruction(
-            data,
+        discriminators::REMOVE_LIQUIDITY2 => parse_remove_liquidity_instruction(
             accounts,
+            9,
             signature,
             slot,
             tx_index,
             block_time_us,
         ),
-        11 => parse_swap_instruction(data, accounts, signature, slot, tx_index, block_time_us),
-        13 => parse_claim_fee_instruction(data, accounts, signature, slot, tx_index, block_time_us),
-        14 => parse_close_position_instruction(
+        discriminators::INITIALIZE_POSITION | discriminators::INITIALIZE_POSITION2 => {
+            parse_initialize_position_instruction(
+                data,
+                accounts,
+                1,
+                2,
+                3,
+                signature,
+                slot,
+                tx_index,
+                block_time_us,
+            )
+        }
+        discriminators::INITIALIZE_POSITION_PDA => parse_initialize_position_instruction(
             data,
             accounts,
+            2,
+            3,
+            4,
+            signature,
+            slot,
+            tx_index,
+            block_time_us,
+        ),
+        discriminators::SWAP | discriminators::SWAP2 => {
+            parse_swap_instruction(data, accounts, signature, slot, tx_index, block_time_us)
+        }
+        discriminators::SWAP_EXACT_OUT | discriminators::SWAP_EXACT_OUT2 => {
+            parse_swap_exact_out_instruction(
+                data,
+                accounts,
+                signature,
+                slot,
+                tx_index,
+                block_time_us,
+            )
+        }
+        discriminators::SWAP_WITH_PRICE_IMPACT | discriminators::SWAP_WITH_PRICE_IMPACT2 => {
+            parse_swap_with_price_impact_instruction(
+                data,
+                accounts,
+                signature,
+                slot,
+                tx_index,
+                block_time_us,
+            )
+        }
+        discriminators::CLAIM_FEE => {
+            parse_claim_fee_instruction(accounts, 4, signature, slot, tx_index, block_time_us)
+        }
+        discriminators::CLAIM_FEE2 => {
+            parse_claim_fee_instruction(accounts, 2, signature, slot, tx_index, block_time_us)
+        }
+        discriminators::CLOSE_POSITION => parse_close_position_instruction(
+            accounts,
+            Some(1),
+            4,
+            signature,
+            slot,
+            tx_index,
+            block_time_us,
+        ),
+        discriminators::CLOSE_POSITION2 => parse_close_position_instruction(
+            accounts,
+            None,
+            1,
             signature,
             slot,
             tx_index,
@@ -126,6 +169,28 @@ pub fn parse_instruction(
         ),
         _ => None,
     }
+}
+
+/// Parse an `initialize_lb_pair2` instruction.
+fn parse_initialize_lb_pair2_instruction(
+    data: &[u8],
+    accounts: &[Pubkey],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+) -> Option<DexEvent> {
+    let active_id = read_i32_le(data, 0)?;
+    let pool = get_account(accounts, 0)?;
+    let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
+
+    Some(DexEvent::MeteoraDlmmInitializePool(MeteoraDlmmInitializePoolEvent {
+        metadata,
+        pool,
+        creator: get_account(accounts, 8).unwrap_or_default(),
+        active_bin_id: active_id,
+        bin_step: 0,
+    }))
 }
 
 /// 解析初始化LB池指令
@@ -139,7 +204,7 @@ fn parse_initialize_lb_pair_instruction(
 ) -> Option<DexEvent> {
     let mut offset = 0;
 
-    let active_id = read_u32_le(data, offset)? as i32;
+    let active_id = read_i32_le(data, offset)?;
     offset += 4;
 
     let bin_step = read_u16_le(data, offset)?;
@@ -150,7 +215,7 @@ fn parse_initialize_lb_pair_instruction(
     Some(DexEvent::MeteoraDlmmInitializePool(MeteoraDlmmInitializePoolEvent {
         metadata,
         pool,
-        creator: get_account(accounts, 1).unwrap_or_default(),
+        creator: get_account(accounts, 8).unwrap_or_default(),
         active_bin_id: active_id,
         bin_step,
     }))
@@ -165,9 +230,7 @@ fn parse_initialize_bin_array_instruction(
     tx_index: u64,
     block_time_us: Option<i64>,
 ) -> Option<DexEvent> {
-    let offset = 0;
-
-    let index = read_u64_le(data, offset)? as i64;
+    let index = read_i64_le(data, 0)?;
 
     let pool = get_account(accounts, 0)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
@@ -182,59 +245,45 @@ fn parse_initialize_bin_array_instruction(
 
 /// 解析添加流动性指令
 fn parse_add_liquidity_instruction(
-    data: &[u8],
     accounts: &[Pubkey],
+    sender_index: usize,
     signature: Signature,
     slot: u64,
     tx_index: u64,
     block_time_us: Option<i64>,
 ) -> Option<DexEvent> {
-    let mut offset = 0;
-
-    let _liquidity_parameter = read_bytes(data, offset, 32)?;
-    offset += 32;
-
-    let amounts = read_vec_u64(data, offset)?;
-
-    let pool = get_account(accounts, 0)?;
+    let pool = get_account(accounts, 1)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
 
     Some(DexEvent::MeteoraDlmmAddLiquidity(MeteoraDlmmAddLiquidityEvent {
         metadata,
         pool,
-        from: get_account(accounts, 1).unwrap_or_default(),
-        position: get_account(accounts, 2).unwrap_or_default(),
-        amounts: [amounts.first().copied().unwrap_or(0), amounts.get(1).copied().unwrap_or(0)],
-        active_bin_id: 0, // 从日志中获取
+        from: get_account(accounts, sender_index)?,
+        position: get_account(accounts, 0).unwrap_or_default(),
+        amounts: [0, 0],
+        active_bin_id: 0,
     }))
 }
 
 /// 解析移除流动性指令
 fn parse_remove_liquidity_instruction(
-    data: &[u8],
     accounts: &[Pubkey],
+    sender_index: usize,
     signature: Signature,
     slot: u64,
     tx_index: u64,
     block_time_us: Option<i64>,
 ) -> Option<DexEvent> {
-    let mut offset = 0;
-
-    let _bin_liquidity_removal = read_bytes(data, offset, 32)?;
-    offset += 32;
-
-    let amounts = read_vec_u64(data, offset)?;
-
-    let pool = get_account(accounts, 0)?;
+    let pool = get_account(accounts, 1)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
 
     Some(DexEvent::MeteoraDlmmRemoveLiquidity(MeteoraDlmmRemoveLiquidityEvent {
         metadata,
         pool,
-        from: get_account(accounts, 1).unwrap_or_default(),
-        position: get_account(accounts, 2).unwrap_or_default(),
-        amounts: [amounts.first().copied().unwrap_or(0), amounts.get(1).copied().unwrap_or(0)],
-        active_bin_id: 0, // 从日志中获取
+        from: get_account(accounts, sender_index)?,
+        position: get_account(accounts, 0).unwrap_or_default(),
+        amounts: [0, 0],
+        active_bin_id: 0,
     }))
 }
 
@@ -242,6 +291,9 @@ fn parse_remove_liquidity_instruction(
 fn parse_initialize_position_instruction(
     data: &[u8],
     accounts: &[Pubkey],
+    position_index: usize,
+    pool_index: usize,
+    owner_index: usize,
     signature: Signature,
     slot: u64,
     tx_index: u64,
@@ -249,19 +301,19 @@ fn parse_initialize_position_instruction(
 ) -> Option<DexEvent> {
     let mut offset = 0;
 
-    let lower_bin_id = read_u32_le(data, offset)? as i32;
+    let lower_bin_id = read_i32_le(data, offset)?;
     offset += 4;
 
-    let width = read_u32_le(data, offset)?;
+    let width = u32::try_from(read_i32_le(data, offset)?).ok()?;
 
-    let pool = get_account(accounts, 0)?;
+    let pool = get_account(accounts, pool_index)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
 
     Some(DexEvent::MeteoraDlmmCreatePosition(MeteoraDlmmCreatePositionEvent {
         metadata,
         pool,
-        position: get_account(accounts, 1).unwrap_or_default(),
-        owner: get_account(accounts, 2).unwrap_or_default(),
+        position: get_account(accounts, position_index)?,
+        owner: get_account(accounts, owner_index)?,
         lower_bin_id,
         width,
     }))
@@ -276,12 +328,10 @@ fn parse_swap_instruction(
     tx_index: u64,
     block_time_us: Option<i64>,
 ) -> Option<DexEvent> {
-    let mut offset = 0;
-
-    let amount_in = read_u64_le(data, offset)?;
-    offset += 8;
-
-    let _min_amount_out = read_u64_le(data, offset)?;
+    if data.len() < 16 {
+        return None;
+    }
+    let amount_in = read_u64_le(data, 0)?;
 
     let pool = get_account(accounts, 0)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
@@ -289,23 +339,90 @@ fn parse_swap_instruction(
     Some(DexEvent::MeteoraDlmmSwap(MeteoraDlmmSwapEvent {
         metadata,
         pool,
-        from: get_account(accounts, 1).unwrap_or_default(),
-        start_bin_id: 0, // 从日志填充
-        end_bin_id: 0,   // 从日志填充
+        from: get_account(accounts, 10).unwrap_or_default(),
+        start_bin_id: 0,
+        end_bin_id: 0,
         amount_in,
-        amount_out: 0,     // 从日志填充
-        swap_for_y: false, // 从日志填充
-        fee: 0,            // 从日志填充
-        protocol_fee: 0,   // 从日志填充
-        fee_bps: 0,        // 从日志填充
-        host_fee: 0,       // 从日志填充
+        amount_out: 0,
+        swap_for_y: false,
+        fee: 0,
+        protocol_fee: 0,
+        fee_bps: 0,
+        host_fee: 0,
+    }))
+}
+
+fn parse_swap_exact_out_instruction(
+    data: &[u8],
+    accounts: &[Pubkey],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+) -> Option<DexEvent> {
+    let max_in_amount = read_u64_le(data, 0)?;
+    let out_amount = read_u64_le(data, 8)?;
+
+    let pool = get_account(accounts, 0)?;
+    let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
+
+    Some(DexEvent::MeteoraDlmmSwap(MeteoraDlmmSwapEvent {
+        metadata,
+        pool,
+        from: get_account(accounts, 10).unwrap_or_default(),
+        start_bin_id: 0,
+        end_bin_id: 0,
+        amount_in: max_in_amount,
+        amount_out: out_amount,
+        swap_for_y: false,
+        fee: 0,
+        protocol_fee: 0,
+        fee_bps: 0,
+        host_fee: 0,
+    }))
+}
+
+fn parse_swap_with_price_impact_instruction(
+    data: &[u8],
+    accounts: &[Pubkey],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+) -> Option<DexEvent> {
+    let option_size = match data.get(8).copied()? {
+        0 => 1,
+        1 => 5,
+        _ => return None,
+    };
+    if data.len() < 8 + option_size + 2 {
+        return None;
+    }
+    let amount_in = read_u64_le(data, 0)?;
+
+    let pool = get_account(accounts, 0)?;
+    let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
+
+    Some(DexEvent::MeteoraDlmmSwap(MeteoraDlmmSwapEvent {
+        metadata,
+        pool,
+        from: get_account(accounts, 10).unwrap_or_default(),
+        start_bin_id: 0,
+        end_bin_id: 0,
+        amount_in,
+        amount_out: 0,
+        swap_for_y: false,
+        fee: 0,
+        protocol_fee: 0,
+        fee_bps: 0,
+        host_fee: 0,
     }))
 }
 
 /// 解析费用领取指令
 fn parse_claim_fee_instruction(
-    _data: &[u8],
     accounts: &[Pubkey],
+    owner_index: usize,
     signature: Signature,
     slot: u64,
     tx_index: u64,
@@ -318,28 +435,105 @@ fn parse_claim_fee_instruction(
         metadata,
         pool,
         position: get_account(accounts, 1).unwrap_or_default(),
-        owner: get_account(accounts, 2).unwrap_or_default(),
-        fee_x: 0, // 从日志填充
-        fee_y: 0, // 从日志填充
+        owner: get_account(accounts, owner_index)?,
+        fee_x: 0,
+        fee_y: 0,
     }))
 }
 
 /// 解析关闭头寸指令
 fn parse_close_position_instruction(
-    _data: &[u8],
     accounts: &[Pubkey],
+    pool_index: Option<usize>,
+    owner_index: usize,
     signature: Signature,
     slot: u64,
     tx_index: u64,
     block_time_us: Option<i64>,
 ) -> Option<DexEvent> {
-    let pool = get_account(accounts, 0)?;
+    let position = get_account(accounts, 0)?;
+    let pool = pool_index.and_then(|index| get_account(accounts, index)).unwrap_or_default();
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
 
     Some(DexEvent::MeteoraDlmmClosePosition(MeteoraDlmmClosePositionEvent {
         metadata,
         pool,
-        position: get_account(accounts, 1).unwrap_or_default(),
-        owner: get_account(accounts, 2).unwrap_or_default(),
+        position,
+        owner: get_account(accounts, owner_index)?,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accounts(count: usize) -> Vec<Pubkey> {
+        (0..count).map(|_| Pubkey::new_unique()).collect()
+    }
+
+    fn instruction(discriminator: [u8; 8], payload: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(8 + payload.len());
+        data.extend_from_slice(&discriminator);
+        data.extend_from_slice(payload);
+        data
+    }
+
+    #[test]
+    fn versioned_account_layouts_use_idl_indices() {
+        let accounts = accounts(16);
+        let event = parse_instruction(
+            &instruction(discriminators::ADD_LIQUIDITY2, &[]),
+            &accounts,
+            Signature::default(),
+            1,
+            0,
+            None,
+        )
+        .expect("add_liquidity2");
+        let DexEvent::MeteoraDlmmAddLiquidity(event) = event else {
+            panic!("unexpected event");
+        };
+        assert_eq!(event.position, accounts[0]);
+        assert_eq!(event.pool, accounts[1]);
+        assert_eq!(event.from, accounts[9]);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(-5i32).to_le_bytes());
+        payload.extend_from_slice(&10i32.to_le_bytes());
+        let event = parse_instruction(
+            &instruction(discriminators::INITIALIZE_POSITION_PDA, &payload),
+            &accounts,
+            Signature::default(),
+            1,
+            0,
+            None,
+        )
+        .expect("initialize_position_pda");
+        let DexEvent::MeteoraDlmmCreatePosition(event) = event else {
+            panic!("unexpected event");
+        };
+        assert_eq!(event.position, accounts[2]);
+        assert_eq!(event.pool, accounts[3]);
+        assert_eq!(event.owner, accounts[4]);
+    }
+
+    #[test]
+    fn close_position2_does_not_treat_rent_receiver_as_owner() {
+        let accounts = accounts(5);
+        let event = parse_instruction(
+            &instruction(discriminators::CLOSE_POSITION2, &[]),
+            &accounts,
+            Signature::default(),
+            1,
+            0,
+            None,
+        )
+        .expect("close_position2");
+        let DexEvent::MeteoraDlmmClosePosition(event) = event else {
+            panic!("unexpected event");
+        };
+        assert_eq!(event.position, accounts[0]);
+        assert_eq!(event.owner, accounts[1]);
+        assert_eq!(event.pool, Pubkey::default());
+    }
 }

--- a/src/instr/mod.rs
+++ b/src/instr/mod.rs
@@ -190,7 +190,32 @@ fn supports_meteora_damm_v2_instruction(instruction_data: &[u8]) -> bool {
 
 #[inline(always)]
 fn supports_meteora_dlmm_instruction(instruction_data: &[u8]) -> bool {
-    matches!(instruction_data.first().copied(), Some(0 | 1 | 2 | 7 | 8 | 11 | 13 | 14))
+    let Some(disc) = disc8(instruction_data) else {
+        return false;
+    };
+    matches!(
+        disc,
+        meteora_dlmm::discriminators::INITIALIZE_LB_PAIR
+            | meteora_dlmm::discriminators::INITIALIZE_LB_PAIR2
+            | meteora_dlmm::discriminators::INITIALIZE_BIN_ARRAY
+            | meteora_dlmm::discriminators::ADD_LIQUIDITY
+            | meteora_dlmm::discriminators::ADD_LIQUIDITY2
+            | meteora_dlmm::discriminators::REMOVE_LIQUIDITY
+            | meteora_dlmm::discriminators::REMOVE_LIQUIDITY2
+            | meteora_dlmm::discriminators::INITIALIZE_POSITION
+            | meteora_dlmm::discriminators::INITIALIZE_POSITION2
+            | meteora_dlmm::discriminators::INITIALIZE_POSITION_PDA
+            | meteora_dlmm::discriminators::SWAP
+            | meteora_dlmm::discriminators::SWAP2
+            | meteora_dlmm::discriminators::SWAP_EXACT_OUT
+            | meteora_dlmm::discriminators::SWAP_EXACT_OUT2
+            | meteora_dlmm::discriminators::SWAP_WITH_PRICE_IMPACT
+            | meteora_dlmm::discriminators::SWAP_WITH_PRICE_IMPACT2
+            | meteora_dlmm::discriminators::CLAIM_FEE
+            | meteora_dlmm::discriminators::CLAIM_FEE2
+            | meteora_dlmm::discriminators::CLOSE_POSITION
+            | meteora_dlmm::discriminators::CLOSE_POSITION2
+    )
 }
 
 #[inline(always)]
@@ -520,7 +545,11 @@ mod tests {
             &METEORA_DAMM_V2_PROGRAM_ID,
             &data8(meteora_damm::discriminators::INITIALIZE_POOL)
         ));
-        assert!(instruction_data_may_parse(&METEORA_DLMM_PROGRAM_ID, &[11, 1, 2, 3]));
+        assert!(instruction_data_may_parse(
+            &METEORA_DLMM_PROGRAM_ID,
+            &data8(meteora_dlmm::discriminators::SWAP2)
+        ));
+        assert!(!instruction_data_may_parse(&METEORA_DLMM_PROGRAM_ID, &[11, 1, 2, 3]));
     }
 
     #[test]

--- a/src/instr/orca_whirlpool.rs
+++ b/src/instr/orca_whirlpool.rs
@@ -125,8 +125,11 @@ pub fn parse_instruction(
     let data = &instruction_data[8..];
 
     match instruction_type {
-        OrcaWhirlpoolInstruction::Swap | OrcaWhirlpoolInstruction::SwapV2 => {
-            parse_swap_instruction(data, accounts, signature, slot, tx_index, block_time_us)
+        OrcaWhirlpoolInstruction::Swap => {
+            parse_swap_instruction(data, accounts, 2, signature, slot, tx_index, block_time_us)
+        }
+        OrcaWhirlpoolInstruction::SwapV2 => {
+            parse_swap_instruction(data, accounts, 4, signature, slot, tx_index, block_time_us)
         }
         OrcaWhirlpoolInstruction::IncreaseLiquidity
         | OrcaWhirlpoolInstruction::IncreaseLiquidityV2 => parse_increase_liquidity_instruction(
@@ -164,6 +167,7 @@ pub fn parse_instruction(
 fn parse_swap_instruction(
     data: &[u8],
     accounts: &[Pubkey],
+    whirlpool_index: usize,
     signature: Signature,
     slot: u64,
     tx_index: u64,
@@ -185,7 +189,7 @@ fn parse_swap_instruction(
 
     let a_to_b = read_bool(data, offset)?;
 
-    let whirlpool = get_account(accounts, 1)?;
+    let whirlpool = get_account(accounts, whirlpool_index)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, whirlpool);
 
     Some(DexEvent::OrcaWhirlpoolSwap(OrcaWhirlpoolSwapEvent {

--- a/src/instr/raydium_amm.rs
+++ b/src/instr/raydium_amm.rs
@@ -109,6 +109,7 @@ fn parse_swap_base_in_instruction(
     let amm = get_account(accounts, 1)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, amm);
 
+    let shift = usize::from(accounts.len() == 17);
     Some(DexEvent::RaydiumAmmV4Swap(RaydiumAmmV4SwapEvent {
         metadata,
         amount_in,
@@ -119,20 +120,20 @@ fn parse_swap_base_in_instruction(
         amm,
         amm_authority: get_account(accounts, 2).unwrap_or_default(),
         amm_open_orders: get_account(accounts, 3).unwrap_or_default(),
-        amm_target_orders: get_account(accounts, 4),
-        pool_coin_token_account: get_account(accounts, 5).unwrap_or_default(),
-        pool_pc_token_account: get_account(accounts, 6).unwrap_or_default(),
-        serum_program: get_account(accounts, 7).unwrap_or_default(),
-        serum_market: get_account(accounts, 8).unwrap_or_default(),
-        serum_bids: get_account(accounts, 9).unwrap_or_default(),
-        serum_asks: get_account(accounts, 10).unwrap_or_default(),
-        serum_event_queue: get_account(accounts, 11).unwrap_or_default(),
-        serum_coin_vault_account: get_account(accounts, 12).unwrap_or_default(),
-        serum_pc_vault_account: get_account(accounts, 13).unwrap_or_default(),
-        serum_vault_signer: get_account(accounts, 14).unwrap_or_default(),
-        user_source_token_account: get_account(accounts, 15).unwrap_or_default(),
-        user_destination_token_account: get_account(accounts, 16).unwrap_or_default(),
-        user_source_owner: get_account(accounts, 17).unwrap_or_default(),
+        amm_target_orders: if shift == 0 { get_account(accounts, 4) } else { None },
+        pool_coin_token_account: get_account(accounts, 5 - shift).unwrap_or_default(),
+        pool_pc_token_account: get_account(accounts, 6 - shift).unwrap_or_default(),
+        serum_program: get_account(accounts, 7 - shift).unwrap_or_default(),
+        serum_market: get_account(accounts, 8 - shift).unwrap_or_default(),
+        serum_bids: get_account(accounts, 9 - shift).unwrap_or_default(),
+        serum_asks: get_account(accounts, 10 - shift).unwrap_or_default(),
+        serum_event_queue: get_account(accounts, 11 - shift).unwrap_or_default(),
+        serum_coin_vault_account: get_account(accounts, 12 - shift).unwrap_or_default(),
+        serum_pc_vault_account: get_account(accounts, 13 - shift).unwrap_or_default(),
+        serum_vault_signer: get_account(accounts, 14 - shift).unwrap_or_default(),
+        user_source_token_account: get_account(accounts, 15 - shift).unwrap_or_default(),
+        user_destination_token_account: get_account(accounts, 16 - shift).unwrap_or_default(),
+        user_source_owner: get_account(accounts, 17 - shift).unwrap_or_default(),
     }))
 }
 
@@ -155,6 +156,7 @@ fn parse_swap_base_out_instruction(
     let amm = get_account(accounts, 1)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, amm);
 
+    let shift = usize::from(accounts.len() == 17);
     Some(DexEvent::RaydiumAmmV4Swap(RaydiumAmmV4SwapEvent {
         metadata,
         amount_in: 0,
@@ -165,20 +167,20 @@ fn parse_swap_base_out_instruction(
         amm,
         amm_authority: get_account(accounts, 2).unwrap_or_default(),
         amm_open_orders: get_account(accounts, 3).unwrap_or_default(),
-        amm_target_orders: get_account(accounts, 4),
-        pool_coin_token_account: get_account(accounts, 5).unwrap_or_default(),
-        pool_pc_token_account: get_account(accounts, 6).unwrap_or_default(),
-        serum_program: get_account(accounts, 7).unwrap_or_default(),
-        serum_market: get_account(accounts, 8).unwrap_or_default(),
-        serum_bids: get_account(accounts, 9).unwrap_or_default(),
-        serum_asks: get_account(accounts, 10).unwrap_or_default(),
-        serum_event_queue: get_account(accounts, 11).unwrap_or_default(),
-        serum_coin_vault_account: get_account(accounts, 12).unwrap_or_default(),
-        serum_pc_vault_account: get_account(accounts, 13).unwrap_or_default(),
-        serum_vault_signer: get_account(accounts, 14).unwrap_or_default(),
-        user_source_token_account: get_account(accounts, 15).unwrap_or_default(),
-        user_destination_token_account: get_account(accounts, 16).unwrap_or_default(),
-        user_source_owner: get_account(accounts, 17).unwrap_or_default(),
+        amm_target_orders: if shift == 0 { get_account(accounts, 4) } else { None },
+        pool_coin_token_account: get_account(accounts, 5 - shift).unwrap_or_default(),
+        pool_pc_token_account: get_account(accounts, 6 - shift).unwrap_or_default(),
+        serum_program: get_account(accounts, 7 - shift).unwrap_or_default(),
+        serum_market: get_account(accounts, 8 - shift).unwrap_or_default(),
+        serum_bids: get_account(accounts, 9 - shift).unwrap_or_default(),
+        serum_asks: get_account(accounts, 10 - shift).unwrap_or_default(),
+        serum_event_queue: get_account(accounts, 11 - shift).unwrap_or_default(),
+        serum_coin_vault_account: get_account(accounts, 12 - shift).unwrap_or_default(),
+        serum_pc_vault_account: get_account(accounts, 13 - shift).unwrap_or_default(),
+        serum_vault_signer: get_account(accounts, 14 - shift).unwrap_or_default(),
+        user_source_token_account: get_account(accounts, 15 - shift).unwrap_or_default(),
+        user_destination_token_account: get_account(accounts, 16 - shift).unwrap_or_default(),
+        user_source_owner: get_account(accounts, 17 - shift).unwrap_or_default(),
     }))
 }
 

--- a/src/instr/raydium_cpmm.rs
+++ b/src/instr/raydium_cpmm.rs
@@ -76,20 +76,20 @@ fn parse_swap_base_in_instruction(
 
     let _minimum_amount_out = read_u64_le(data, offset)?;
 
-    let pool = get_account(accounts, 0)?;
+    let pool = get_account(accounts, 3)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
 
     Some(DexEvent::RaydiumCpmmSwap(RaydiumCpmmSwapEvent {
         metadata,
 
         // IDL SwapEvent 事件字段 - 从日志填充，这里设置默认值
-        pool_id: Pubkey::default(), // 将从日志填充
-        input_vault_before: 0,      // 将从日志填充
-        output_vault_before: 0,     // 将从日志填充
-        input_amount: 0,            // 将从日志填充
-        output_amount: 0,           // 将从日志填充
-        input_transfer_fee: 0,      // 将从日志填充
-        output_transfer_fee: 0,     // 将从日志填充
+        pool_id: pool,
+        input_vault_before: 0,  // Filled from the event log.
+        output_vault_before: 0, // Filled from the event log.
+        input_amount: 0,        // Filled from the event log.
+        output_amount: 0,       // Filled from the event log.
+        input_transfer_fee: 0,  // Filled from the event log.
+        output_transfer_fee: 0, // Filled from the event log.
         base_input: true,
         // 暂时注释，以后会用，AI禁止改动
         // 指令参数字段
@@ -126,20 +126,20 @@ fn parse_swap_base_out_instruction(
 
     let _amount_out = read_u64_le(data, offset)?;
 
-    let pool = get_account(accounts, 0)?;
+    let pool = get_account(accounts, 3)?;
     let metadata = create_metadata_simple(signature, slot, tx_index, block_time_us, pool);
 
     Some(DexEvent::RaydiumCpmmSwap(RaydiumCpmmSwapEvent {
         metadata,
 
         // IDL SwapEvent 事件字段 - 从日志填充，这里设置默认值
-        pool_id: Pubkey::default(), // 将从日志填充
-        input_vault_before: 0,      // 将从日志填充
-        output_vault_before: 0,     // 将从日志填充
-        input_amount: 0,            // 将从日志填充
-        output_amount: 0,           // 将从日志填充
-        input_transfer_fee: 0,      // 将从日志填充
-        output_transfer_fee: 0,     // 将从日志填充
+        pool_id: pool,
+        input_vault_before: 0,  // Filled from the event log.
+        output_vault_before: 0, // Filled from the event log.
+        input_amount: 0,        // Filled from the event log.
+        output_amount: 0,       // Filled from the event log.
+        input_transfer_fee: 0,  // Filled from the event log.
+        output_transfer_fee: 0, // Filled from the event log.
         base_input: false,
         // 暂时注释，以后会用，AI禁止改动
         // 指令参数字段

--- a/src/instr/utils.rs
+++ b/src/instr/utils.rs
@@ -48,6 +48,12 @@ pub fn read_u32_le(data: &[u8], offset: usize) -> Option<u32> {
     data.get(offset..offset + 4).map(|slice| u32::from_le_bytes(slice.try_into().unwrap()))
 }
 
+/// Read a little-endian `i64` from instruction data.
+#[inline(always)]
+pub fn read_i64_le(data: &[u8], offset: usize) -> Option<i64> {
+    data.get(offset..offset + 8).map(|slice| i64::from_le_bytes(slice.try_into().unwrap()))
+}
+
 /// 从指令数据中读取 u16（小端序）- SIMD 优化
 #[inline(always)]
 pub fn read_u16_le(data: &[u8], offset: usize) -> Option<u16> {

--- a/src/logs/meteora_dlmm.rs
+++ b/src/logs/meteora_dlmm.rs
@@ -8,14 +8,24 @@ use solana_sdk::signature::Signature;
 
 /// Meteora DLMM 事件 discriminator 常量
 pub mod discriminators {
-    pub const SWAP_EVENT: [u8; 8] = [143, 190, 90, 218, 196, 30, 51, 222];
-    pub const ADD_LIQUIDITY_EVENT: [u8; 8] = [181, 157, 89, 67, 143, 182, 52, 72];
-    pub const REMOVE_LIQUIDITY_EVENT: [u8; 8] = [80, 85, 209, 72, 24, 206, 35, 178];
-    pub const INITIALIZE_BIN_ARRAY_EVENT: [u8; 8] = [11, 18, 155, 194, 33, 115, 238, 119];
-    pub const INITIALIZE_POOL_EVENT: [u8; 8] = [95, 180, 10, 172, 84, 174, 232, 40];
-    pub const CREATE_POSITION_EVENT: [u8; 8] = [123, 233, 11, 43, 146, 180, 97, 119];
-    pub const CLOSE_POSITION_EVENT: [u8; 8] = [94, 168, 102, 45, 59, 122, 137, 54];
-    pub const CLAIM_FEE_EVENT: [u8; 8] = [152, 70, 208, 111, 104, 91, 44, 1];
+    pub const SWAP_EVENT: [u8; 8] = [81, 108, 227, 190, 205, 208, 10, 196];
+    pub const SWAP2_EVENT: [u8; 8] = [46, 116, 82, 215, 148, 27, 84, 77];
+    pub const ADD_LIQUIDITY_EVENT: [u8; 8] = [31, 94, 125, 90, 227, 52, 61, 186];
+    pub const REMOVE_LIQUIDITY_EVENT: [u8; 8] = [116, 244, 97, 232, 103, 31, 152, 58];
+    pub const INITIALIZE_POOL_EVENT: [u8; 8] = [185, 74, 252, 125, 27, 215, 188, 111];
+    pub const CREATE_POSITION_EVENT: [u8; 8] = [144, 142, 252, 84, 157, 53, 37, 121];
+    pub const CLOSE_POSITION_EVENT: [u8; 8] = [255, 196, 16, 107, 28, 202, 53, 128];
+    pub const CLAIM_FEE_EVENT: [u8; 8] = [75, 122, 154, 48, 140, 74, 123, 163];
+    pub const CLAIM_FEE2_EVENT: [u8; 8] = [232, 171, 242, 97, 58, 77, 35, 45];
+
+    pub const LEGACY_SWAP_EVENT: [u8; 8] = [143, 190, 90, 218, 196, 30, 51, 222];
+    pub const LEGACY_ADD_LIQUIDITY_EVENT: [u8; 8] = [181, 157, 89, 67, 143, 182, 52, 72];
+    pub const LEGACY_REMOVE_LIQUIDITY_EVENT: [u8; 8] = [80, 85, 209, 72, 24, 206, 35, 178];
+    pub const LEGACY_INITIALIZE_BIN_ARRAY_EVENT: [u8; 8] = [11, 18, 155, 194, 33, 115, 238, 119];
+    pub const LEGACY_INITIALIZE_POOL_EVENT: [u8; 8] = [95, 180, 10, 172, 84, 174, 232, 40];
+    pub const LEGACY_CREATE_POSITION_EVENT: [u8; 8] = [123, 233, 11, 43, 146, 180, 97, 119];
+    pub const LEGACY_CLOSE_POSITION_EVENT: [u8; 8] = [94, 168, 102, 45, 59, 122, 137, 54];
+    pub const LEGACY_CLAIM_FEE_EVENT: [u8; 8] = [152, 70, 208, 111, 104, 91, 44, 1];
 }
 
 /// 主要的 Meteora DLMM 日志解析函数
@@ -48,13 +58,26 @@ fn parse_structured_log(
     let data = &program_data[8..];
 
     match discriminator {
-        discriminators::SWAP_EVENT => {
+        discriminators::SWAP_EVENT | discriminators::LEGACY_SWAP_EVENT => {
             parse_swap_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
         }
-        discriminators::ADD_LIQUIDITY_EVENT => {
+        discriminators::SWAP2_EVENT => {
+            parse_swap2_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
+        }
+        discriminators::ADD_LIQUIDITY_EVENT | discriminators::LEGACY_ADD_LIQUIDITY_EVENT => {
             parse_add_liquidity_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
         }
-        discriminators::REMOVE_LIQUIDITY_EVENT => parse_remove_liquidity_event(
+        discriminators::REMOVE_LIQUIDITY_EVENT | discriminators::LEGACY_REMOVE_LIQUIDITY_EVENT => {
+            parse_remove_liquidity_event(
+                data,
+                signature,
+                slot,
+                tx_index,
+                block_time_us,
+                grpc_recv_us,
+            )
+        }
+        discriminators::LEGACY_INITIALIZE_BIN_ARRAY_EVENT => parse_initialize_bin_array_event(
             data,
             signature,
             slot,
@@ -62,7 +85,10 @@ fn parse_structured_log(
             block_time_us,
             grpc_recv_us,
         ),
-        discriminators::INITIALIZE_BIN_ARRAY_EVENT => parse_initialize_bin_array_event(
+        discriminators::INITIALIZE_POOL_EVENT => {
+            parse_lb_pair_create_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
+        }
+        discriminators::LEGACY_INITIALIZE_POOL_EVENT => parse_initialize_pool_event(
             data,
             signature,
             slot,
@@ -70,7 +96,7 @@ fn parse_structured_log(
             block_time_us,
             grpc_recv_us,
         ),
-        discriminators::INITIALIZE_POOL_EVENT => parse_initialize_pool_event(
+        discriminators::CREATE_POSITION_EVENT => parse_position_create_event(
             data,
             signature,
             slot,
@@ -78,7 +104,7 @@ fn parse_structured_log(
             block_time_us,
             grpc_recv_us,
         ),
-        discriminators::CREATE_POSITION_EVENT => parse_create_position_event(
+        discriminators::LEGACY_CREATE_POSITION_EVENT => parse_create_position_event(
             data,
             signature,
             slot,
@@ -87,10 +113,16 @@ fn parse_structured_log(
             grpc_recv_us,
         ),
         discriminators::CLOSE_POSITION_EVENT => {
+            parse_position_close_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
+        }
+        discriminators::LEGACY_CLOSE_POSITION_EVENT => {
             parse_close_position_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
         }
-        discriminators::CLAIM_FEE_EVENT => {
+        discriminators::CLAIM_FEE_EVENT | discriminators::LEGACY_CLAIM_FEE_EVENT => {
             parse_claim_fee_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
+        }
+        discriminators::CLAIM_FEE2_EVENT => {
+            parse_claim_fee2_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
         }
         _ => None,
     }
@@ -133,6 +165,67 @@ pub fn parse_swap_from_data(data: &[u8], metadata: EventMetadata) -> Option<DexE
 
     let fee_bps = read_u128_le(data, offset)?;
     offset += 16;
+
+    let host_fee = read_u64_le(data, offset)?;
+
+    Some(DexEvent::MeteoraDlmmSwap(MeteoraDlmmSwapEvent {
+        metadata,
+        pool,
+        from,
+        start_bin_id,
+        end_bin_id,
+        amount_in,
+        amount_out,
+        swap_for_y,
+        fee,
+        protocol_fee,
+        fee_bps,
+        host_fee,
+    }))
+}
+
+#[inline(always)]
+pub fn parse_swap2_from_data(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    if data.len() < 147 {
+        return None;
+    }
+    let mut offset = 0;
+
+    let pool = read_pubkey(data, offset)?;
+    offset += 32;
+
+    let from = read_pubkey(data, offset)?;
+    offset += 32;
+
+    let start_bin_id = read_i32_le(data, offset)?;
+    offset += 4;
+
+    let end_bin_id = read_i32_le(data, offset)?;
+    offset += 4;
+
+    let swap_for_y = read_bool(data, offset)?;
+    offset += 1;
+
+    let fee_bps = read_u128_le(data, offset)?;
+    offset += 16;
+
+    let amount_in = read_u64_le(data, offset)?;
+    offset += 8;
+
+    let _amount_left = read_u64_le(data, offset)?;
+    offset += 8;
+
+    let amount_out = read_u64_le(data, offset)?;
+    offset += 8;
+
+    let fee = read_u64_le(data, offset)?;
+    offset += 8;
+
+    let protocol_fee = read_u64_le(data, offset)?;
+    offset += 8;
+
+    let _limit_order_fee = read_u64_le(data, offset)?;
+    offset += 8;
 
     let host_fee = read_u64_le(data, offset)?;
 
@@ -337,6 +430,71 @@ pub fn parse_claim_fee_from_data(data: &[u8], metadata: EventMetadata) -> Option
     }))
 }
 
+#[inline(always)]
+pub fn parse_claim_fee2_from_data(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    if data.len() < 116 {
+        return None;
+    }
+    parse_claim_fee_from_data(data, metadata)
+}
+
+#[inline(always)]
+pub fn parse_lb_pair_create_from_data(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    let mut offset = 0;
+
+    let pool = read_pubkey(data, offset)?;
+    offset += 32;
+
+    let bin_step = read_u16_le(data, offset)?;
+
+    Some(DexEvent::MeteoraDlmmInitializePool(MeteoraDlmmInitializePoolEvent {
+        metadata,
+        pool,
+        creator: Default::default(),
+        active_bin_id: 0,
+        bin_step,
+    }))
+}
+
+#[inline(always)]
+pub fn parse_position_create_from_data(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    let mut offset = 0;
+
+    let pool = read_pubkey(data, offset)?;
+    offset += 32;
+
+    let position = read_pubkey(data, offset)?;
+    offset += 32;
+
+    let owner = read_pubkey(data, offset)?;
+
+    Some(DexEvent::MeteoraDlmmCreatePosition(MeteoraDlmmCreatePositionEvent {
+        metadata,
+        pool,
+        position,
+        owner,
+        lower_bin_id: 0,
+        width: 0,
+    }))
+}
+
+#[inline(always)]
+pub fn parse_position_close_from_data(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    let mut offset = 0;
+
+    let position = read_pubkey(data, offset)?;
+    offset += 32;
+
+    let owner = read_pubkey(data, offset)?;
+
+    Some(DexEvent::MeteoraDlmmClosePosition(MeteoraDlmmClosePositionEvent {
+        metadata,
+        pool: Default::default(),
+        position,
+        owner,
+    }))
+}
+
 /// 解析交换事件
 fn parse_swap_event(
     data: &[u8],
@@ -397,6 +555,25 @@ fn parse_swap_event(
         fee_bps,
         host_fee,
     }))
+}
+
+fn parse_swap2_event(
+    data: &[u8],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+    grpc_recv_us: i64,
+) -> Option<DexEvent> {
+    let metadata = create_metadata_simple(
+        signature,
+        slot,
+        tx_index,
+        block_time_us,
+        Default::default(),
+        grpc_recv_us,
+    );
+    parse_swap2_from_data(data, metadata)
 }
 
 /// 解析添加流动性事件
@@ -649,6 +826,82 @@ fn parse_claim_fee_event(
         fee_x,
         fee_y,
     }))
+}
+
+fn parse_claim_fee2_event(
+    data: &[u8],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+    grpc_recv_us: i64,
+) -> Option<DexEvent> {
+    let metadata = create_metadata_simple(
+        signature,
+        slot,
+        tx_index,
+        block_time_us,
+        Default::default(),
+        grpc_recv_us,
+    );
+    parse_claim_fee2_from_data(data, metadata)
+}
+
+fn parse_lb_pair_create_event(
+    data: &[u8],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+    grpc_recv_us: i64,
+) -> Option<DexEvent> {
+    let metadata = create_metadata_simple(
+        signature,
+        slot,
+        tx_index,
+        block_time_us,
+        Default::default(),
+        grpc_recv_us,
+    );
+    parse_lb_pair_create_from_data(data, metadata)
+}
+
+fn parse_position_create_event(
+    data: &[u8],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+    grpc_recv_us: i64,
+) -> Option<DexEvent> {
+    let metadata = create_metadata_simple(
+        signature,
+        slot,
+        tx_index,
+        block_time_us,
+        Default::default(),
+        grpc_recv_us,
+    );
+    parse_position_create_from_data(data, metadata)
+}
+
+fn parse_position_close_event(
+    data: &[u8],
+    signature: Signature,
+    slot: u64,
+    tx_index: u64,
+    block_time_us: Option<i64>,
+    grpc_recv_us: i64,
+) -> Option<DexEvent> {
+    let metadata = create_metadata_simple(
+        signature,
+        slot,
+        tx_index,
+        block_time_us,
+        Default::default(),
+        grpc_recv_us,
+    );
+    parse_position_close_from_data(data, metadata)
 }
 
 /// 文本回退解析

--- a/src/logs/optimized_matcher.rs
+++ b/src/logs/optimized_matcher.rs
@@ -248,6 +248,8 @@ mod discriminators {
     // Raydium CPMM discriminators
     pub const RAYDIUM_CPMM_SWAP_BASE_IN: u64 =
         u64::from_le_bytes([143, 190, 90, 218, 196, 30, 51, 222]);
+    pub const RAYDIUM_CPMM_SWAP_EVENT: u64 =
+        u64::from_le_bytes([64, 198, 205, 232, 38, 8, 113, 226]);
     pub const RAYDIUM_CPMM_SWAP_BASE_OUT: u64 =
         u64::from_le_bytes([55, 217, 98, 86, 163, 74, 180, 173]);
     pub const RAYDIUM_CPMM_CREATE_POOL: u64 =
@@ -309,21 +311,26 @@ mod discriminators {
     pub const METEORA_DBC_CURVE_COMPLETE: u64 =
         u64::from_le_bytes([229, 231, 86, 84, 156, 134, 75, 24]);
 
-    // Meteora DLMM discriminators
-    pub const METEORA_DLMM_SWAP: u64 = u64::from_le_bytes([143, 190, 90, 218, 196, 30, 51, 222]);
+    // Meteora DLMM event discriminators. Current DLMM uses Anchor event-CPI
+    // discriminators that overlap with Meteora Pools, so scoped routing is required.
+    pub const METEORA_DLMM_SWAP: u64 = u64::from_le_bytes([81, 108, 227, 190, 205, 208, 10, 196]);
+    pub const METEORA_DLMM_SWAP2: u64 = u64::from_le_bytes([46, 116, 82, 215, 148, 27, 84, 77]);
     pub const METEORA_DLMM_ADD_LIQUIDITY: u64 =
-        u64::from_le_bytes([181, 157, 89, 67, 143, 182, 52, 72]);
+        u64::from_le_bytes([31, 94, 125, 90, 227, 52, 61, 186]);
     pub const METEORA_DLMM_REMOVE_LIQUIDITY: u64 =
-        u64::from_le_bytes([80, 85, 209, 72, 24, 206, 35, 178]);
+        u64::from_le_bytes([116, 244, 97, 232, 103, 31, 152, 58]);
     pub const METEORA_DLMM_INITIALIZE_POOL: u64 =
-        u64::from_le_bytes([95, 180, 10, 172, 84, 174, 232, 40]);
+        u64::from_le_bytes([185, 74, 252, 125, 27, 215, 188, 111]);
     pub const METEORA_DLMM_INITIALIZE_BIN_ARRAY: u64 =
         u64::from_le_bytes([11, 18, 155, 194, 33, 115, 238, 119]);
     pub const METEORA_DLMM_CREATE_POSITION: u64 =
-        u64::from_le_bytes([123, 233, 11, 43, 146, 180, 97, 119]);
+        u64::from_le_bytes([144, 142, 252, 84, 157, 53, 37, 121]);
     pub const METEORA_DLMM_CLOSE_POSITION: u64 =
-        u64::from_le_bytes([94, 168, 102, 45, 59, 122, 137, 54]);
-    pub const METEORA_DLMM_CLAIM_FEE: u64 = u64::from_le_bytes([152, 70, 208, 111, 104, 91, 44, 1]);
+        u64::from_le_bytes([255, 196, 16, 107, 28, 202, 53, 128]);
+    pub const METEORA_DLMM_CLAIM_FEE: u64 =
+        u64::from_le_bytes([75, 122, 154, 48, 140, 74, 123, 163]);
+    pub const METEORA_DLMM_CLAIM_FEE2: u64 =
+        u64::from_le_bytes([232, 171, 242, 97, 58, 77, 35, 45]);
 }
 
 /// Optimized unified log parser with **discriminator predecode, decode-on-match** strategy
@@ -473,7 +480,8 @@ fn unscoped_filter_allows_discriminator(discriminator: u64, filter: &EventTypeFi
             filter_wants_pumpfun_trade_event(filter)
                 || filter.should_include(EventType::RaydiumLaunchlabTrade)
         }
-        // Shared by Raydium CPMM swap-base-in and Meteora DLMM swap.
+        // Legacy DLMM swap overlapped Raydium CPMM. Current DLMM swap overlaps
+        // Meteora Pools swap and is resolved by scoped routing.
         discriminators::RAYDIUM_CPMM_SWAP_BASE_IN => {
             filter.should_include(EventType::RaydiumCpmmSwap)
                 || filter.should_include(EventType::MeteoraDlmmSwap)
@@ -564,6 +572,23 @@ fn parse_log_optimized_inner(
     recent_blockhash: Option<&[u8]>,
     program_id: Option<&Pubkey>,
 ) -> Option<DexEvent> {
+    if program_id == Some(&program_ids::RAYDIUM_AMM_V4_PROGRAM_ID) && log.contains("ray_log: ") {
+        if event_type_filter
+            .map(|filter| !filter.should_include(EventType::RaydiumAmmV4Swap))
+            .unwrap_or(false)
+        {
+            return None;
+        }
+        let metadata = EventMetadata {
+            signature,
+            slot,
+            tx_index,
+            block_time_us: block_time_us.unwrap_or(0),
+            grpc_recv_us,
+            recent_blockhash: recent_blockhash.map(|s| bs58::encode(s).into_string()),
+        };
+        return crate::logs::raydium_amm::parse_ray_log_swap(log, metadata);
+    }
     // Step 1: Find "Program data: " prefix using SIMD
     let log_bytes = log.as_bytes();
     let pos = PROGRAM_DATA_FINDER.find(log_bytes)?;
@@ -884,9 +909,8 @@ fn parse_log_optimized_inner(
             crate::logs::meteora_damm::parse_close_position_from_data(data, metadata)
         }
 
-        // NOTE: Meteora DLMM discriminators conflict with Raydium CPMM!
-        // METEORA_DLMM_SWAP == RAYDIUM_CPMM_SWAP_BASE_IN
-        // Handle DLMM in fallback using log content detection
+        // NOTE: current Meteora DLMM discriminators overlap other Meteora
+        // programs, so DLMM is routed in the program-scoped path.
 
         // Unknown discriminator - try fallback protocols
         _ => {
@@ -1000,7 +1024,8 @@ fn program_scoped_discriminator_to_event_type(
             _ => None,
         },
         program_ids::RAYDIUM_CPMM_PROGRAM_ID => match discriminator {
-            discriminators::RAYDIUM_CPMM_SWAP_BASE_IN
+            discriminators::RAYDIUM_CPMM_SWAP_EVENT
+            | discriminators::RAYDIUM_CPMM_SWAP_BASE_IN
             | discriminators::RAYDIUM_CPMM_SWAP_BASE_OUT => Some(EventType::RaydiumCpmmSwap),
             discriminators::RAYDIUM_CPMM_CREATE_POOL => Some(EventType::RaydiumCpmmInitialize),
             discriminators::RAYDIUM_CPMM_DEPOSIT => Some(EventType::RaydiumCpmmDeposit),
@@ -1070,7 +1095,9 @@ fn program_scoped_discriminator_to_event_type(
             _ => None,
         },
         program_ids::METEORA_DLMM_PROGRAM_ID => match discriminator {
-            discriminators::METEORA_DLMM_SWAP => Some(EventType::MeteoraDlmmSwap),
+            discriminators::METEORA_DLMM_SWAP | discriminators::METEORA_DLMM_SWAP2 => {
+                Some(EventType::MeteoraDlmmSwap)
+            }
             discriminators::METEORA_DLMM_ADD_LIQUIDITY => Some(EventType::MeteoraDlmmAddLiquidity),
             discriminators::METEORA_DLMM_REMOVE_LIQUIDITY => {
                 Some(EventType::MeteoraDlmmRemoveLiquidity)
@@ -1087,7 +1114,9 @@ fn program_scoped_discriminator_to_event_type(
             discriminators::METEORA_DLMM_CLOSE_POSITION => {
                 Some(EventType::MeteoraDlmmClosePosition)
             }
-            discriminators::METEORA_DLMM_CLAIM_FEE => Some(EventType::MeteoraDlmmClaimFee),
+            discriminators::METEORA_DLMM_CLAIM_FEE | discriminators::METEORA_DLMM_CLAIM_FEE2 => {
+                Some(EventType::MeteoraDlmmClaimFee)
+            }
             _ => None,
         },
         _ => None,
@@ -1298,6 +1327,9 @@ fn parse_program_scoped_event(
                 }
             }
             match discriminator {
+                discriminators::RAYDIUM_CPMM_SWAP_EVENT => {
+                    crate::logs::raydium_cpmm::parse_swap_event_from_data(data, metadata)
+                }
                 discriminators::RAYDIUM_CPMM_SWAP_BASE_IN => {
                     crate::logs::raydium_cpmm::parse_swap_base_in_from_data(data, metadata)
                 }
@@ -1454,6 +1486,9 @@ fn parse_program_scoped_event(
                 discriminators::METEORA_DLMM_SWAP => {
                     crate::logs::meteora_dlmm::parse_swap_from_data(data, metadata)
                 }
+                discriminators::METEORA_DLMM_SWAP2 => {
+                    crate::logs::meteora_dlmm::parse_swap2_from_data(data, metadata)
+                }
                 discriminators::METEORA_DLMM_ADD_LIQUIDITY => {
                     crate::logs::meteora_dlmm::parse_add_liquidity_from_data(data, metadata)
                 }
@@ -1461,19 +1496,22 @@ fn parse_program_scoped_event(
                     crate::logs::meteora_dlmm::parse_remove_liquidity_from_data(data, metadata)
                 }
                 discriminators::METEORA_DLMM_INITIALIZE_POOL => {
-                    crate::logs::meteora_dlmm::parse_initialize_pool_from_data(data, metadata)
+                    crate::logs::meteora_dlmm::parse_lb_pair_create_from_data(data, metadata)
                 }
                 discriminators::METEORA_DLMM_INITIALIZE_BIN_ARRAY => {
                     crate::logs::meteora_dlmm::parse_initialize_bin_array_from_data(data, metadata)
                 }
                 discriminators::METEORA_DLMM_CREATE_POSITION => {
-                    crate::logs::meteora_dlmm::parse_create_position_from_data(data, metadata)
+                    crate::logs::meteora_dlmm::parse_position_create_from_data(data, metadata)
                 }
                 discriminators::METEORA_DLMM_CLOSE_POSITION => {
-                    crate::logs::meteora_dlmm::parse_close_position_from_data(data, metadata)
+                    crate::logs::meteora_dlmm::parse_position_close_from_data(data, metadata)
                 }
                 discriminators::METEORA_DLMM_CLAIM_FEE => {
                     crate::logs::meteora_dlmm::parse_claim_fee_from_data(data, metadata)
+                }
+                discriminators::METEORA_DLMM_CLAIM_FEE2 => {
+                    crate::logs::meteora_dlmm::parse_claim_fee2_from_data(data, metadata)
                 }
                 _ => None,
             }
@@ -2037,7 +2075,7 @@ mod tests {
         let dlmm_filter = EventTypeFilter::include_only(vec![EventType::MeteoraDlmmSwap]);
         assert!(filter_allows_discriminator(
             None,
-            discriminators::METEORA_DLMM_SWAP,
+            discriminators::METEORA_DLMM_SWAP2,
             Some(&dlmm_filter),
         ));
 

--- a/src/logs/raydium_amm.rs
+++ b/src/logs/raydium_amm.rs
@@ -20,6 +20,48 @@ pub mod discriminators {
 /// Raydium AMM V4 程序 ID
 pub const PROGRAM_ID: &str = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8";
 
+/// Decode the official bincode `ray_log` swap records emitted by AMM V4.
+#[inline]
+pub fn parse_ray_log_swap(log: &str, metadata: EventMetadata) -> Option<DexEvent> {
+    const PREFIX: &str = "ray_log: ";
+    let start = log.find(PREFIX)? + PREFIX.len();
+    let data = base64_simd::STANDARD.decode_to_vec(log[start..].trim().as_bytes()).ok()?;
+    if data.len() != 57 || !matches!(data[0], 3 | 4) {
+        return None;
+    }
+    let first = read_u64_le(&data, 1)?;
+    let second = read_u64_le(&data, 9)?;
+    let actual = read_u64_le(&data, 49)?;
+    let (amount_in, minimum_amount_out, max_amount_in, amount_out) =
+        if data[0] == 3 { (first, second, 0, actual) } else { (actual, 0, first, second) };
+
+    Some(DexEvent::RaydiumAmmV4Swap(RaydiumAmmV4SwapEvent {
+        metadata,
+        amount_in,
+        minimum_amount_out,
+        max_amount_in,
+        amount_out,
+        token_program: Pubkey::default(),
+        amm: Pubkey::default(),
+        amm_authority: Pubkey::default(),
+        amm_open_orders: Pubkey::default(),
+        amm_target_orders: None,
+        pool_coin_token_account: Pubkey::default(),
+        pool_pc_token_account: Pubkey::default(),
+        serum_program: Pubkey::default(),
+        serum_market: Pubkey::default(),
+        serum_bids: Pubkey::default(),
+        serum_asks: Pubkey::default(),
+        serum_event_queue: Pubkey::default(),
+        serum_coin_vault_account: Pubkey::default(),
+        serum_pc_vault_account: Pubkey::default(),
+        serum_vault_signer: Pubkey::default(),
+        user_source_token_account: Pubkey::default(),
+        user_destination_token_account: Pubkey::default(),
+        user_source_owner: Pubkey::default(),
+    }))
+}
+
 /// 解析 Raydium AMM V4 日志
 #[inline]
 pub fn parse_log(

--- a/src/logs/raydium_cpmm.rs
+++ b/src/logs/raydium_cpmm.rs
@@ -8,6 +8,7 @@ use solana_sdk::{pubkey::Pubkey, signature::Signature};
 
 /// Raydium CPMM discriminator 常量
 pub mod discriminators {
+    pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
     pub const SWAP_BASE_IN: [u8; 8] = [143, 190, 90, 218, 196, 30, 51, 222];
     pub const SWAP_BASE_OUT: [u8; 8] = [55, 217, 98, 86, 163, 74, 180, 173];
     pub const CREATE_POOL: [u8; 8] = [233, 146, 209, 142, 207, 104, 64, 188];
@@ -56,6 +57,17 @@ fn parse_structured_log(
     let data = &program_data[8..];
 
     match discriminator {
+        discriminators::SWAP_EVENT => parse_swap_event_from_data(
+            data,
+            create_metadata_simple(
+                signature,
+                slot,
+                tx_index,
+                block_time_us,
+                Pubkey::default(),
+                grpc_recv_us,
+            ),
+        ),
         discriminators::SWAP_BASE_IN => {
             parse_swap_base_in_event(data, signature, slot, tx_index, block_time_us, grpc_recv_us)
         }
@@ -78,6 +90,42 @@ fn parse_structured_log(
 // =============================================================================
 // Public from_data parsers - Accept pre-decoded data, eliminate double decode
 // =============================================================================
+
+/// Parse the stable prefix of the current Anchor `SwapEvent` payload.
+#[inline(always)]
+pub fn parse_swap_event_from_data(data: &[u8], metadata: EventMetadata) -> Option<DexEvent> {
+    if data.len() < 32 + (6 * 8) + 1 {
+        return None;
+    }
+    let mut offset = 0;
+    let pool_id = read_pubkey(data, offset)?;
+    offset += 32;
+    let input_vault_before = read_u64_le(data, offset)?;
+    offset += 8;
+    let output_vault_before = read_u64_le(data, offset)?;
+    offset += 8;
+    let input_amount = read_u64_le(data, offset)?;
+    offset += 8;
+    let output_amount = read_u64_le(data, offset)?;
+    offset += 8;
+    let input_transfer_fee = read_u64_le(data, offset)?;
+    offset += 8;
+    let output_transfer_fee = read_u64_le(data, offset)?;
+    offset += 8;
+    let base_input = read_bool(data, offset)?;
+
+    Some(DexEvent::RaydiumCpmmSwap(RaydiumCpmmSwapEvent {
+        metadata,
+        pool_id,
+        input_vault_before,
+        output_vault_before,
+        input_amount,
+        output_amount,
+        input_transfer_fee,
+        output_transfer_fee,
+        base_input,
+    }))
+}
 
 /// Parse Raydium CPMM SwapBaseIn event from pre-decoded data
 #[inline(always)]

--- a/src/shredstream/pump_ix.rs
+++ b/src/shredstream/pump_ix.rs
@@ -2183,7 +2183,7 @@ mod tests {
     #[test]
     fn unknown_program_outer_uses_filter_to_parse_matching_protocol() {
         let static_keys = vec![RAYDIUM_CPMM_PROGRAM_ID, Pubkey::new_unique()];
-        let ix_accounts = vec![1, 42];
+        let ix_accounts = vec![1, 42, 43, 44];
         let mut data = Vec::new();
         data.extend_from_slice(&crate::instr::raydium_cpmm::discriminators::SWAP_BASE_IN);
         data.extend_from_slice(&100_u64.to_le_bytes());
@@ -2318,7 +2318,7 @@ mod tests {
     #[test]
     fn non_pump_outer_accounts_keep_instruction_length_with_alt_defaults() {
         let static_keys = vec![RAYDIUM_CPMM_PROGRAM_ID, Pubkey::new_unique()];
-        let ix_accounts = vec![1, 42];
+        let ix_accounts = vec![1, 42, 43, 44];
         let mut data = Vec::new();
         data.extend_from_slice(&crate::instr::raydium_cpmm::discriminators::SWAP_BASE_IN);
         data.extend_from_slice(&100_u64.to_le_bytes());

--- a/tests/current_mainnet_transactions.rs
+++ b/tests/current_mainnet_transactions.rs
@@ -1,0 +1,178 @@
+use sol_parser_sdk::{parse_transaction_from_rpc, DexEvent};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::signature::Signature;
+use std::str::FromStr;
+
+fn run_mainnet_tests() -> bool {
+    std::env::var("RUN_MAINNET_TESTS").as_deref() == Ok("1")
+}
+
+fn rpc_client() -> RpcClient {
+    RpcClient::new(
+        std::env::var("SOLANA_RPC_URL")
+            .unwrap_or_else(|_| "https://api.mainnet-beta.solana.com".to_string()),
+    )
+}
+
+fn parse(signature: &str) -> Vec<DexEvent> {
+    let signature = Signature::from_str(signature).expect("valid fixture signature");
+    parse_transaction_from_rpc(&rpc_client(), &signature, None)
+        .unwrap_or_else(|error| panic!("{signature}: {error}"))
+}
+
+// These transactions were captured from current mainnet traffic on 2026-08-13.
+// Run with: RUN_MAINNET_TESTS=1 SOLANA_RPC_URL=<optional archive RPC> cargo test --test current_mainnet_transactions
+
+#[test]
+fn current_meteora_dlmm_swap_and_nested_orca() {
+    if !run_mainnet_tests() {
+        return;
+    }
+    const SIGNATURE: &str =
+        "eEWaGsbRPoiD36Xf3epzSMmdtXX36va76b13YfsDV3ncsxQHBTjC68zZ8mbzFXTNWy3n3qKUAHjgHBconX4Gu1i";
+    let events = parse(SIGNATURE);
+    let swaps: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            DexEvent::MeteoraDlmmSwap(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(swaps.len(), 1);
+    assert_eq!(swaps[0].metadata.signature.to_string(), SIGNATURE);
+    assert_eq!(swaps[0].metadata.slot, 438_873_646);
+    assert_eq!(swaps[0].amount_in, 2_738_183_783);
+    assert_eq!(swaps[0].amount_out, 81_555_062);
+    assert_eq!(swaps[0].fee, 18_486_656);
+    assert_eq!(swaps[0].protocol_fee, 2_054_072);
+
+    let orca: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            DexEvent::OrcaWhirlpoolSwap(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(orca.len(), 1);
+    assert_eq!(orca[0].input_amount, 2_397_194_654);
+    assert_eq!(orca[0].output_amount, 942_951_733);
+}
+
+#[test]
+fn current_meteora_dlmm_add_liquidity_occurrences() {
+    if !run_mainnet_tests() {
+        return;
+    }
+    const SIGNATURE: &str =
+        "h3sGiriW4jCGgbnNF8DaEKnsWhjtcH5ZM1dkyZFidgD2fx9aDNatray38yRmkxaWez3g5qFNpyXhE8ho716vjgp";
+    let adds: Vec<_> = parse(SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::MeteoraDlmmAddLiquidity(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(adds.len(), 3);
+    assert_eq!(adds[0].metadata.slot, 438_873_652);
+    assert_eq!(adds[0].amounts, [0, 389_400_592]);
+    assert_eq!(adds[1].amounts, [4_957_546_677, 65_633_812]);
+    assert_eq!(adds[2].amounts, [6_984_260_460, 0]);
+}
+
+#[test]
+fn current_pumpfun_and_pumpswap_trades() {
+    if !run_mainnet_tests() {
+        return;
+    }
+    const PUMPFUN_SIGNATURE: &str =
+        "QUYUtVPVkkjV2GGFTC4MfxtauNpRvWDViGCGxTckxPWbPZvEY92d1sZD9Lq5iK31sy3Drwy28gHmV89iRt9hz9R";
+    let pumpfun: Vec<_> = parse(PUMPFUN_SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::PumpFunBuy(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(pumpfun.len(), 1);
+    assert_eq!(pumpfun[0].metadata.slot, 438_880_952);
+    assert_eq!(pumpfun[0].sol_amount, 977_777_777);
+    assert_eq!(pumpfun[0].token_amount, 30_765_521_374_696);
+    assert_eq!(pumpfun[0].ix_name, "buy");
+
+    const PUMPSWAP_SIGNATURE: &str =
+        "2qgqjVi7XtBeSudSkZhbQrsdFNeMUB4jApLdcdihAwcWWb5SxQvQKjrfr2ZQ12TrR4BEwvaY7PiHLqE3uZD24iw7";
+    let pumpswap: Vec<_> = parse(PUMPSWAP_SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::PumpSwapBuy(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(pumpswap.len(), 1);
+    assert_eq!(pumpswap[0].metadata.slot, 438_881_023);
+    assert_eq!(pumpswap[0].base_amount_out, 7_317_003_080);
+    assert_eq!(pumpswap[0].quote_amount_in, 10_000_000);
+    assert_eq!(pumpswap[0].ix_name, "buy_exact_quote_in");
+}
+
+#[test]
+fn current_raydium_clmm_cpmm_amm_v4_and_launchlab() {
+    if !run_mainnet_tests() {
+        return;
+    }
+    const CLMM_SIGNATURE: &str =
+        "2TyjCWrh3zqNmDg7NgdGAFqGaCbEkUHE8zrjzsRyqRVTXYZNKFFJgFEDce5mD4se3h2u6GyNJLXbeAW1ad8dsApq";
+    let clmm: Vec<_> = parse(CLMM_SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::RaydiumClmmSwap(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(clmm.len(), 1);
+    assert_eq!(clmm[0].metadata.slot, 438_880_315);
+    assert_eq!((clmm[0].amount_0, clmm[0].amount_1), (156_679, 11_888));
+
+    const CPMM_SIGNATURE: &str =
+        "4v27ccyrAgpCdCHLvjvn8smFn4Fb4HGcRVTSt952eNcF5jg5niA5bKRLPoGrzxXZdZULEZujgA5TXdESNbwmFYE8";
+    let cpmm: Vec<_> = parse(CPMM_SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::RaydiumCpmmSwap(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(cpmm.len(), 3);
+    assert_eq!(cpmm[0].metadata.slot, 438_881_024);
+    assert_eq!((cpmm[0].input_amount, cpmm[0].output_amount), (851_111, 3_788_666));
+    assert_eq!((cpmm[1].input_amount, cpmm[1].output_amount), (636_739, 1_163_813_842));
+    assert_eq!((cpmm[2].input_amount, cpmm[2].output_amount), (1_163_813_842, 2_843_080));
+
+    const AMM_V4_SIGNATURE: &str =
+        "2iHYs4AHC5nutcbBxpA5aptBYTGaDUYBgamohfetDnAPiPBW5NkguxgnjVF5886Jy8MZ19UXdeZyPKq9C5wqAki4";
+    let amm_v4: Vec<_> = parse(AMM_V4_SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::RaydiumAmmV4Swap(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(amm_v4.len(), 1);
+    assert_eq!(amm_v4[0].metadata.slot, 438_881_026);
+    assert_eq!(amm_v4[0].amount_in, 28_804_156_949_609);
+    assert_eq!(amm_v4[0].amount_out, 428_715_251);
+
+    const LAUNCHLAB_SIGNATURE: &str =
+        "4pSXdZEdL3oFCcbccroG7GkV4oEVtbygS2pBVP28chfNETEN8yqE3q6gMws4F2ZsbfE8rDGEbgBqTnv5xahH5RFT";
+    let launchlab: Vec<_> = parse(LAUNCHLAB_SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::RaydiumLaunchlabTrade(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(launchlab.len(), 1);
+    assert_eq!(launchlab[0].metadata.slot, 438_880_206);
+    assert_eq!(launchlab[0].amount_in, 511_580_573);
+    assert_eq!(launchlab[0].amount_out, 5_169_841_048_834);
+}


### PR DESCRIPTION
## Summary
- parse the current Meteora DLMM Anchor event-CPI prefix layout while retaining legacy suffix compatibility
- update current Meteora, Raydium, and Orca instruction/event layouts and official IDLs
- preserve repeated swaps and liquidity events with occurrence-aware log/instruction deduplication
- add reusable mainnet transaction fixtures captured on 2026-08-13 for Meteora DLMM, PumpFun, PumpSwap, Raydium, and Orca

## Notable fixes
- Meteora DLMM Swap/Swap2 and current liquidity, position, and fee event layouts
- Raydium CPMM SwapEvent discriminator, payload, and pool account index
- Raydium AMM V4 57-byte ray_log and current 17/18-account swap layouts
- Orca Whirlpool swap and swap_v2 pool account indices
- nested/direct-child CPI merging without dropping multiple events from one transaction

## Validation
- cargo test: 197 unit tests passed, 4 mainnet fixture tests passed, 10 doc tests passed, 2 ignored
- cargo test --no-default-features --features parse-zero-copy: passed
- live mainnet replay with RUN_MAINNET_TESTS=1: passed for all eight stored signatures
- cargo fmt --all -- --check
- git diff --check