### PR TITLE
fix: anchor Meteora DLMM swap mint filling

### DIFF
--- a/src/core/account_dispatcher.rs
+++ b/src/core/account_dispatcher.rs
@@ -676,12 +676,14 @@ pub fn fill_accounts_with_owned_keys(
 
         // Meteora DLMM
         DexEvent::MeteoraDlmmSwap(e) => {
-            fill_event_accounts!(
+            let pool = e.pool;
+            fill_event_accounts_anchored!(
                 e,
                 meta,
                 transaction,
                 program_invokes,
                 &METEORA_DLMM_PROGRAM,
+                &pool,
                 |get: &AccountGetter<'_>| {
                     account_fillers::meteora::fill_dlmm_swap_accounts(e, get);
                 }
@@ -751,8 +753,12 @@ pub fn fill_accounts_with_owned_keys(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::events::{PumpSwapBuyEvent, PumpSwapSellEvent, RaydiumLaunchlabTradeEvent};
-    use crate::grpc::program_ids::{PUMPSWAP_PROGRAM, RAYDIUM_LAUNCHLAB_PROGRAM};
+    use crate::core::events::{
+        MeteoraDlmmSwapEvent, PumpSwapBuyEvent, PumpSwapSellEvent, RaydiumLaunchlabTradeEvent,
+    };
+    use crate::grpc::program_ids::{
+        METEORA_DLMM_PROGRAM, PUMPSWAP_PROGRAM, RAYDIUM_LAUNCHLAB_PROGRAM,
+    };
     use yellowstone_grpc_proto::prelude::{
         CompiledInstruction, Message, MessageHeader, Transaction, TransactionStatusMeta,
     };
@@ -879,6 +885,94 @@ mod tests {
             ),
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn dlmm_route_backfills_each_leg_from_matching_pool_invoke() {
+        let first_pool = Pubkey::new_unique();
+        let second_pool = Pubkey::new_unique();
+        let first_x_mint = Pubkey::new_unique();
+        let first_y_mint = Pubkey::new_unique();
+        let second_x_mint = Pubkey::new_unique();
+        let second_y_mint = Pubkey::new_unique();
+        let padding = Pubkey::new_unique();
+        let static_pubkeys = [
+            first_pool,
+            second_pool,
+            first_x_mint,
+            first_y_mint,
+            second_x_mint,
+            second_y_mint,
+            METEORA_DLMM_PROGRAM,
+            padding,
+        ];
+        let account_keys = static_pubkeys.iter().map(|key| key.to_bytes().to_vec()).collect();
+
+        let dlmm_accounts = |len, pool_index, x_mint_index, y_mint_index| {
+            let mut accounts = vec![7u8; len];
+            accounts[0] = pool_index;
+            accounts[6] = x_mint_index;
+            accounts[7] = y_mint_index;
+            accounts
+        };
+        let transaction = Some(Transaction {
+            signatures: vec![vec![0u8; 64]],
+            message: Some(Message {
+                header: Some(MessageHeader::default()),
+                account_keys,
+                recent_blockhash: vec![0u8; 32],
+                instructions: vec![
+                    CompiledInstruction {
+                        program_id_index: 6,
+                        accounts: dlmm_accounts(20, 0, 2, 3),
+                        data: vec![0],
+                    },
+                    CompiledInstruction {
+                        program_id_index: 6,
+                        accounts: dlmm_accounts(15, 1, 4, 5),
+                        data: vec![0],
+                    },
+                ],
+                versioned: false,
+                address_table_lookups: Vec::new(),
+            }),
+        });
+        let meta = TransactionStatusMeta::default();
+        let invokes = HashMap::from([(METEORA_DLMM_PROGRAM, vec![(0i32, -1i32), (1i32, -1i32)])]);
+        let swap_event = |pool| {
+            DexEvent::MeteoraDlmmSwap(MeteoraDlmmSwapEvent {
+                metadata: EventMetadata::default(),
+                token_x_mint: Pubkey::default(),
+                token_y_mint: Pubkey::default(),
+                pool,
+                from: Pubkey::default(),
+                start_bin_id: 0,
+                end_bin_id: 0,
+                amount_in: 1,
+                amount_out: 1,
+                swap_for_y: false,
+                fee: 0,
+                protocol_fee: 0,
+                fee_bps: 0,
+                host_fee: 0,
+            })
+        };
+
+        let mut first_event = swap_event(first_pool);
+        fill_accounts_with_owned_keys(&mut first_event, &meta, &transaction, &invokes);
+        let DexEvent::MeteoraDlmmSwap(first_event) = first_event else {
+            unreachable!();
+        };
+        assert_eq!(first_event.token_x_mint, first_x_mint);
+        assert_eq!(first_event.token_y_mint, first_y_mint);
+
+        let mut second_event = swap_event(second_pool);
+        fill_accounts_with_owned_keys(&mut second_event, &meta, &transaction, &invokes);
+        let DexEvent::MeteoraDlmmSwap(second_event) = second_event else {
+            unreachable!();
+        };
+        assert_eq!(second_event.token_x_mint, second_x_mint);
+        assert_eq!(second_event.token_y_mint, second_y_mint);
     }
 
     #[test]

--- a/src/core/events/types.rs
+++ b/src/core/events/types.rs
@@ -2638,8 +2638,10 @@ pub struct MeteoraDlmmSwapEvent {
     pub metadata: EventMetadata,
 
     #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
     pub token_x_mint: Pubkey,
     #[cfg_attr(feature = "parse-borsh", borsh(skip))]
+    #[serde(default)]
     pub token_y_mint: Pubkey,
 
     // === Borsh 序列化字段（从 inner instruction data 读取）===
@@ -2758,9 +2760,12 @@ pub struct MeteoraDlmmClaimFeeEvent {
 
 #[cfg(test)]
 mod serde_compat_tests {
-    use super::{PumpSwapBuyEvent, PumpSwapPool, PumpSwapSellEvent};
+    use super::{
+        EventMetadata, MeteoraDlmmSwapEvent, PumpSwapBuyEvent, PumpSwapPool, PumpSwapSellEvent,
+    };
     use serde::Serialize;
     use serde_json::Value;
+    use solana_sdk::pubkey::Pubkey;
 
     fn without_fields<T: Serialize>(value: &T, fields: &[&str]) -> Value {
         let mut json = serde_json::to_value(value).expect("serialize fixture");
@@ -2822,6 +2827,32 @@ mod serde_compat_tests {
 
         let decoded: PumpSwapPool = serde_json::from_value(json).expect("legacy pool JSON");
         assert_eq!(decoded.virtual_quote_reserves, 0);
+    }
+
+    #[test]
+    fn meteora_dlmm_swap_accepts_json_from_before_mint_fields() {
+        let event = MeteoraDlmmSwapEvent {
+            metadata: EventMetadata::default(),
+            token_x_mint: Pubkey::new_unique(),
+            token_y_mint: Pubkey::new_unique(),
+            pool: Pubkey::new_unique(),
+            from: Pubkey::new_unique(),
+            start_bin_id: 1,
+            end_bin_id: 2,
+            amount_in: 3,
+            amount_out: 4,
+            swap_for_y: true,
+            fee: 5,
+            protocol_fee: 6,
+            fee_bps: 7,
+            host_fee: 8,
+        };
+        let json = without_fields(&event, &["token_x_mint", "token_y_mint"]);
+
+        let decoded: MeteoraDlmmSwapEvent =
+            serde_json::from_value(json).expect("legacy Meteora DLMM swap JSON");
+        assert_eq!(decoded.token_x_mint, Pubkey::default());
+        assert_eq!(decoded.token_y_mint, Pubkey::default());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Match each Meteora DLMM swap event to the instruction whose `lb_pair` account equals the event pool.
- Add a multi-leg regression test with different instruction lengths to prevent cross-pool mint assignment.
- Keep pre-0.6.4 serialized swap events readable by defaulting the new mint fields during Serde deserialization.

## Why

The previous longest-instruction heuristic could select another DLMM leg in transactions containing multiple DLMM swaps, causing `token_x_mint` and `token_y_mint` to be populated from the wrong pool.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib --tests` (216 unit tests and 6 mainnet fixture tests)
- `cargo test --lib --tests --no-default-features --features parse-zero-copy` (216 unit tests and 6 mainnet fixture tests)
- `cargo clippy --lib --tests -- -A clippy::result_large_err -A clippy::items_after_test_module -D warnings`
- Replayed the current mainnet `swap` and CPI `swap2` examples from 2026-08-14.