### PR TITLE
release: prepare sol-parser-sdk 0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,20 +113,23 @@ sol-parser-sdk = { path = "../sol-parser-sdk", default-features = false, feature
 
 ```toml
 # Add to your Cargo.toml
-sol-parser-sdk = "0.6.3"
+sol-parser-sdk = "0.6.4"
 ```
 
 Or with the zero-copy parser (maximum performance):
 
 ```toml
-sol-parser-sdk = { version = "0.6.3", default-features = false, features = ["parse-zero-copy"] }
+sol-parser-sdk = { version = "0.6.4", default-features = false, features = ["parse-zero-copy"] }
 ```
 
 ### Release Notes
 
 #### v0.6.4
 
-- Adds Meteora DLMM Swap event account filler to populate `token_x_mint` and `token_y_mint` from instruction accounts.
+- Adds `token_x_mint` and `token_y_mint` context to current Meteora DLMM swap events.
+- Anchors mint enrichment to each event pool so multi-leg DLMM routes cannot reuse another pool's accounts.
+- Adds reusable mainnet RPC examples captured on 2026-08-14 for direct `swap` and CPI `swap2` parsing.
+- Keeps JSON produced before the new mint fields compatible with Serde deserialization.
 
 #### v0.6.3
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,16 +113,23 @@ sol-parser-sdk = { path = "../sol-parser-sdk", default-features = false, feature
 
 ```toml
 # 在 Cargo.toml 中添加
-sol-parser-sdk = "0.6.3"
+sol-parser-sdk = "0.6.4"
 ```
 
 或使用零拷贝解析器（最高性能）：
 
 ```toml
-sol-parser-sdk = { version = "0.6.3", default-features = false, features = ["parse-zero-copy"] }
+sol-parser-sdk = { version = "0.6.4", default-features = false, features = ["parse-zero-copy"] }
 ```
 
 ### 发布说明
+
+#### v0.6.4
+
+- 为当前 Meteora DLMM swap 事件增加 `token_x_mint` 和 `token_y_mint` 上下文。
+- 按事件池精确匹配 mint 账户，防止多段 DLMM 路由复用其他池的账户。
+- 增加 2026-08-14 采集的主网 RPC 示例，覆盖直接 `swap` 和 CPI `swap2` 解析。
+- 兼容反序列化尚未包含新 mint 字段的旧版 JSON。
 
 #### v0.6.3
 


### PR DESCRIPTION
## Summary

- Update the crates.io dependency examples to `0.6.4` in both READMEs.
- Complete the English and Chinese `v0.6.4` release notes.
- Document Meteora DLMM mint enrichment, multi-leg pool anchoring, reusable current mainnet RPC examples, and legacy JSON compatibility.

## Validation

- `cargo fmt --all -- --check`
- `cargo package --list --allow-dirty`
- `cargo test --lib --tests` (216 unit tests and 6 mainnet fixture tests)
- `cargo test --lib --tests --no-default-features --features parse-zero-copy` (216 unit tests and 6 mainnet fixture tests)