### PR TITLE
fix: expose Raydium LaunchLab quote context

### DIFF
--- a/src/core/account_dispatcher.rs
+++ b/src/core/account_dispatcher.rs
@@ -60,6 +60,7 @@ fn find_instruction_invoke_anchored<'a>(
     meta: &TransactionStatusMeta,
     transaction: &Option<Transaction>,
     account_keys: Option<&Vec<Vec<u8>>>,
+    anchor_account_index: usize,
     anchor: &Pubkey,
 ) -> Option<&'a (i32, i32)> {
     if *anchor != Pubkey::default() {
@@ -72,7 +73,7 @@ fn find_instruction_invoke_anchored<'a>(
                 &meta.loaded_readonly_addresses,
                 invoke,
             )
-            .is_some_and(|get_account| get_account(0) == *anchor)
+            .is_some_and(|get_account| get_account(anchor_account_index) == *anchor)
         });
         if anchored.is_some() {
             return anchored;
@@ -146,8 +147,37 @@ macro_rules! fill_event_accounts_anchored {
             let account_keys =
                 $tx.as_ref().and_then(|tx| tx.message.as_ref()).map(|msg| &msg.account_keys);
             if let Some(invoke) =
-                find_instruction_invoke_anchored(invokes, $meta, $tx, account_keys, $anchor)
+                find_instruction_invoke_anchored(invokes, $meta, $tx, account_keys, 0, $anchor)
             {
+                if let Some(get_account) = get_instruction_account_getter(
+                    $meta,
+                    $tx,
+                    account_keys,
+                    &$meta.loaded_writable_addresses,
+                    &$meta.loaded_readonly_addresses,
+                    invoke,
+                ) {
+                    $filler(&get_account);
+                }
+            }
+        }
+    };
+}
+
+/// Pool-anchored account filling for protocols whose pool is not account zero.
+macro_rules! fill_event_accounts_anchored_at {
+    ($event:expr, $meta:expr, $tx:expr, $invokes:expr, $program_id:expr, $anchor_index:expr, $anchor:expr, $filler:expr) => {
+        if let Some(invokes) = $invokes.get($program_id) {
+            let account_keys =
+                $tx.as_ref().and_then(|tx| tx.message.as_ref()).map(|msg| &msg.account_keys);
+            if let Some(invoke) = find_instruction_invoke_anchored(
+                invokes,
+                $meta,
+                $tx,
+                account_keys,
+                $anchor_index,
+                $anchor,
+            ) {
                 if let Some(get_account) = get_instruction_account_getter(
                     $meta,
                     $tx,
@@ -684,24 +714,30 @@ pub fn fill_accounts_with_owned_keys(
 
         // RaydiumLaunchlab
         DexEvent::RaydiumLaunchlabTrade(e) => {
-            fill_event_accounts!(
+            let pool = e.pool_state;
+            fill_event_accounts_anchored_at!(
                 e,
                 meta,
                 transaction,
                 program_invokes,
                 &RAYDIUM_LAUNCHLAB_PROGRAM,
+                4,
+                &pool,
                 |get: &AccountGetter<'_>| {
                     account_fillers::raydium_launchlab::fill_trade_accounts(e, get);
                 }
             );
         }
         DexEvent::RaydiumLaunchlabPoolCreate(e) => {
-            fill_event_accounts!(
+            let pool = e.pool_state;
+            fill_event_accounts_anchored_at!(
                 e,
                 meta,
                 transaction,
                 program_invokes,
                 &RAYDIUM_LAUNCHLAB_PROGRAM,
+                5,
+                &pool,
                 |get: &AccountGetter<'_>| {
                     account_fillers::raydium_launchlab::fill_pool_create_accounts(e, get);
                 }
@@ -715,8 +751,8 @@ pub fn fill_accounts_with_owned_keys(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::events::{PumpSwapBuyEvent, PumpSwapSellEvent};
-    use crate::grpc::program_ids::PUMPSWAP_PROGRAM;
+    use crate::core::events::{PumpSwapBuyEvent, PumpSwapSellEvent, RaydiumLaunchlabTradeEvent};
+    use crate::grpc::program_ids::{PUMPSWAP_PROGRAM, RAYDIUM_LAUNCHLAB_PROGRAM};
     use yellowstone_grpc_proto::prelude::{
         CompiledInstruction, Message, MessageHeader, Transaction, TransactionStatusMeta,
     };
@@ -843,5 +879,83 @@ mod tests {
             ),
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn launchlab_trade_backfills_from_matching_pool_invoke() {
+        let first_pool = Pubkey::new_unique();
+        let second_pool = Pubkey::new_unique();
+        let first_quote_mint = Pubkey::new_unique();
+        let second_quote_mint = Pubkey::new_unique();
+        let padding = Pubkey::new_unique();
+        let static_pubkeys = [
+            first_pool,
+            second_pool,
+            first_quote_mint,
+            second_quote_mint,
+            RAYDIUM_LAUNCHLAB_PROGRAM,
+            padding,
+        ];
+        let account_keys = static_pubkeys.iter().map(|key| key.to_bytes().to_vec()).collect();
+        let launchlab_accounts = |pool_index, quote_mint_index| {
+            let mut accounts = vec![5u8; 15];
+            accounts[4] = pool_index;
+            accounts[10] = quote_mint_index;
+            accounts[14] = 4;
+            accounts
+        };
+        let transaction = Some(Transaction {
+            signatures: vec![vec![0u8; 64]],
+            message: Some(Message {
+                header: Some(MessageHeader::default()),
+                account_keys,
+                recent_blockhash: vec![0u8; 32],
+                instructions: vec![
+                    CompiledInstruction {
+                        program_id_index: 4,
+                        accounts: launchlab_accounts(0, 2),
+                        data: vec![0],
+                    },
+                    CompiledInstruction {
+                        program_id_index: 4,
+                        accounts: launchlab_accounts(1, 3),
+                        data: vec![0],
+                    },
+                ],
+                versioned: false,
+                address_table_lookups: Vec::new(),
+            }),
+        });
+        let meta = TransactionStatusMeta::default();
+        let invokes =
+            HashMap::from([(RAYDIUM_LAUNCHLAB_PROGRAM, vec![(0i32, -1i32), (1i32, -1i32)])]);
+        let mut event = DexEvent::RaydiumLaunchlabTrade(RaydiumLaunchlabTradeEvent {
+            metadata: EventMetadata::default(),
+            pool_state: first_pool,
+            user: Pubkey::default(),
+            amount_in: 1,
+            amount_out: 2,
+            is_buy: true,
+            trade_direction: TradeDirection::Buy,
+            exact_in: true,
+            global_config: Pubkey::default(),
+            platform_config: Pubkey::default(),
+            user_base_token: Pubkey::default(),
+            user_quote_token: Pubkey::default(),
+            base_vault: Pubkey::default(),
+            quote_vault: Pubkey::default(),
+            base_mint: Pubkey::default(),
+            quote_mint: Pubkey::default(),
+            base_token_program: Pubkey::default(),
+            quote_token_program: Pubkey::default(),
+        });
+
+        fill_accounts_with_owned_keys(&mut event, &meta, &transaction, &invokes);
+
+        let DexEvent::RaydiumLaunchlabTrade(event) = event else {
+            unreachable!();
+        };
+        assert_eq!(event.quote_mint, first_quote_mint);
+        assert_ne!(event.quote_mint, second_quote_mint);
     }
 }

--- a/src/core/account_fillers/raydium_launchlab.rs
+++ b/src/core/account_fillers/raydium_launchlab.rs
@@ -5,11 +5,11 @@ use solana_sdk::pubkey::Pubkey;
 
 pub type AccountGetter<'a> = dyn Fn(usize) -> Pubkey + 'a;
 
-/// 填充 Raydium LaunchLab Trade 事件账户
+/// Fills account context for a Raydium LaunchLab trade event.
 ///
 /// Raydium LaunchLab trade instruction account mapping:
-/// 0: payer
-/// 4: pool_state
+/// 0: payer, 2: global_config, 3: platform_config, 4: pool_state,
+/// 5-8: user token accounts and vaults, 9-12: mints and token programs.
 pub fn fill_trade_accounts(e: &mut RaydiumLaunchlabTradeEvent, get: &AccountGetter<'_>) {
     if e.user == Pubkey::default() {
         e.user = get(0);
@@ -17,18 +17,137 @@ pub fn fill_trade_accounts(e: &mut RaydiumLaunchlabTradeEvent, get: &AccountGett
     if e.pool_state == Pubkey::default() {
         e.pool_state = get(4);
     }
+    if e.global_config == Pubkey::default() {
+        e.global_config = get(2);
+    }
+    if e.platform_config == Pubkey::default() {
+        e.platform_config = get(3);
+    }
+    if e.user_base_token == Pubkey::default() {
+        e.user_base_token = get(5);
+    }
+    if e.user_quote_token == Pubkey::default() {
+        e.user_quote_token = get(6);
+    }
+    if e.base_vault == Pubkey::default() {
+        e.base_vault = get(7);
+    }
+    if e.quote_vault == Pubkey::default() {
+        e.quote_vault = get(8);
+    }
+    if e.base_mint == Pubkey::default() {
+        e.base_mint = get(9);
+    }
+    if e.quote_mint == Pubkey::default() {
+        e.quote_mint = get(10);
+    }
+    if e.base_token_program == Pubkey::default() {
+        e.base_token_program = get(11);
+    }
+    if e.quote_token_program == Pubkey::default() {
+        e.quote_token_program = get(12);
+    }
 }
 
-/// Raydium LaunchLab Pool Create 账户填充
+/// Fills account context for a Raydium LaunchLab pool-create event.
 ///
 /// Raydium LaunchLab initialize instruction account mapping:
-/// 1: creator
-/// 5: pool_state
+/// All current initialize variants share indices 0-9. `initialize` and
+/// `initialize_v2` use token-program indices 11-12, while
+/// `initialize_with_token_2022` uses indices 10-11.
 pub fn fill_pool_create_accounts(e: &mut RaydiumLaunchlabPoolCreateEvent, get: &AccountGetter<'_>) {
     if e.pool_state == Pubkey::default() {
         e.pool_state = get(5);
     }
     if e.creator == Pubkey::default() {
         e.creator = get(1);
+    }
+    if e.payer == Pubkey::default() {
+        e.payer = get(0);
+    }
+    if e.global_config == Pubkey::default() {
+        e.global_config = get(2);
+    }
+    if e.platform_config == Pubkey::default() {
+        e.platform_config = get(3);
+    }
+    if e.base_mint == Pubkey::default() {
+        e.base_mint = get(6);
+    }
+    if e.quote_mint == Pubkey::default() {
+        e.quote_mint = get(7);
+    }
+    if e.base_vault == Pubkey::default() {
+        e.base_vault = get(8);
+    }
+    if e.quote_vault == Pubkey::default() {
+        e.quote_vault = get(9);
+    }
+    let token_program_indices = if get(17) == crate::instr::raydium_launchlab::PROGRAM_ID_PUBKEY {
+        (11, 12)
+    } else if get(14) == crate::instr::raydium_launchlab::PROGRAM_ID_PUBKEY {
+        (10, 11)
+    } else {
+        return;
+    };
+    if e.base_token_program == Pubkey::default() {
+        e.base_token_program = get(token_program_indices.0);
+    }
+    if e.quote_token_program == Pubkey::default() {
+        e.quote_token_program = get(token_program_indices.1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event() -> RaydiumLaunchlabPoolCreateEvent {
+        RaydiumLaunchlabPoolCreateEvent {
+            metadata: EventMetadata::default(),
+            base_mint_param: BaseMintParam {
+                symbol: String::new(),
+                name: String::new(),
+                uri: String::new(),
+                decimals: 0,
+            },
+            pool_state: Pubkey::default(),
+            payer: Pubkey::default(),
+            creator: Pubkey::default(),
+            global_config: Pubkey::default(),
+            platform_config: Pubkey::default(),
+            base_mint: Pubkey::default(),
+            quote_mint: Pubkey::default(),
+            base_vault: Pubkey::default(),
+            quote_vault: Pubkey::default(),
+            base_token_program: Pubkey::default(),
+            quote_token_program: Pubkey::default(),
+        }
+    }
+
+    #[test]
+    fn pool_create_filler_handles_standard_initialize_layout() {
+        let mut accounts: Vec<_> = (0..18).map(|_| Pubkey::new_unique()).collect();
+        accounts[17] = crate::instr::raydium_launchlab::PROGRAM_ID_PUBKEY;
+        let get = |index: usize| accounts.get(index).copied().unwrap_or_default();
+        let mut event = event();
+
+        fill_pool_create_accounts(&mut event, &get);
+
+        assert_eq!(event.base_token_program, accounts[11]);
+        assert_eq!(event.quote_token_program, accounts[12]);
+    }
+
+    #[test]
+    fn pool_create_filler_handles_token_2022_initialize_layout() {
+        let mut accounts: Vec<_> = (0..15).map(|_| Pubkey::new_unique()).collect();
+        accounts[14] = crate::instr::raydium_launchlab::PROGRAM_ID_PUBKEY;
+        let get = |index: usize| accounts.get(index).copied().unwrap_or_default();
+        let mut event = event();
+
+        fill_pool_create_accounts(&mut event, &get);
+
+        assert_eq!(event.base_token_program, accounts[10]);
+        assert_eq!(event.quote_token_program, accounts[11]);
     }
 }

--- a/src/core/events/types.rs
+++ b/src/core/events/types.rs
@@ -76,7 +76,25 @@ pub struct RaydiumLaunchlabPoolCreateEvent {
     pub metadata: EventMetadata,
     pub base_mint_param: BaseMintParam,
     pub pool_state: Pubkey,
+    #[serde(default)]
+    pub payer: Pubkey,
     pub creator: Pubkey,
+    #[serde(default)]
+    pub global_config: Pubkey,
+    #[serde(default)]
+    pub platform_config: Pubkey,
+    #[serde(default)]
+    pub base_mint: Pubkey,
+    #[serde(default)]
+    pub quote_mint: Pubkey,
+    #[serde(default)]
+    pub base_vault: Pubkey,
+    #[serde(default)]
+    pub quote_vault: Pubkey,
+    #[serde(default)]
+    pub base_token_program: Pubkey,
+    #[serde(default)]
+    pub quote_token_program: Pubkey,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -106,6 +124,36 @@ pub struct RaydiumLaunchlabTradeEvent {
     pub trade_direction: TradeDirection,
     #[cfg_attr(feature = "parse-borsh", borsh(skip))]
     pub exact_in: bool,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub global_config: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub platform_config: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub user_base_token: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub user_quote_token: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub base_vault: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub quote_vault: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub base_mint: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub quote_mint: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub base_token_program: Pubkey,
+    #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
+    pub quote_token_program: Pubkey,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/core/merger.rs
+++ b/src/core/merger.rs
@@ -850,7 +850,16 @@ fn merge_raydium_launchlab_pool_create_log_preferred(
     log: &mut RaydiumLaunchlabPoolCreateEvent,
     ix: RaydiumLaunchlabPoolCreateEvent,
 ) {
+    fill_pk(&mut log.payer, ix.payer);
     fill_pk(&mut log.creator, ix.creator);
+    fill_pk(&mut log.global_config, ix.global_config);
+    fill_pk(&mut log.platform_config, ix.platform_config);
+    fill_pk(&mut log.base_mint, ix.base_mint);
+    fill_pk(&mut log.quote_mint, ix.quote_mint);
+    fill_pk(&mut log.base_vault, ix.base_vault);
+    fill_pk(&mut log.quote_vault, ix.quote_vault);
+    fill_pk(&mut log.base_token_program, ix.base_token_program);
+    fill_pk(&mut log.quote_token_program, ix.quote_token_program);
     fill_str_if_empty(&mut log.base_mint_param.name, &ix.base_mint_param.name);
     fill_str_if_empty(&mut log.base_mint_param.symbol, &ix.base_mint_param.symbol);
     fill_str_if_empty(&mut log.base_mint_param.uri, &ix.base_mint_param.uri);
@@ -866,12 +875,22 @@ fn merge_raydium_launchlab_migrate_amm_log_preferred(
     fill_pk(&mut log.user, ix.user);
 }
 
-/// RaydiumLaunchlabTrade 当前无独立「仅 ix 账户」字段；保留占位以便与 dedup 对齐，日后扩展。
 #[inline]
 fn merge_raydium_launchlab_trade_log_preferred(
-    _log: &mut RaydiumLaunchlabTradeEvent,
-    _ix: RaydiumLaunchlabTradeEvent,
+    log: &mut RaydiumLaunchlabTradeEvent,
+    ix: RaydiumLaunchlabTradeEvent,
 ) {
+    fill_pk(&mut log.user, ix.user);
+    fill_pk(&mut log.global_config, ix.global_config);
+    fill_pk(&mut log.platform_config, ix.platform_config);
+    fill_pk(&mut log.user_base_token, ix.user_base_token);
+    fill_pk(&mut log.user_quote_token, ix.user_quote_token);
+    fill_pk(&mut log.base_vault, ix.base_vault);
+    fill_pk(&mut log.quote_vault, ix.quote_vault);
+    fill_pk(&mut log.base_mint, ix.base_mint);
+    fill_pk(&mut log.quote_mint, ix.quote_mint);
+    fill_pk(&mut log.base_token_program, ix.base_token_program);
+    fill_pk(&mut log.quote_token_program, ix.quote_token_program);
 }
 
 #[inline]

--- a/src/grpc/log_instr_dedup.rs
+++ b/src/grpc/log_instr_dedup.rs
@@ -42,6 +42,7 @@ enum LogInstrDedupKey {
         pool: Pubkey,
         user: Pubkey,
         is_buy: bool,
+        occurrence: u16,
     },
     RaydiumLaunchlabPoolCreate {
         pool: Pubkey,
@@ -121,6 +122,7 @@ fn pumpswap_ix_lane(ix_name: &str) -> u8 {
 #[derive(Clone, Hash, PartialEq, Eq)]
 enum OccurrenceBase {
     PumpFun { mint: Pubkey, user: Pubkey, is_buy: bool, lane: u8 },
+    RaydiumLaunchlab { pool: Pubkey, user: Pubkey, is_buy: bool },
     RaydiumClmm(Pubkey),
     RaydiumCpmm(Pubkey),
     RaydiumAmmV4 { base_out: bool, amount: u64 },
@@ -164,6 +166,7 @@ fn log_instr_dedup_key(ev: &DexEvent) -> Option<LogInstrDedupKey> {
             pool: t.pool_state,
             user: t.user,
             is_buy: t.is_buy,
+            occurrence: 0,
         }),
         RaydiumLaunchlabPoolCreate(p) => {
             Some(LogInstrDedupKey::RaydiumLaunchlabPoolCreate { pool: p.pool_state })
@@ -216,6 +219,22 @@ fn next_dedup_key(
                 occurrence_counts,
             );
             Some(pumpfun_trade_key_with_occ(t, occ))
+        }
+        RaydiumLaunchlabTrade(t) => {
+            let occurrence = next_occurrence(
+                OccurrenceBase::RaydiumLaunchlab {
+                    pool: t.pool_state,
+                    user: t.user,
+                    is_buy: t.is_buy,
+                },
+                occurrence_counts,
+            );
+            Some(LogInstrDedupKey::RaydiumLaunchlabTrade {
+                pool: t.pool_state,
+                user: t.user,
+                is_buy: t.is_buy,
+                occurrence,
+            })
         }
         RaydiumClmmSwap(s) => {
             let occurrence =
@@ -306,7 +325,7 @@ mod tests {
     use super::*;
     use crate::core::events::{
         EventMetadata, PumpFunCreateTokenEvent, PumpFunCreateV2TokenEvent, PumpFunTradeEvent,
-        PumpSwapCreatePoolEvent,
+        PumpSwapCreatePoolEvent, RaydiumLaunchlabTradeEvent, TradeDirection,
     };
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
 
@@ -411,6 +430,59 @@ mod tests {
             vec![clmm_swap(pool, true, 0), clmm_swap(pool, false, 0)],
         );
         assert_eq!(merged.len(), 2);
+    }
+
+    fn launchlab_trade(pool: Pubkey, user: Pubkey, amount_in: u64, quote_mint: Pubkey) -> DexEvent {
+        DexEvent::RaydiumLaunchlabTrade(RaydiumLaunchlabTradeEvent {
+            metadata: dummy_meta(),
+            pool_state: pool,
+            user,
+            amount_in,
+            amount_out: amount_in.saturating_mul(2),
+            is_buy: true,
+            trade_direction: TradeDirection::Buy,
+            exact_in: true,
+            global_config: Pubkey::default(),
+            platform_config: Pubkey::default(),
+            user_base_token: Pubkey::default(),
+            user_quote_token: Pubkey::default(),
+            base_vault: Pubkey::default(),
+            quote_vault: Pubkey::default(),
+            base_mint: Pubkey::default(),
+            quote_mint,
+            base_token_program: Pubkey::default(),
+            quote_token_program: Pubkey::default(),
+        })
+    }
+
+    #[test]
+    fn launchlab_same_pool_occurrences_are_retained_and_enriched_in_order() {
+        let pool = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let first_quote_mint = Pubkey::new_unique();
+        let second_quote_mint = Pubkey::new_unique();
+        let merged = dedupe_log_instruction_events(
+            vec![
+                launchlab_trade(pool, user, 100, Pubkey::default()),
+                launchlab_trade(pool, user, 200, Pubkey::default()),
+            ],
+            vec![
+                launchlab_trade(pool, user, 9_999, first_quote_mint),
+                launchlab_trade(pool, user, 8_888, second_quote_mint),
+            ],
+        );
+
+        assert_eq!(merged.len(), 2);
+        let DexEvent::RaydiumLaunchlabTrade(first) = &merged[0] else {
+            unreachable!();
+        };
+        let DexEvent::RaydiumLaunchlabTrade(second) = &merged[1] else {
+            unreachable!();
+        };
+        assert_eq!(first.amount_in, 100);
+        assert_eq!(first.quote_mint, first_quote_mint);
+        assert_eq!(second.amount_in, 200);
+        assert_eq!(second.quote_mint, second_quote_mint);
     }
 
     #[test]

--- a/src/instr/raydium_launchlab.rs
+++ b/src/instr/raydium_launchlab.rs
@@ -81,11 +81,26 @@ pub fn parse_instruction(
             false,
             false,
         ),
-        discriminators::INITIALIZE
-        | discriminators::INITIALIZE_V2
-        | discriminators::INITIALIZE_WITH_TOKEN_2022 => {
-            parse_pool_create_instruction(data, accounts, signature, slot, tx_index, block_time_us)
+        discriminators::INITIALIZE | discriminators::INITIALIZE_V2 => {
+            parse_pool_create_instruction(
+                data,
+                accounts,
+                signature,
+                slot,
+                tx_index,
+                block_time_us,
+                (11, 12),
+            )
         }
+        discriminators::INITIALIZE_WITH_TOKEN_2022 => parse_pool_create_instruction(
+            data,
+            accounts,
+            signature,
+            slot,
+            tx_index,
+            block_time_us,
+            (10, 11),
+        ),
         // The LaunchLab IDL does not expose enough fields to synthesize a
         // migration event with the SDK's migrate layout.
         discriminators::MIGRATE_TO_AMM | discriminators::MIGRATE_TO_CPSWAP => None,
@@ -93,9 +108,9 @@ pub fn parse_instruction(
     }
 }
 
-/// 解析 buy/sell 指令。
+/// Parses a buy or sell instruction.
 ///
-/// 外层指令只携带用户输入的 amount / min-max amount；真实成交量由 log 事件覆盖。
+/// Outer instructions contain user limits; log events remain authoritative for executed amounts.
 fn parse_trade_instruction(
     data: &[u8],
     accounts: &[Pubkey],
@@ -124,10 +139,20 @@ fn parse_trade_instruction(
         is_buy,
         trade_direction: if is_buy { TradeDirection::Buy } else { TradeDirection::Sell },
         exact_in,
+        global_config: get_account(accounts, 2).unwrap_or_default(),
+        platform_config: get_account(accounts, 3).unwrap_or_default(),
+        user_base_token: get_account(accounts, 5).unwrap_or_default(),
+        user_quote_token: get_account(accounts, 6).unwrap_or_default(),
+        base_vault: get_account(accounts, 7).unwrap_or_default(),
+        quote_vault: get_account(accounts, 8).unwrap_or_default(),
+        base_mint: get_account(accounts, 9).unwrap_or_default(),
+        quote_mint: get_account(accounts, 10).unwrap_or_default(),
+        base_token_program: get_account(accounts, 11).unwrap_or_default(),
+        quote_token_program: get_account(accounts, 12).unwrap_or_default(),
     }))
 }
 
-/// 解析 initialize / initialize_v2 / initialize_with_token_2022 指令。
+/// Parses an initialize variant using its current IDL token-program indices.
 fn parse_pool_create_instruction(
     data: &[u8],
     accounts: &[Pubkey],
@@ -135,6 +160,7 @@ fn parse_pool_create_instruction(
     slot: u64,
     tx_index: u64,
     block_time_us: Option<i64>,
+    token_program_indices: (usize, usize),
 ) -> Option<DexEvent> {
     let base_mint_param = parse_mint_params(data)?;
 
@@ -145,7 +171,16 @@ fn parse_pool_create_instruction(
         metadata,
         base_mint_param,
         pool_state,
+        payer: get_account(accounts, 0).unwrap_or_default(),
         creator: get_account(accounts, 1).unwrap_or_default(),
+        global_config: get_account(accounts, 2).unwrap_or_default(),
+        platform_config: get_account(accounts, 3).unwrap_or_default(),
+        base_mint: get_account(accounts, 6).unwrap_or_default(),
+        quote_mint: get_account(accounts, 7).unwrap_or_default(),
+        base_vault: get_account(accounts, 8).unwrap_or_default(),
+        quote_vault: get_account(accounts, 9).unwrap_or_default(),
+        base_token_program: get_account(accounts, token_program_indices.0).unwrap_or_default(),
+        quote_token_program: get_account(accounts, token_program_indices.1).unwrap_or_default(),
     }))
 }
 
@@ -172,4 +207,175 @@ fn read_borsh_string(data: &[u8], offset: &mut usize) -> Option<String> {
 fn read_u32_le(data: &[u8], offset: usize) -> Option<u32> {
     let bytes = data.get(offset..offset + 4)?;
     Some(u32::from_le_bytes(bytes.try_into().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trade_data(discriminator: [u8; 8]) -> Vec<u8> {
+        let mut data = discriminator.to_vec();
+        data.extend_from_slice(&1_000u64.to_le_bytes());
+        data.extend_from_slice(&900u64.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        data
+    }
+
+    fn initialize_data(discriminator: [u8; 8]) -> Vec<u8> {
+        let mut data = discriminator.to_vec();
+        data.push(6);
+        for value in ["USD1 Token", "U1", "https://example.invalid/u1.json"] {
+            data.extend_from_slice(&(value.len() as u32).to_le_bytes());
+            data.extend_from_slice(value.as_bytes());
+        }
+        data
+    }
+
+    #[test]
+    fn trade_instruction_exposes_current_idl_account_context() {
+        let accounts: Vec<_> = (0..15).map(|_| Pubkey::new_unique()).collect();
+
+        for discriminator in [
+            discriminators::BUY_EXACT_IN,
+            discriminators::BUY_EXACT_OUT,
+            discriminators::SELL_EXACT_IN,
+            discriminators::SELL_EXACT_OUT,
+        ] {
+            let event = parse_instruction(
+                &trade_data(discriminator),
+                &accounts,
+                Signature::default(),
+                1,
+                2,
+                Some(3),
+            )
+            .expect("trade event");
+            let DexEvent::RaydiumLaunchlabTrade(event) = event else {
+                panic!("expected LaunchLab trade");
+            };
+
+            assert_eq!(event.user, accounts[0]);
+            assert_eq!(event.global_config, accounts[2]);
+            assert_eq!(event.platform_config, accounts[3]);
+            assert_eq!(event.pool_state, accounts[4]);
+            assert_eq!(event.user_base_token, accounts[5]);
+            assert_eq!(event.user_quote_token, accounts[6]);
+            assert_eq!(event.base_vault, accounts[7]);
+            assert_eq!(event.quote_vault, accounts[8]);
+            assert_eq!(event.base_mint, accounts[9]);
+            assert_eq!(event.quote_mint, accounts[10]);
+            assert_eq!(event.base_token_program, accounts[11]);
+            assert_eq!(event.quote_token_program, accounts[12]);
+        }
+    }
+
+    #[test]
+    fn initialize_instructions_expose_current_idl_mint_context() {
+        for (discriminator, account_count, token_program_indices) in [
+            (discriminators::INITIALIZE, 18, (11, 12)),
+            (discriminators::INITIALIZE_V2, 18, (11, 12)),
+            (discriminators::INITIALIZE_WITH_TOKEN_2022, 15, (10, 11)),
+        ] {
+            let accounts: Vec<_> = (0..account_count).map(|_| Pubkey::new_unique()).collect();
+            let event = parse_instruction(
+                &initialize_data(discriminator),
+                &accounts,
+                Signature::default(),
+                1,
+                2,
+                Some(3),
+            )
+            .expect("pool create event");
+            let DexEvent::RaydiumLaunchlabPoolCreate(event) = event else {
+                panic!("expected LaunchLab pool create");
+            };
+
+            assert_eq!(event.payer, accounts[0]);
+            assert_eq!(event.creator, accounts[1]);
+            assert_eq!(event.global_config, accounts[2]);
+            assert_eq!(event.platform_config, accounts[3]);
+            assert_eq!(event.pool_state, accounts[5]);
+            assert_eq!(event.base_mint, accounts[6]);
+            assert_eq!(event.quote_mint, accounts[7]);
+            assert_eq!(event.base_vault, accounts[8]);
+            assert_eq!(event.quote_vault, accounts[9]);
+            assert_eq!(event.base_token_program, accounts[token_program_indices.0]);
+            assert_eq!(event.quote_token_program, accounts[token_program_indices.1]);
+        }
+    }
+
+    #[test]
+    fn trade_json_without_new_account_context_remains_readable() {
+        let accounts: Vec<_> = (0..15).map(|_| Pubkey::new_unique()).collect();
+        let event = parse_instruction(
+            &trade_data(discriminators::BUY_EXACT_IN),
+            &accounts,
+            Signature::default(),
+            1,
+            2,
+            Some(3),
+        )
+        .expect("trade event");
+        let DexEvent::RaydiumLaunchlabTrade(event) = event else {
+            panic!("expected LaunchLab trade");
+        };
+        let mut json = serde_json::to_value(event).expect("serialize event");
+        let object = json.as_object_mut().expect("event object");
+        for field in [
+            "global_config",
+            "platform_config",
+            "user_base_token",
+            "user_quote_token",
+            "base_vault",
+            "quote_vault",
+            "base_mint",
+            "quote_mint",
+            "base_token_program",
+            "quote_token_program",
+        ] {
+            object.remove(field);
+        }
+
+        let restored: RaydiumLaunchlabTradeEvent =
+            serde_json::from_value(json).expect("deserialize legacy event");
+        assert_eq!(restored.quote_mint, Pubkey::default());
+        assert_eq!(restored.global_config, Pubkey::default());
+    }
+
+    #[test]
+    fn pool_create_json_without_new_account_context_remains_readable() {
+        let accounts: Vec<_> = (0..18).map(|_| Pubkey::new_unique()).collect();
+        let event = parse_instruction(
+            &initialize_data(discriminators::INITIALIZE),
+            &accounts,
+            Signature::default(),
+            1,
+            2,
+            Some(3),
+        )
+        .expect("pool create event");
+        let DexEvent::RaydiumLaunchlabPoolCreate(event) = event else {
+            panic!("expected LaunchLab pool create");
+        };
+        let mut json = serde_json::to_value(event).expect("serialize event");
+        let object = json.as_object_mut().expect("event object");
+        for field in [
+            "payer",
+            "global_config",
+            "platform_config",
+            "base_mint",
+            "quote_mint",
+            "base_vault",
+            "quote_vault",
+            "base_token_program",
+            "quote_token_program",
+        ] {
+            object.remove(field);
+        }
+
+        let restored: RaydiumLaunchlabPoolCreateEvent =
+            serde_json::from_value(json).expect("deserialize legacy event");
+        assert_eq!(restored.payer, Pubkey::default());
+        assert_eq!(restored.quote_mint, Pubkey::default());
+    }
 }

--- a/src/logs/raydium_launchlab.rs
+++ b/src/logs/raydium_launchlab.rs
@@ -91,6 +91,16 @@ pub fn parse_trade_from_data(data: &[u8], metadata: EventMetadata) -> Option<Dex
         is_buy,
         trade_direction: if is_buy { TradeDirection::Buy } else { TradeDirection::Sell },
         exact_in,
+        global_config: Pubkey::default(),
+        platform_config: Pubkey::default(),
+        user_base_token: Pubkey::default(),
+        user_quote_token: Pubkey::default(),
+        base_vault: Pubkey::default(),
+        quote_vault: Pubkey::default(),
+        base_mint: Pubkey::default(),
+        quote_mint: Pubkey::default(),
+        base_token_program: Pubkey::default(),
+        quote_token_program: Pubkey::default(),
     }))
 }
 
@@ -110,7 +120,16 @@ pub fn parse_pool_create_from_data(data: &[u8], metadata: EventMetadata) -> Opti
         metadata,
         base_mint_param,
         pool_state,
+        payer: Pubkey::default(),
         creator,
+        global_config: Pubkey::default(),
+        platform_config: Pubkey::default(),
+        base_mint: Pubkey::default(),
+        quote_mint: Pubkey::default(),
+        base_vault: Pubkey::default(),
+        quote_vault: Pubkey::default(),
+        base_token_program: Pubkey::default(),
+        quote_token_program: Pubkey::default(),
     }))
 }
 

--- a/tests/current_mainnet_transactions.rs
+++ b/tests/current_mainnet_transactions.rs
@@ -176,3 +176,27 @@ fn current_raydium_clmm_cpmm_amm_v4_and_launchlab() {
     assert_eq!(launchlab[0].amount_in, 511_580_573);
     assert_eq!(launchlab[0].amount_out, 5_169_841_048_834);
 }
+
+#[test]
+fn current_raydium_launchlab_usd1_trade_exposes_quote_context() {
+    if !run_mainnet_tests() {
+        return;
+    }
+    const SIGNATURE: &str =
+        "zuaKyxjpM7G5et2XqZofjjGNczNduGs6g8ipCEeZKKV7h6FFgRNJbXnzfufSZWD3bEacmf8sVktXpZaadQhmVuJ";
+    const USD1_MINT: &str = "USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB";
+    const USD1_GLOBAL_CONFIG: &str = "EPiZbnrThjyLnoQ6QQzkxeFqyL5uyg9RzNHHAudUPxBz";
+
+    let trades: Vec<_> = parse(SIGNATURE)
+        .into_iter()
+        .filter_map(|event| match event {
+            DexEvent::RaydiumLaunchlabTrade(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(trades.len(), 1);
+    assert_eq!(trades[0].metadata.slot, 438_894_516);
+    assert_eq!(trades[0].quote_mint.to_string(), USD1_MINT);
+    assert_eq!(trades[0].global_config.to_string(), USD1_GLOBAL_CONFIG);
+}


### PR DESCRIPTION
## Summary

- expose current LaunchLab config, mint, vault, token-account, and token-program context on trade and pool-create events
- handle the distinct `initialize_with_token_2022` account layout and preserve legacy JSON/Borsh compatibility
- anchor account enrichment by pool and preserve repeated same-pool trades during log/instruction deduplication
- add a reusable current-mainnet USD1 fixture from slot 438894516

This provides the parser-side Raydium USD1 capability requested by 0xfnzero/solana-streamer#45.

## Verification

- `cargo test --locked --lib` (205 passed)
- `cargo test --locked --no-default-features --features parse-zero-copy --lib` (205 passed)
- `RUN_MAINNET_TESTS=1 cargo test --locked --test current_mainnet_transactions current_raydium_launchlab_usd1_trade_exposes_quote_context -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --locked --all-targets -- -D warnings -A clippy::result_large_err -A clippy::items_after_test_module`

## Mainnet fixture

- signature: `zuaKyxjpM7G5et2XqZofjjGNczNduGs6g8ipCEeZKKV7h6FFgRNJbXnzfufSZWD3bEacmf8sVktXpZaadQhmVuJ`
- quote mint: `USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB`
- slot: `438894516`