### PR TITLE
release: prepare sol-parser-sdk 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "sol-parser-sdk"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sol-parser-sdk"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["William <byteblock6@gmail.com>", "sgxiang <sgxiang@gmail.com>", "wei <1415121722@qq.com>"]
 repository = "https://github.com/0xfnzero/sol-parser-sdk"

--- a/README.md
+++ b/README.md
@@ -113,16 +113,23 @@ sol-parser-sdk = { path = "../sol-parser-sdk", default-features = false, feature
 
 ```toml
 # Add to your Cargo.toml
-sol-parser-sdk = "0.6.1"
+sol-parser-sdk = "0.6.2"
 ```
 
 Or with the zero-copy parser (maximum performance):
 
 ```toml
-sol-parser-sdk = { version = "0.6.1", default-features = false, features = ["parse-zero-copy"] }
+sol-parser-sdk = { version = "0.6.2", default-features = false, features = ["parse-zero-copy"] }
 ```
 
 ### Release Notes
+
+#### v0.6.2
+
+- Parses the current Meteora DLMM Anchor event-CPI prefix layout while retaining legacy suffix compatibility.
+- Aligns Meteora DLMM, Raydium CPMM/AMM V4, and Orca Whirlpool event and account layouts with current official sources.
+- Preserves repeated swaps and liquidity events with occurrence-aware log/instruction deduplication and stack-aware CPI merging.
+- Adds reusable mainnet transaction fixtures captured on 2026-08-13 for Meteora DLMM, PumpFun, PumpSwap, Raydium, and Orca.
 
 #### v0.6.1
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,16 +113,23 @@ sol-parser-sdk = { path = "../sol-parser-sdk", default-features = false, feature
 
 ```toml
 # 在 Cargo.toml 中添加
-sol-parser-sdk = "0.6.1"
+sol-parser-sdk = "0.6.2"
 ```
 
 或使用零拷贝解析器（最高性能）：
 
 ```toml
-sol-parser-sdk = { version = "0.6.1", default-features = false, features = ["parse-zero-copy"] }
+sol-parser-sdk = { version = "0.6.2", default-features = false, features = ["parse-zero-copy"] }
 ```
 
 ### 发布说明
+
+#### v0.6.2
+
+- 支持当前 Meteora DLMM Anchor event-CPI 前缀布局，同时保留 legacy 后缀格式兼容。
+- 按当前官方来源对齐 Meteora DLMM、Raydium CPMM/AMM V4 和 Orca Whirlpool 的事件与账户布局。
+- 使用 occurrence-aware 日志/指令去重和 stack-aware CPI 合并，保留同一交易中的重复 swap 与流动性事件。
+- 加入 2026-08-13 采集的可复用主网交易 fixture，覆盖 Meteora DLMM、PumpFun、PumpSwap、Raydium 和 Orca。
 
 #### v0.6.1
 


### PR DESCRIPTION
## Summary
- bump the crate and lockfile version to 0.6.2
- update crates.io dependency examples in the English and Chinese READMEs
- document the current Meteora DLMM event-CPI fix, Raydium and Orca layout updates, occurrence-aware deduplication, and reusable 2026-08-13 mainnet fixtures

## Included runtime fixes
The parser changes were merged in #17. This release makes those fixes available for downstream crates such as solana-streamer without using a path or Git dependency.

## Validation
- cargo test --locked: 197 unit tests passed
- current mainnet transaction fixtures: 4 passed, covering 8 stored signatures
- doctests: 10 passed, 2 ignored
- cargo publish --dry-run --allow-dirty: package verification passed
- git diff --check

## Release note
The dry run reports the existing transitive keccak 0.1.5 lockfile entry as yanked. Package verification still succeeds, and this PR does not introduce that dependency.