### PR TITLE
Release sol-parser-sdk 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "sol-parser-sdk"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sol-parser-sdk"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["William <byteblock6@gmail.com>", "sgxiang <sgxiang@gmail.com>", "wei <1415121722@qq.com>"]
 repository = "https://github.com/0xfnzero/sol-parser-sdk"

--- a/README.md
+++ b/README.md
@@ -113,16 +113,23 @@ sol-parser-sdk = { path = "../sol-parser-sdk", default-features = false, feature
 
 ```toml
 # Add to your Cargo.toml
-sol-parser-sdk = "0.6.2"
+sol-parser-sdk = "0.6.3"
 ```
 
 Or with the zero-copy parser (maximum performance):
 
 ```toml
-sol-parser-sdk = { version = "0.6.2", default-features = false, features = ["parse-zero-copy"] }
+sol-parser-sdk = { version = "0.6.3", default-features = false, features = ["parse-zero-copy"] }
 ```
 
 ### Release Notes
+
+#### v0.6.3
+
+- Exposes current Raydium LaunchLab quote mint and global configuration context, including USD1 pools.
+- Adds opt-in transaction fee, priority fee, compute budget, and SWQoS tip parsing for all providers supported by sol-trade-sdk.
+- Identifies each recognized tip provider and recipient while keeping the disabled transaction-cost path allocation-free and effectively zero-cost.
+- Adds reusable mainnet transaction fixtures captured on 2026-08-13 for LaunchLab USD1 and transaction-cost parsing.
 
 #### v0.6.2
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,16 +113,23 @@ sol-parser-sdk = { path = "../sol-parser-sdk", default-features = false, feature
 
 ```toml
 # 在 Cargo.toml 中添加
-sol-parser-sdk = "0.6.2"
+sol-parser-sdk = "0.6.3"
 ```
 
 或使用零拷贝解析器（最高性能）：
 
 ```toml
-sol-parser-sdk = { version = "0.6.2", default-features = false, features = ["parse-zero-copy"] }
+sol-parser-sdk = { version = "0.6.3", default-features = false, features = ["parse-zero-copy"] }
 ```
 
 ### 发布说明
+
+#### v0.6.3
+
+- 输出当前 Raydium LaunchLab 的 quote mint 和 global configuration 上下文，包括 USD1 池。
+- 增加可选的交易费、优先费、compute budget 和 SWQoS tip 解析，覆盖 sol-trade-sdk 支持的全部服务商。
+- 返回每笔已识别 tip 的服务商和收款地址；未启用交易成本解析时不分配内存，开销可忽略。
+- 增加 2026-08-13 采集的 LaunchLab USD1 和交易成本主网交易 fixture，便于后续复用验证。
 
 #### v0.6.2
 


### PR DESCRIPTION
## Summary

- bump the crate and lockfile version to 0.6.3
- document LaunchLab USD1 context and opt-in transaction cost/SWQoS tip parsing
- update crates.io dependency examples in the English and Chinese READMEs

## Verification

- `cargo fmt --check`
- `cargo test --locked`
- `cargo test --locked --no-default-features --features parse-zero-copy`
- default and zero-copy library Clippy with warnings denied, excluding the existing `result_large_err` lint
- `cargo package --locked --allow-dirty`
- `git diff --check`